### PR TITLE
cloud: add CloudItemType, upload types and UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { VoiceEditor } from './components/VoiceEditor';
 import { SamplerPanel } from './components/SamplerPanel';
 import { SongMode } from './components/SongMode';
 import { CloudLibrary } from './components/CloudLibrary';
+import type { CloudItemType } from './services/CloudStorage';
 import { exportSongToXM } from './utils/xmExport';
 import { getNoteColor } from './utils/noteColors';
 import { noteToMidi, midiToNote } from './utils/musicTheory';
@@ -870,44 +871,80 @@ export const App: React.FC = () => {
         setActiveSongSlot(slot);
     };
 
-    // --- SAVE/LOAD SONGS AS FILE ---
-    const getSongDataForUpload = useCallback(() => {
+    // --- DATA EXTRACTORS FOR CLOUD ---
+    // 1. Full Song
+    const getSongData = useCallback(() => {
         return {
             version: 1,
             pattern,
             tempo,
             ambianceUrl,
-            params: {
-                synthA, synthB, kick, snare, closedHat, openHat, sampler
-            },
+            params: { synthA, synthB, kick, snare, closedHat, openHat, sampler },
             trackStorage,
             activeTrackSlots,
             songStructure
         };
     }, [pattern, tempo, ambianceUrl, synthA, synthB, kick, snare, closedHat, openHat, sampler, trackStorage, activeTrackSlots, songStructure]);
 
-    const loadSongData = useCallback((songData: any) => {
-        if (songData.pattern) setPattern(songData.pattern);
-        if (songData.tempo) setTempo(songData.tempo);
-        if (songData.ambianceUrl !== undefined) setAmbianceUrl(songData.ambianceUrl);
+    // 2. Pattern Bank (Just the storage)
+    const getBankData = useCallback(() => {
+        return {
+            type: 'bank',
+            trackStorage
+        };
+    }, [trackStorage]);
 
-        if (songData.params) {
-            if (songData.params.synthA) { setSynthA(songData.params.synthA); synthARef.current = songData.params.synthA; }
-            if (songData.params.synthB) { setSynthB(songData.params.synthB); synthBRef.current = songData.params.synthB; }
-            if (songData.params.kick) { setKick(songData.params.kick); kickRef.current = songData.params.kick; }
-            if (songData.params.snare) { setSnare(songData.params.snare); snareRef.current = songData.params.snare; }
-            if (songData.params.closedHat) { setClosedHat(songData.params.closedHat); closedHatRef.current = songData.params.closedHat; }
-            if (songData.params.openHat) { setOpenHat(songData.params.openHat); openHatRef.current = songData.params.openHat; }
-            if (songData.params.sampler) { setSampler(songData.params.sampler); samplerRef.current = songData.params.sampler; }
+    // 3. Single Pattern (Current active)
+    const getPatternData = useCallback(() => {
+        return {
+            type: 'pattern',
+            pattern
+        };
+    }, [pattern]);
+
+    // --- DATA LOADER ---
+    const loadCloudData = useCallback((data: any, type: CloudItemType) => {
+        console.log("Loading Cloud Data:", type, data);
+
+        if (type === 'song') {
+            // Full Song Load (Same as file import)
+            if (data.pattern) setPattern(data.pattern);
+            if (data.tempo) setTempo(data.tempo);
+            if (data.ambianceUrl !== undefined) setAmbianceUrl(data.ambianceUrl);
+            
+            if (data.params) {
+                if (data.params.synthA) { setSynthA(data.params.synthA); synthARef.current = data.params.synthA; }
+                if (data.params.synthB) { setSynthB(data.params.synthB); synthBRef.current = data.params.synthB; }
+                if (data.params.kick) { setKick(data.params.kick); kickRef.current = data.params.kick; }
+                if (data.params.snare) { setSnare(data.params.snare); snareRef.current = data.params.snare; }
+                if (data.params.closedHat) { setClosedHat(data.params.closedHat); closedHatRef.current = data.params.closedHat; }
+                if (data.params.openHat) { setOpenHat(data.params.openHat); openHatRef.current = data.params.openHat; }
+                if (data.params.sampler) { setSampler(data.params.sampler); samplerRef.current = data.params.sampler; }
+            }
+            
+            if (data.trackStorage) setTrackStorage(data.trackStorage);
+            if (data.activeTrackSlots) setActiveTrackSlots(data.activeTrackSlots);
+            if (data.songStructure) setSongStructure(data.songStructure);
+            alert("Song loaded!");
+
+        } else if (type === 'bank') {
+            // Load Bank (Replace all patterns in storage)
+            if (data.trackStorage) {
+                setTrackStorage(data.trackStorage);
+                alert("Pattern Bank loaded! Check your pattern slots.");
+            }
+
+        } else if (type === 'pattern') {
+            // Load Single Pattern (Replace CURRENT pattern)
+            if (data.pattern) {
+                setPattern(data.pattern);
+                alert("Pattern loaded into current view!");
+            }
         }
-
-        if (songData.trackStorage) setTrackStorage(songData.trackStorage);
-        if (songData.activeTrackSlots) setActiveTrackSlots(songData.activeTrackSlots);
-        if (songData.songStructure) setSongStructure(songData.songStructure);
     }, []);
 
     const exportSongToFile = useCallback(() => {
-        const songData = getSongDataForUpload();
+        const songData = getSongData();
         
         const jsonStr = JSON.stringify(songData, null, 2);
         const blob = new Blob([jsonStr], { type: 'application/json' });
@@ -920,7 +957,7 @@ export const App: React.FC = () => {
         a.click();
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
-    }, [getSongDataForUpload]);
+    }, [getSongData]);
 
     const importSongFromFile = useCallback(() => {
         const input = document.createElement('input');
@@ -934,7 +971,7 @@ export const App: React.FC = () => {
                 const text = await file.text();
                 const songData = JSON.parse(text);
                 
-                loadSongData(songData);
+                        loadCloudData(songData, 'song');
                 
                 alert('Song loaded successfully!');
             } catch (err) {
@@ -943,7 +980,7 @@ export const App: React.FC = () => {
             }
         };
         input.click();
-    }, [loadSongData]);
+    }, [loadCloudData]);
 
     // --- MODULE RENDER HELPERS ---
     const getSynthControls = (params: SynthParams): KnobConfig[] => [
@@ -1063,11 +1100,13 @@ export const App: React.FC = () => {
     return (
         <div className="flex flex-col h-screen w-screen bg-gradient-to-br from-[#050709] via-[#080a0b] to-[#0a0c0f] text-gray-200 overflow-hidden font-sans relative">
 
-            <CloudLibrary
-                isOpen={isCloudLibraryOpen}
+            <CloudLibrary 
+                isOpen={isCloudLibraryOpen} 
                 onClose={() => setIsCloudLibraryOpen(false)}
-                onLoadSong={loadSongData}
-                getSongDataForUpload={getSongDataForUpload}
+                onLoadData={loadCloudData}
+                getSongData={getSongData}
+                getBankData={getBankData}
+                getPatternData={getPatternData}
             />
 
             {isVoiceEditorOpen && (

--- a/src/components/CloudLibrary.tsx
+++ b/src/components/CloudLibrary.tsx
@@ -1,22 +1,29 @@
 // src/components/CloudLibrary.tsx
 import React, { useEffect, useState } from 'react';
 import { CloudStorage } from '../services/CloudStorage';
-import type { CloudSongMeta } from '../services/CloudStorage';
+import type { CloudSongMeta, CloudItemType } from '../services/CloudStorage';
 
 interface CloudLibraryProps {
     isOpen: boolean;
     onClose: () => void;
-    onLoadSong: (data: any) => void;
-    getSongDataForUpload: () => any; // Function to get current app state
+    onLoadData: (data: any, type: CloudItemType) => void;
+    // Data getters for different types
+    getSongData: () => any;
+    getBankData: () => any;
+    getPatternData: () => any;
 }
 
-export const CloudLibrary: React.FC<CloudLibraryProps> = ({ isOpen, onClose, onLoadSong, getSongDataForUpload }) => {
+export const CloudLibrary: React.FC<CloudLibraryProps> = ({ 
+    isOpen, onClose, onLoadData, getSongData, getBankData, getPatternData 
+}) => {
     const [activeTab, setActiveTab] = useState<'browse' | 'upload'>('browse');
+    const [filterType, setFilterType] = useState<CloudItemType | 'all'>('all');
     const [songs, setSongs] = useState<CloudSongMeta[]>([]);
     const [isLoading, setIsLoading] = useState(false);
 
     // Upload Form State
     const [uploadForm, setUploadForm] = useState({ name: '', author: '', description: '' });
+    const [uploadType, setUploadType] = useState<CloudItemType>('song');
     const [uploadStatus, setUploadStatus] = useState<'idle' | 'uploading' | 'success' | 'error'>('idle');
 
     useEffect(() => {
@@ -32,45 +39,21 @@ export const CloudLibrary: React.FC<CloudLibraryProps> = ({ isOpen, onClose, onL
         setIsLoading(false);
     };
 
-    const handleLoadClick = async (id: string) => {
+    const handleLoadClick = async (item: CloudSongMeta) => {
         setIsLoading(true);
         try {
-            const data = await CloudStorage.getSongData(id);
-            onLoadSong(data);
+            const data = await CloudStorage.getSongData(item.id);
+            // Pass both data and type so App.tsx knows how to handle it
+            onLoadData(data, item.type);
             onClose();
         } catch (e) {
-            alert("Failed to load song data");
+            alert("Failed to load data");
         } finally {
             setIsLoading(false);
         }
     };
 
-    const handleUpload = async (e: React.FormEvent) => {
-        e.preventDefault();
-        setUploadStatus('uploading');
-
-        try {
-            const songData = getSongDataForUpload();
-            const result = await CloudStorage.uploadSong({
-                name: uploadForm.name || "Untitled",
-                author: uploadForm.author || "Anonymous",
-                description: uploadForm.description,
-                data: songData
-            });
-
-            if (result.success) {
-                setUploadStatus('success');
-                setTimeout(() => {
-                    setUploadStatus('idle');
-                    setActiveTab('browse');
-                }, 1500);
-            } else {
-                setUploadStatus('error');
-            }
-        } catch (e) {
-            setUploadStatus('error');
-        }
-    };
+    const filteredSongs = songs.filter(s => filterType === 'all' || s.type === filterType);
 
     if (!isOpen) return null;
 
@@ -90,7 +73,7 @@ export const CloudLibrary: React.FC<CloudLibraryProps> = ({ isOpen, onClose, onL
                         onClick={() => setActiveTab('upload')}
                         className={`flex-1 py-4 font-orbitron font-bold text-sm tracking-widest transition-colors ${activeTab === 'upload' ? 'text-pink-400 bg-gray-800/50' : 'text-gray-500 hover:text-gray-300'}`}
                     >
-                        UPLOAD CURRENT
+                        UPLOAD
                     </button>
                 </div>
 
@@ -98,8 +81,19 @@ export const CloudLibrary: React.FC<CloudLibraryProps> = ({ isOpen, onClose, onL
                 <div className="flex-1 overflow-y-auto p-6 min-h-[400px]">
                     {activeTab === 'browse' ? (
                         <div className="space-y-4">
+                            {/* Filter Bar */}
                             <div className="flex justify-between items-center mb-4">
-                                <h3 className="text-cyan-500 font-mono text-xs uppercase">Community Patterns</h3>
+                                <div className="flex gap-2">
+                                    {['all', 'song', 'bank', 'pattern'].map((t) => (
+                                        <button
+                                            key={t}
+                                            onClick={() => setFilterType(t as any)}
+                                            className={`px-3 py-1 rounded text-xs font-bold uppercase transition-all ${filterType === t ? 'bg-cyan-600 text-white' : 'bg-gray-800 text-gray-500 hover:bg-gray-700'}`}
+                                        >
+                                            {t}
+                                        </button>
+                                    ))}
+                                </div>
                                 <button onClick={loadLibrary} className="text-xs text-gray-400 hover:text-white">↻ Refresh</button>
                             </div>
 
@@ -109,17 +103,25 @@ export const CloudLibrary: React.FC<CloudLibraryProps> = ({ isOpen, onClose, onL
                                 <div className="text-center py-10 text-gray-600 font-mono">No songs found. Be the first to upload!</div>
                             ) : (
                                 <div className="grid gap-3">
-                                    {songs.map(song => (
-                                        <div key={song.id} className="bg-gray-800/40 border border-gray-700 hover:border-cyan-500/50 rounded-lg p-3 flex justify-between items-center transition-all group">
+                                    {filteredSongs.map(item => (
+                                        <div key={item.id} className="bg-gray-800/40 border border-gray-700 hover:border-cyan-500/50 rounded-lg p-3 flex justify-between items-center transition-all group">
                                             <div>
-                                                <div className="font-bold text-gray-200">{song.name}</div>
-                                                <div className="text-xs text-gray-500 font-mono mt-1">
-                                                    by <span className="text-cyan-400">{song.author}</span> • {song.date}
+                                                <div className="flex items-center gap-2">
+                                                    <span className={`text-[10px] px-1.5 py-0.5 rounded text-black font-bold uppercase ${
+                                                        item.type === 'song' ? 'bg-blue-400' : 
+                                                        item.type === 'bank' ? 'bg-purple-400' : 'bg-green-400'
+                                                    }`}>
+                                                        {item.type}
+                                                    </span>
+                                                    <span className="font-bold text-gray-200">{item.name}</span>
                                                 </div>
-                                                {song.description && <div className="text-xs text-gray-600 mt-1 italic">{song.description}</div>}
+                                                <div className="text-xs text-gray-500 font-mono mt-1 ml-1">
+                                                    by <span className="text-cyan-400">{item.author}</span> • {item.date}
+                                                </div>
+                                                {item.description && <div className="text-xs text-gray-600 mt-1 ml-1 italic">{item.description}</div>}
                                             </div>
-                                            <button
-                                                onClick={() => handleLoadClick(song.id)}
+                                            <button 
+                                                onClick={() => handleLoadClick(item)}
                                                 className="bg-cyan-900/30 text-cyan-400 border border-cyan-800 px-3 py-1.5 rounded text-xs font-bold font-orbitron hover:bg-cyan-500 hover:text-black transition-all"
                                             >
                                                 LOAD
@@ -133,8 +135,33 @@ export const CloudLibrary: React.FC<CloudLibraryProps> = ({ isOpen, onClose, onL
                         <div className="max-w-md mx-auto">
                             <h3 className="text-pink-500 font-mono text-xs uppercase mb-6 text-center">Share your creation</h3>
                             <form onSubmit={handleUpload} className="space-y-4">
+                                
+                                {/* Type Selection */}
+                                <div className="bg-gray-800/50 p-3 rounded-lg border border-gray-700">
+                                    <label className="block text-xs text-gray-400 font-mono mb-2 uppercase">What are you saving?</label>
+                                    <div className="flex gap-4">
+                                        <label className="flex items-center gap-2 cursor-pointer">
+                                            <input type="radio" name="utype" checked={uploadType === 'song'} onChange={() => setUploadType('song')} className="accent-pink-500"/>
+                                            <span className="text-sm text-gray-300">Full Song</span>
+                                        </label>
+                                        <label className="flex items-center gap-2 cursor-pointer">
+                                            <input type="radio" name="utype" checked={uploadType === 'bank'} onChange={() => setUploadType('bank')} className="accent-pink-500"/>
+                                            <span className="text-sm text-gray-300">Pattern Bank</span>
+                                        </label>
+                                        <label className="flex items-center gap-2 cursor-pointer">
+                                            <input type="radio" name="utype" checked={uploadType === 'pattern'} onChange={() => setUploadType('pattern')} className="accent-pink-500"/>
+                                            <span className="text-sm text-gray-300">Current Pattern</span>
+                                        </label>
+                                    </div>
+                                    <div className="text-[10px] text-gray-500 mt-2 italic">
+                                        {uploadType === 'song' && "Saves arrangement, patterns, and knob settings."}
+                                        {uploadType === 'bank' && "Saves all 8 pattern slots for all tracks."}
+                                        {uploadType === 'pattern' && "Saves only the currently active pattern."}
+                                    </div>
+                                </div>
+
                                 <div>
-                                    <label className="block text-xs text-gray-400 font-mono mb-1">Song Name</label>
+                                    <label className="block text-xs text-gray-400 font-mono mb-1">Name</label>
                                     <input
                                         type="text"
                                         required
@@ -142,7 +169,7 @@ export const CloudLibrary: React.FC<CloudLibraryProps> = ({ isOpen, onClose, onL
                                         value={uploadForm.name}
                                         onChange={e => setUploadForm({...uploadForm, name: e.target.value})}
                                         className="w-full bg-gray-900 border border-gray-700 rounded p-2 text-white focus:border-pink-500 focus:outline-none transition-colors"
-                                        placeholder="My Awesome Track"
+                                        placeholder={uploadType === 'song' ? "My Song" : "My Pattern"}
                                     />
                                 </div>
                                 <div>
@@ -178,10 +205,10 @@ export const CloudLibrary: React.FC<CloudLibraryProps> = ({ isOpen, onClose, onL
                                               'bg-pink-700 text-white hover:bg-pink-600 border border-pink-500 shadow-[0_0_15px_rgba(236,72,153,0.3)]'}
                                         `}
                                     >
-                                        {uploadStatus === 'uploading' ? 'UPLOADING...' :
-                                         uploadStatus === 'success' ? 'UPLOAD COMPLETE!' :
-                                         uploadStatus === 'error' ? 'FAILED - TRY AGAIN' :
-                                         'UPLOAD TO CLOUD'}
+                                        {uploadStatus === 'uploading' ? 'UPLOADING...' : 
+                                         uploadStatus === 'success' ? 'UPLOAD COMPLETE!' : 
+                                         uploadStatus === 'error' ? 'FAILED - TRY AGAIN' : 
+                                         `UPLOAD ${uploadType.toUpperCase()}`}
                                     </button>
                                 </div>
                             </form>

--- a/src/services/CloudStorage.ts
+++ b/src/services/CloudStorage.ts
@@ -1,59 +1,61 @@
 // src/services/CloudStorage.ts
 
-// Replace this with your actual Hugging Face Space URL
-// Example: "https://your-username-space-name.hf.space"
-const API_BASE_URL = "https://ford442-electribe-cloud.hf.space";
+// src/services/CloudStorage.ts
+
+// Replace with your actual Space URL
+const API_BASE_URL = "https://ford442-storage-manager.hf.space"; 
+
+export type CloudItemType = 'song' | 'pattern' | 'bank' | 'sample';
 
 export interface CloudSongMeta {
     id: string;
     name: string;
     author: string;
     date: string;
+    type: CloudItemType;
     description?: string;
+    filename?: string;
 }
 
 export interface CloudSongPayload {
     name: string;
     author: string;
     description: string;
-    data: any; // The full JSON song data
+    type: CloudItemType; // Added type field
+    data: any; 
 }
 
 export const CloudStorage = {
     async getSongs(): Promise<CloudSongMeta[]> {
         try {
             const res = await fetch(`${API_BASE_URL}/api/songs`);
-            if (!res.ok) throw new Error("Failed to fetch songs");
+            if (!res.ok) throw new Error("Failed to fetch library");
             return await res.json();
         } catch (e) {
             console.error("CloudStorage: Fetch error", e);
-            // Return mock data if API fails for testing UI
-            return [
-                { id: '1', name: 'Acid House Demo', author: 'Jules', date: '2023-12-12', description: 'Classic 303 vibes' },
-                { id: '2', name: 'DnB Roller', author: 'Guest', date: '2023-12-13', description: 'Fast paced beats' }
-            ];
+            return [];
         }
     },
 
     async getSongData(id: string): Promise<any> {
         const res = await fetch(`${API_BASE_URL}/api/songs/${id}`);
-        if (!res.ok) throw new Error("Failed to fetch song data");
+        if (!res.ok) throw new Error("Failed to fetch data");
         return await res.json();
     },
 
-    async uploadSong(payload: CloudSongPayload): Promise<{ success: boolean; id?: string; error?: string }> {
+    async uploadItem(payload: CloudSongPayload): Promise<{ success: boolean; id?: string; error?: string }> {
         try {
-            const res = await fetch(`${API_BASE_URL}/api/upload`, {
+            const res = await fetch(`${API_BASE_URL}/api/songs`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload)
             });
-
+            
             if (!res.ok) {
                 const err = await res.text();
                 throw new Error(err || res.statusText);
             }
-
+            
             const data = await res.json();
             return { success: true, id: data.id };
         } catch (e: any) {


### PR DESCRIPTION
Adds CloudItemType and updates CloudLibrary and App to support browsing/uploading songs, banks, and patterns.

- Export  and include  in payloads
- CloudLibrary: browse/upload tabs, filters, upload type radio buttons
- App: provide getSong/getBank/getPattern data functions and handle loading by type

Tests: existing tests pass locally (with unrelated env warnings).