### PR TITLE
Fix TypeScript errors in GamepadDebugger and useGamepad refs

### DIFF
--- a/src/components/GamepadDebugger.tsx
+++ b/src/components/GamepadDebugger.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState, useRef } from 'react';
 
 export const GamepadDebugger: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   const [gamepads, setGamepads] = useState<Gamepad[]>([]);
-  const reqRef = useRef<number>();
+  const reqRef = useRef<number | null>(null);
 
   useEffect(() => {
     const loop = () => {

--- a/src/hooks/useGamepad.ts
+++ b/src/hooks/useGamepad.ts
@@ -45,7 +45,7 @@ const MAPPINGS = {
 type KeyState = { [key: string]: boolean };
 
 export function useGamepad() {
-  const requestRef = useRef<number>();
+  const requestRef = useRef<number | undefined>(undefined);
   const keyState = useRef<KeyState>({});
 
   // Helper to dispatch keyboard events


### PR DESCRIPTION
This PR fixes 3 TypeScript errors blocking the build. 
1. `src/components/GamepadDebugger.tsx`: initialized `reqRef` with `null` to satisfy `React.useRef` signature.
2. `src/hooks/useGamepad.ts`: initialized `requestRef` with `undefined` to satisfy `React.useRef` signature and allow assignment to `undefined`.

---
*PR created automatically by Jules for task [6584253612035843850](https://jules.google.com/task/6584253612035843850) started by @ford442*