### PR TITLE
⚡ Bolt: Optimize SamplerPanel knob rendering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -722,6 +722,18 @@ export const App: React.FC = () => {
     const handleSamplerChange = useCallback((id: string, val: number) => { let realVal = val; if (id === 'playbackSpeed') realVal = val * 4.0; else if (id === 'filterCutoff') realVal = val * 20000; else if (id === 'filterResonance') realVal = val * 20; setSampler(prev => { const next = [...prev]; const currentBank = next[activeSamplerBank]; // @ts-ignore
     next[activeSamplerBank] = { ...currentBank, [id]: realVal }; return next; }); }, [activeSamplerBank]);
 
+    // Stable handler for SamplerPanel to avoid re-renders
+    const handleSamplerParamChange = useCallback((bankIdx: number, key: string, val: any) => {
+        setSampler(prev => {
+            const next = [...prev];
+            if (next[bankIdx]) {
+                next[bankIdx] = { ...next[bankIdx], [key as keyof SamplerBankParams]: val };
+            }
+            samplerRef.current = next;
+            return next;
+        });
+    }, []);
+
     const onSynthAParamChange = useCallback((id: string, v: number) => handleSynthChange(true, id, v), [handleSynthChange]);
     const onSynthBParamChange = useCallback((id: string, v: number) => handleSynthChange(false, id, v), [handleSynthChange]);
 
@@ -735,7 +747,7 @@ export const App: React.FC = () => {
 
     const synthAChild = useMemo(() => (<div className="absolute top-4 right-6 pointer-events-auto"><WaveformSelector selected={synthA.waveform} onChange={(w) => updateSynthA({ waveform: w })} accentColor="cyan" /></div>), [synthA.waveform, updateSynthA]);
     const synthBChild = useMemo(() => (<div className="absolute top-4 right-6 pointer-events-auto"><WaveformSelector selected={synthB.waveform} onChange={(w) => updateSynthB({ waveform: w })} accentColor="pink" /></div>), [synthB.waveform, updateSynthB]);
-    const samplerChild = useMemo(() => (<div className="absolute top-4 left-[30%] w-[40%] h-auto pointer-events-auto z-10 bg-gray-900/80 rounded-lg border border-purple-500/30 backdrop-blur-sm"><SamplerPanel params={sampler} onChange={(u) => updateSampler(u)} onLoadSample={handleLoadSample} audioContext={audioEngine?.context!} audioEngine={audioEngine || undefined} activeBankIdx={activeSamplerBank} onBankChange={setActiveSamplerBank} onOpenEditor={() => setIsVoiceEditorOpen(true)} ttsPhrases={ttsPhrases} onTtsPhraseChange={setTtsPhrases} /></div>), [sampler, updateSampler, audioEngine, setIsVoiceEditorOpen, activeSamplerBank, handleLoadSample, ttsPhrases]);
+    const samplerChild = useMemo(() => (<div className="absolute top-4 left-[30%] w-[40%] h-auto pointer-events-auto z-10 bg-gray-900/80 rounded-lg border border-purple-500/30 backdrop-blur-sm"><SamplerPanel params={sampler} onChange={(u) => updateSampler(u)} onParamChange={handleSamplerParamChange} onLoadSample={handleLoadSample} audioContext={audioEngine?.context!} audioEngine={audioEngine || undefined} activeBankIdx={activeSamplerBank} onBankChange={setActiveSamplerBank} onOpenEditor={() => setIsVoiceEditorOpen(true)} ttsPhrases={ttsPhrases} onTtsPhraseChange={setTtsPhrases} /></div>), [sampler, updateSampler, handleSamplerParamChange, audioEngine, setIsVoiceEditorOpen, activeSamplerBank, handleLoadSample, ttsPhrases]);
 
     // --- RENDER PARTS FOR 3D ---
     // Extract parts so they can be passed to either normal view or 3D view

--- a/src/components/Knob.tsx
+++ b/src/components/Knob.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useRef, useEffect, useCallback, memo } from 'react';
 
 interface KnobProps {
   label: string;
@@ -12,7 +12,7 @@ interface KnobProps {
   logarithmic?: boolean;
 }
 
-export const Knob: React.FC<KnobProps> = ({ label, value, onChange, min, max, step = 1, color = 'cyan', unit = '', logarithmic = false }) => {
+export const Knob: React.FC<KnobProps> = memo(({ label, value, onChange, min, max, step = 1, color = 'cyan', unit = '', logarithmic = false }) => {
   const knobRef = useRef<HTMLDivElement>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [dragStartY, setDragStartY] = useState(0);
@@ -186,4 +186,4 @@ export const Knob: React.FC<KnobProps> = ({ label, value, onChange, min, max, st
       <span className="text-sm font-mono text-gray-300">{formatValue(value)}</span>
     </div>
   );
-};
+});

--- a/src/components/SamplerPanel.tsx
+++ b/src/components/SamplerPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect, memo } from 'react';
+import React, { useRef, useState, useEffect, memo, useCallback } from 'react';
 import type { SamplerParams, AudioEngine } from '../types'; // Note: This is now SamplerBankParams[]
 import { SupertonicService } from '../services/Supertonic';
 import { Knob } from './Knob';
@@ -15,6 +15,7 @@ interface SamplerPanelProps {
     ttsPhrases: string[];            // Array of 8 TTS phrases
     onTtsPhraseChange: (phrases: string[]) => void; // Update TTS phrases
     onHarmonize?: (bankIndex: number, chordType: string) => Promise<void>; // New prop
+    onParamChange?: (bankIndex: number, key: string, value: any) => void;
 }
 
 // 8 Banks
@@ -27,7 +28,7 @@ const grainSizeToPercent = (size: number) => ((size - 441) / (22050 - 441) * 100
 const SamplerPanelComponent: React.FC<SamplerPanelProps> = ({
     params, onChange, onLoadSample, audioContext, audioEngine, activeBankIdx, onBankChange, onOpenEditor,
     ttsPhrases, onTtsPhraseChange,
-    onHarmonize
+    onHarmonize, onParamChange
 }) => {
     const fileInputRef = useRef<HTMLInputElement>(null);
     const [isRecording, setIsRecording] = useState(false);
@@ -98,11 +99,40 @@ const SamplerPanelComponent: React.FC<SamplerPanelProps> = ({
         onChange(newParams);
     };
 
+    // Ref to access updateParam stably in callbacks even if params change
+    const updateParamRef = useRef(updateParam);
+    useEffect(() => { updateParamRef.current = updateParam; });
+
+    // Stable Handlers for Knobs to prevent re-renders
+    const handleSpeedChange = useCallback((v: number) => {
+        if (onParamChange) onParamChange(activeBankIdx, 'playbackSpeed', v);
+        else updateParamRef.current('playbackSpeed', v);
+    }, [activeBankIdx, onParamChange]);
+
+    const handleVolumeChange = useCallback((v: number) => {
+        if (onParamChange) onParamChange(activeBankIdx, 'volume', v);
+        else updateParamRef.current('volume', v);
+    }, [activeBankIdx, onParamChange]);
+
+    const handleFilterChange = useCallback((v: number) => {
+        if (onParamChange) onParamChange(activeBankIdx, 'filterCutoff', v);
+        else updateParamRef.current('filterCutoff', v);
+    }, [activeBankIdx, onParamChange]);
+
+    const handleDriveChange = useCallback((v: number) => {
+        if (onParamChange) onParamChange(activeBankIdx, 'drive', v);
+        else updateParamRef.current('drive', v);
+    }, [activeBankIdx, onParamChange]);
+
     // Handle mode change
     const handleModeChange = (mode: 'loop' | 'stretch' | 'wavetable') => {
-        const newParams = [...params];
-        newParams[activeBankIdx] = { ...currentParams, mode };
-        onChange(newParams);
+        if (onParamChange) {
+            onParamChange(activeBankIdx, 'mode', mode);
+        } else {
+            const newParams = [...params];
+            newParams[activeBankIdx] = { ...currentParams, mode };
+            onChange(newParams);
+        }
         
         // Update audio engine immediately
         if (audioEngine?.setSustainMode) {
@@ -112,9 +142,13 @@ const SamplerPanelComponent: React.FC<SamplerPanelProps> = ({
 
     // Handle grain size change
     const handleGrainSizeChange = (size: number) => {
-        const newParams = [...params];
-        newParams[activeBankIdx] = { ...currentParams, grainSize: size };
-        onChange(newParams);
+        if (onParamChange) {
+            onParamChange(activeBankIdx, 'grainSize', size);
+        } else {
+            const newParams = [...params];
+            newParams[activeBankIdx] = { ...currentParams, grainSize: size };
+            onChange(newParams);
+        }
         
         // Update audio engine immediately
         if (audioEngine?.setSustainGrainSize) {
@@ -473,10 +507,10 @@ const SamplerPanelComponent: React.FC<SamplerPanelProps> = ({
 
                 {/* ROW 6: Parameters for Active Bank */}
                 <div className="grid grid-cols-4 gap-2 mt-1 bg-gray-800/30 p-1 rounded">
-                    <Knob label="Speed" value={currentParams.playbackSpeed || 1} onChange={v => updateParam('playbackSpeed', v)} min={0.1} max={4.0} color="purple" />
-                    <Knob label="Vol" value={currentParams.volume} onChange={v => updateParam('volume', v)} min={0} max={2.0} color="purple" />
-                    <Knob label="Filter" value={currentParams.filterCutoff} onChange={v => updateParam('filterCutoff', v)} min={100} max={20000} color="purple" logarithmic />
-                    <Knob label="Drive" value={currentParams.drive} onChange={v => updateParam('drive', v)} min={0} max={1} color="red" />
+                    <Knob label="Speed" value={currentParams.playbackSpeed || 1} onChange={handleSpeedChange} min={0.1} max={4.0} color="purple" />
+                    <Knob label="Vol" value={currentParams.volume} onChange={handleVolumeChange} min={0} max={2.0} color="purple" />
+                    <Knob label="Filter" value={currentParams.filterCutoff} onChange={handleFilterChange} min={100} max={20000} color="purple" logarithmic />
+                    <Knob label="Drive" value={currentParams.drive} onChange={handleDriveChange} min={0} max={1} color="red" />
                 </div>
             </div>
         </div>


### PR DESCRIPTION
💡 What: Optimized the rendering of the `SamplerPanel` by preventing unnecessary re-renders of sibling `Knob` components when one knob is adjusted.
🎯 Why: Previously, dragging a single knob in the SamplerPanel would cause all 4 knobs to re-render because the parent component regenerated inline `onChange` handlers on every update. This caused unnecessary VDOM diffing during high-frequency events (60fps drag).
📊 Impact: Reduces re-renders of `Knob` components by 75% during single-knob interaction (only the active knob updates).
🔬 Measurement: Verified via `src/__tests__/SamplerPanel.perf.test.tsx` (which confirms memoization behavior) and manual analysis of component props stability.

---
*PR created automatically by Jules for task [14016455902400124554](https://jules.google.com/task/14016455902400124554) started by @ford442*