### PR TITLE
Fix TypeScript error for WaveShaperNode curve assignment

### DIFF
--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -15,15 +15,15 @@ const modeToWorkletValue = (mode: 'loop' | 'stretch' | 'wavetable'): number => {
 };
 
 // Helper for distortion
-const distortionCurveCache = new Map<number, Float32Array>();
+const distortionCurveCache = new Map<number, Float32Array<ArrayBuffer>>();
 
-function makeDistortionCurve(amount: number) {
+function makeDistortionCurve(amount: number): Float32Array<ArrayBuffer> {
     if (distortionCurveCache.has(amount)) {
         return distortionCurveCache.get(amount)!;
     }
     const k = typeof amount === 'number' ? amount : 50,
         n_samples = 44100,
-        curve = new Float32Array(n_samples),
+        curve = new Float32Array(n_samples) as Float32Array<ArrayBuffer>,
         deg = Math.PI / 180;
     let x;
     for (let i = 0; i < n_samples; ++i) {


### PR DESCRIPTION
Resolved TypeScript errors in `src/hooks/useAudioEngine.ts` where assigning a `Float32Array` to `driveNode.curve` failed due to type incompatibility between `ArrayBufferLike` and `ArrayBuffer`.

Changes:
- Updated `makeDistortionCurve` to explicitly return `Float32Array<ArrayBuffer>`.
- Updated `distortionCurveCache` map to store `Float32Array<ArrayBuffer>`.
- Added a type assertion (`as Float32Array<ArrayBuffer>`) when creating the new `Float32Array` to ensure strict type compliance for the Web Audio API.

---
*PR created automatically by Jules for task [6671440009830228627](https://jules.google.com/task/6671440009830228627) started by @ford442*