### PR TITLE
🎨 Palette: Add keyboard support to DragValue buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,7 @@
 ## 2025-05-25 - Visible Focus in Dense Grids
 **Learning:** In dense grids of interactive elements (like a sequencer), the default `focus:outline-none` style (often used for aesthetics) leaves keyboard users completely lost.
 **Action:** Always replace `focus:outline-none` with a high-contrast `focus-visible` ring that contrasts with the background, ideally matching the element's semantic color if applicable.
+
+## 2025-05-26 - Keyboard Support for Mouse-Repeat Buttons
+**Learning:** Buttons designed for "press and hold" (repeat) actions using `onMouseDown` are often inaccessible to keyboard users because standard `onClick` is omitted. A keyboard "click" (Enter/Space) needs to trigger a single step action to ensure functionality parity.
+**Action:** Always handle `onClick` or `onKeyDown` (Enter/Space) for repeat buttons to perform a single step, ensuring keyboard users can interact with the control. Use `event.detail === 0` to distinguish keyboard activation from mouse clicks if necessary.

--- a/src/components/DragValue.tsx
+++ b/src/components/DragValue.tsx
@@ -109,12 +109,23 @@ export const DragValue: React.FC<DragValueProps> = ({ value, onChange, min = 0, 
     return () => stopRepeat();
   }, []);
 
+  const handleButtonClick = (e: React.MouseEvent, direction: 1 | -1) => {
+    // Only handle keyboard activation (Enter/Space) where detail is 0
+    // Mouse clicks (detail > 0) are handled by onMouseDown for repeat behavior
+    if (e.detail === 0) {
+      let newVal = valueRef.current + direction * step;
+      newVal = Math.max(min, Math.min(max, Math.round(newVal / step) * step));
+      onChange(newVal);
+    }
+  };
+
   return (
     <div className={`flex flex-col items-center ${className || ''}`}>
       {label && <label className="text-xs text-gray-400 uppercase tracking-wider">{label}</label>}
       <div className="flex items-center gap-1">
         {/* Minus button */}
         <button
+          onClick={(e) => handleButtonClick(e, -1)}
           onMouseDown={() => startRepeat(-1)}
           onMouseUp={stopRepeat}
           onMouseLeave={stopRepeat}
@@ -177,6 +188,7 @@ export const DragValue: React.FC<DragValueProps> = ({ value, onChange, min = 0, 
         </div>
         {/* Plus button */}
         <button
+          onClick={(e) => handleButtonClick(e, 1)}
           onMouseDown={() => startRepeat(1)}
           onMouseUp={stopRepeat}
           onMouseLeave={stopRepeat}

--- a/src/components/__tests__/DragValue.test.tsx
+++ b/src/components/__tests__/DragValue.test.tsx
@@ -81,4 +81,21 @@ describe('DragValue Keyboard Navigation', () => {
         fireEvent.keyDown(slider, { key: 'End' });
         expect(onChange).toHaveBeenCalledWith(100);
     });
+
+    it('handles keyboard activation on increment/decrement buttons', () => {
+        const onChange = vi.fn();
+        render(<DragValue {...defaultProps} onChange={onChange} />);
+
+        const plusBtn = screen.getByLabelText('Increase Test Label');
+        const minusBtn = screen.getByLabelText('Decrease Test Label');
+
+        // Simulate Enter key on buttons (which fires click in browsers)
+        // We use detail: 0 to simulate keyboard-triggered click
+        fireEvent.click(plusBtn, { detail: 0 });
+        expect(onChange).toHaveBeenCalledWith(51);
+
+        onChange.mockClear();
+        fireEvent.click(minusBtn, { detail: 0 });
+        expect(onChange).toHaveBeenCalledWith(49);
+    });
 });


### PR DESCRIPTION
- **What:** Added keyboard support (Enter/Space) to the +/- buttons in `DragValue` component.
- **Why:** Previously, these buttons only supported mouse interactions (`onMouseDown` for repeat), making them inaccessible to keyboard users.
- **How:** Implemented an `onClick` handler that checks `event.detail === 0` to identify keyboard activation and trigger a single step change.
- **Testing:** Added a unit test verifying that `fireEvent.click(..., { detail: 0 })` calls `onChange` correctly.

---
*PR created automatically by Jules for task [9644129189695133827](https://jules.google.com/task/9644129189695133827) started by @ford442*