### PR TITLE
⚡ Bolt: Lazy Load Studio3D Component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useLayoutEffect, useRef, useState, memo, useMemo, forwardRef, useImperativeHandle } from 'react'
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState, memo, useMemo, forwardRef, useImperativeHandle, lazy, Suspense } from 'react'
 import { useAudioEngine } from './hooks/useAudioEngine'
 import { usePyodideEngine } from './hooks/usePyodideEngine'
 import { useScheduler } from './hooks/useScheduler'
@@ -22,7 +22,8 @@ import { exportSongToXM } from './utils/xmExport';
 import { getNoteColor } from './utils/noteColors';
 import { noteToMidi, midiToNote } from './utils/musicTheory';
 import { audioBufferToWav, blobToBase64 } from './utils/audioExport';
-import { Studio3D } from './components/Studio3D'; // IMPORT 3D STUDIO
+
+const Studio3D = lazy(() => import('./components/Studio3D').then(module => ({ default: module.Studio3D })));
 
 import {
     noteToFrequency,
@@ -964,13 +965,15 @@ export const App: React.FC = () => {
     // --- MAIN RENDER ---
     if (is3DMode) {
         return (
-            <Studio3D
-                header={headerNode}
-                sequencer={sequencerNode}
-                keyboard={keyboardNode}
-                rack={rackNode}
-                onExit={() => setIs3DMode(false)}
-            />
+            <Suspense fallback={<div className="flex items-center justify-center h-screen w-screen bg-black text-cyan-400 font-orbitron text-xl tracking-widest animate-pulse">LOADING 3D STUDIO...</div>}>
+                <Studio3D
+                    header={headerNode}
+                    sequencer={sequencerNode}
+                    keyboard={keyboardNode}
+                    rack={rackNode}
+                    onExit={() => setIs3DMode(false)}
+                />
+            </Suspense>
         );
     }
 


### PR DESCRIPTION
💡 What: Implemented code splitting for the `Studio3D` component in `src/App.tsx`.
🎯 Why: The `Studio3D` component imports heavy 3D libraries (`three`, `@react-three/fiber`, `@react-three/drei`). Loading these on initial app load increases bundle size significantly, even though 3D mode is disabled by default.
📊 Impact: Reduces the main bundle size by moving 3D-related code into a separate chunk that is only loaded when the user activates "3D Mode".
🔬 Measurement: Verify that `Studio3D` chunk is requested only after clicking the "3D" button in the UI.

---
*PR created automatically by Jules for task [14895381167982428834](https://jules.google.com/task/14895381167982428834) started by @ford442*