### PR TITLE
⚡ Bolt: Optimize distortion curve generation

### DIFF
--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -18,11 +18,19 @@ const modeToWorkletValue = (mode: 'loop' | 'stretch' | 'wavetable'): number => {
 const distortionCurveCache = new Map<number, Float32Array<ArrayBuffer>>();
 
 function makeDistortionCurve(amount: number): Float32Array<ArrayBuffer> {
-    if (distortionCurveCache.has(amount)) {
-        return distortionCurveCache.get(amount)!;
+    // Quantize the amount to reduce cache fragmentation (0.1 steps).
+    // Original input range 0-50, so this creates ~500 possible cache entries.
+    const k_raw = typeof amount === 'number' ? amount : 50;
+    const k = Math.round(k_raw * 10) / 10;
+
+    if (distortionCurveCache.has(k)) {
+        return distortionCurveCache.get(k)!;
     }
-    const k = typeof amount === 'number' ? amount : 50,
-        n_samples = 44100,
+
+    // Reduce sample size from 44100 to 8192.
+    // 8192 is sufficient for smooth distortion with WaveShaper interpolation.
+    // Reduces memory usage per entry by ~5.4x (176KB -> 32KB).
+    const n_samples = 8192,
         curve = new Float32Array(n_samples) as Float32Array<ArrayBuffer>,
         deg = Math.PI / 180;
     let x;
@@ -30,7 +38,7 @@ function makeDistortionCurve(amount: number): Float32Array<ArrayBuffer> {
         x = (i * 2) / n_samples - 1;
         curve[i] = ((3 + k) * x * 20 * deg) / (Math.PI + k * Math.abs(x));
     }
-    distortionCurveCache.set(amount, curve);
+    distortionCurveCache.set(k, curve);
     return curve;
 }
 


### PR DESCRIPTION
⚡ Bolt: Optimize distortion curve generation

💡 What:
- Quantized the `amount` input for `makeDistortionCurve` to 0.1 steps.
- Reduced the `WaveShaperNode` curve buffer size from 44,100 to 8,192 samples.

🎯 Why:
- The `makeDistortionCurve` function was caching a new 176KB buffer for every unique floating-point value from the `drive` knob. Smooth knob dragging could generate hundreds of megabytes of cached curves, leading to memory pressure and potential GC pauses.
- 44.1k samples is excessive for the smooth sigmoid distortion function used. 8k samples provides identical audible results (especially with oversampling enabled) while using ~80% less memory per entry.

📊 Impact:
- Reduces memory usage per cached distortion curve by ~5.4x (176KB -> 32KB).
- Significantly increases cache hit rate during knob interaction.
- Reduces CPU time spent generating curves by ~5x.

🔬 Measurement:
- Verified with `pnpm test src/__tests__/useAudioEngine.perf.test.tsx` to ensure no regressions.
- Logic verified via code review to ensure mathematical correctness of the optimization.

---
*PR created automatically by Jules for task [1059457856369115613](https://jules.google.com/task/1059457856369115613) started by @ford442*