### PR TITLE
Fix RubberBandStretcher unbound types error in AudioWorklet

### DIFF
--- a/src/audio-worklets/rubberband-processor.ts
+++ b/src/audio-worklets/rubberband-processor.ts
@@ -91,7 +91,7 @@ class RubberBandProcessor extends AudioWorkletProcessor {
           });
 
           this.rubberBand = new module.RubberBandStretcher(
-            this.sampleRate,
+            Math.floor(this.sampleRate),
             1, // Mono
             1 | 32 | 1048576, // RealTime | Finer | FormantPreserved
             1.0,


### PR DESCRIPTION
Fixes a runtime error in the `RubberBandProcessor` AudioWorklet where the WASM module failed to initialize.

The error "Cannot construct RubberBandStretcher due to unbound types" occurs because the C++ `RubberBandWrapper` constructor expects an `int` (or `size_t`) for the sample rate, but the AudioWorklet passes a JavaScript number (double/float). Emscripten's strict binding mechanism rejects this mismatch.

Changes:
- Modified `src/audio-worklets/rubberband-processor.ts` to explicitly cast `this.sampleRate` to an integer using `Math.floor()`.

This ensures the correct C++ constructor overload is selected. Build artifacts and submodule changes were reverted to ensure a clean commit.

---
*PR created automatically by Jules for task [13684689945044389183](https://jules.google.com/task/13684689945044389183) started by @ford442*