### PR TITLE
⚡ Bolt: Optimize HardwareModule WebGPU updates

### DIFF
--- a/src/__tests__/HardwareModule.gpu.test.tsx
+++ b/src/__tests__/HardwareModule.gpu.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act, waitFor } from '@testing-library/react';
+import { HardwareModule } from '../components/HardwareModule';
+import type { KnobConfig } from '../components/HardwareModule';
+
+describe('HardwareModule - WebGPU Optimization', () => {
+    const mockControls: KnobConfig[] = [
+        { id: 'test1', label: 'Test 1', x: 0.3, y: 0.5, size: 0.08, value: 0.5 }
+    ];
+    const mockColorHex: [number, number, number] = [0.0, 0.7, 1.0];
+
+    let mockWriteBuffer: any;
+    let mockDevice: any;
+    let mockContext: any;
+    let requestAnimationFrameMock: any;
+    let cancelAnimationFrameMock: any;
+    let frameCallbacks: FrameRequestCallback[] = [];
+
+    beforeEach(() => {
+        // Mock RequestAnimationFrame
+        frameCallbacks = [];
+        requestAnimationFrameMock = vi.fn((cb) => {
+            frameCallbacks.push(cb);
+            return frameCallbacks.length - 1;
+        });
+        cancelAnimationFrameMock = vi.fn();
+        vi.stubGlobal('requestAnimationFrame', requestAnimationFrameMock);
+        vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrameMock);
+        vi.stubGlobal('performance', { now: () => 1000 });
+
+        // Mock WebGPU Globals
+        vi.stubGlobal('GPUBufferUsage', {
+            UNIFORM: 1,
+            COPY_DST: 2
+        });
+
+        // Mock WebGPU
+        mockWriteBuffer = vi.fn();
+        mockDevice = {
+            createShaderModule: vi.fn(),
+            createRenderPipeline: vi.fn().mockReturnValue({
+                getBindGroupLayout: vi.fn()
+            }),
+            createBuffer: vi.fn().mockReturnValue({}),
+            createBindGroup: vi.fn().mockReturnValue({}),
+            createCommandEncoder: vi.fn().mockReturnValue({
+                beginRenderPass: vi.fn().mockReturnValue({
+                    setPipeline: vi.fn(),
+                    setBindGroup: vi.fn(),
+                    draw: vi.fn(),
+                    end: vi.fn()
+                }),
+                finish: vi.fn()
+            }),
+            queue: {
+                writeBuffer: mockWriteBuffer,
+                submit: vi.fn()
+            },
+            destroy: vi.fn()
+        };
+
+        mockContext = {
+            configure: vi.fn(),
+            getCurrentTexture: vi.fn().mockReturnValue({
+                createView: vi.fn()
+            })
+        };
+
+        const mockAdapter = {
+            requestDevice: vi.fn().mockResolvedValue(mockDevice)
+        };
+
+        vi.stubGlobal('navigator', {
+            gpu: {
+                requestAdapter: vi.fn().mockResolvedValue(mockAdapter),
+                getPreferredCanvasFormat: vi.fn().mockReturnValue('bgra8unorm')
+            }
+        });
+
+        // Mock canvas context
+        HTMLCanvasElement.prototype.getContext = vi.fn((type) => {
+            if (type === 'webgpu') return mockContext;
+            return null;
+        }) as any;
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it('optimizes buffer writes: full write initially, partial write on animation frame', async () => {
+        const onParamChange = vi.fn();
+        let rerender: any;
+
+        await act(async () => {
+            const result = render(
+                <HardwareModule
+                    title="Test Module"
+                    colorHex={mockColorHex}
+                    controls={mockControls}
+                    onParamChange={onParamChange}
+                    is3D={true}
+                />
+            );
+            rerender = result.rerender;
+        });
+
+        // Wait for async init using waitFor
+        await waitFor(() => {
+            expect(mockWriteBuffer).toHaveBeenCalled();
+        });
+
+        // Initial render: Full Write
+        // writeBuffer(buffer, 0, buf) -> 3 args (plus implied optional)
+        const firstCall = mockWriteBuffer.mock.calls[0];
+        const writtenData = firstCall[2];
+        expect(writtenData).toBeInstanceOf(Float32Array);
+        expect(writtenData.length).toBe(72);
+        expect(firstCall[3]).toBeUndefined(); // offset
+        expect(firstCall[4]).toBeUndefined(); // size
+
+        // Trigger next frame
+        await act(async () => {
+             const cb = frameCallbacks.shift();
+             if (cb) cb(performance.now());
+        });
+
+        // Subsequent frame: Partial Write (size 2)
+        expect(mockWriteBuffer).toHaveBeenCalledTimes(2);
+        const secondCall = mockWriteBuffer.mock.calls[1];
+        expect(secondCall[3]).toBe(0); // offset
+        expect(secondCall[4]).toBe(2); // size = 2 elements (time, ratio)
+
+        // Update props: Should trigger Full Write again
+        const newControls = [...mockControls, { id: 'new', label: 'New', x: 0, y: 0, size: 0.1, value: 0 }];
+        await act(async () => {
+            rerender(
+                <HardwareModule
+                    title="Test Module"
+                    colorHex={mockColorHex}
+                    controls={newControls}
+                    onParamChange={onParamChange}
+                    is3D={true}
+                />
+            );
+        });
+
+        // The useEffect runs, sets dirty=true.
+        // In 3D mode, the animation loop is running asynchronously.
+        // We trigger the next frame to see the effect of dirty=true.
+        await act(async () => {
+            const cb = frameCallbacks.shift();
+            if (cb) cb(performance.now());
+        });
+
+        expect(mockWriteBuffer).toHaveBeenCalledTimes(3);
+        const thirdCall = mockWriteBuffer.mock.calls[2];
+        // Expect full write because props changed
+        expect(thirdCall[3]).toBeUndefined();
+        expect(thirdCall[4]).toBeUndefined();
+    });
+});

--- a/src/components/HardwareModule.tsx
+++ b/src/components/HardwareModule.tsx
@@ -161,6 +161,9 @@ export const HardwareModule = React.memo(
         // Ref to store the render function for demand-based rendering
         const renderRef = useRef<(() => void) | null>(null);
 
+        // Ref to track dirty state for GPU buffer updates
+        const dirtyRef = useRef(true);
+
         // Refs for accessibility elements to enable focus management
         const sliderRefs = useRef<(HTMLDivElement | null)[]>([]);
 
@@ -172,6 +175,7 @@ export const HardwareModule = React.memo(
         // Sync refs & Update Staging Buffer
         useEffect(() => {
             controlsRef.current = controls;
+            dirtyRef.current = true; // Mark as dirty when props change
 
             // Update Staging Buffer (Static Data)
             // This moves the overhead of populating controls/color from the 60fps render loop
@@ -534,8 +538,15 @@ export const HardwareModule = React.memo(
                 buf[0] = performance.now() / 1000;
                 buf[1] = width / height;
 
-                // PERFORMANCE: Single batched write
-                device.queue.writeBuffer(uniformBuffer, 0, buf);
+                // PERFORMANCE: Optimized partial write
+                // Only write the full buffer if static data changed (dirtyRef)
+                // Otherwise, only write the first 8 bytes (2 floats: time, ratio)
+                if (dirtyRef.current) {
+                    device.queue.writeBuffer(uniformBuffer, 0, buf);
+                    dirtyRef.current = false;
+                } else {
+                    device.queue.writeBuffer(uniformBuffer, 0, buf, 0, 2);
+                }
 
                 const encoder = device.createCommandEncoder();
                 const pass = encoder.beginRenderPass({


### PR DESCRIPTION
💡 What: Optimized the WebGPU render loop in `HardwareModule.tsx` to perform partial buffer updates.
🎯 Why: The previous implementation re-uploaded the entire uniform buffer (288 bytes) to the GPU on every animation frame, even though most data (knob values, colors, positions) remains static. This consumed unnecessary bandwidth and processing time.
📊 Impact: Reduces per-frame data transfer to the GPU by ~97% (from 288 bytes down to 8 bytes) for standard animation frames. Full updates occur only when component props actually change.
🔬 Measurement: Verified with a new regression test `src/__tests__/HardwareModule.gpu.test.tsx` that mocks the WebGPU API and asserts `writeBuffer` is called with the optimization (partial write size=2) on subsequent frames.

---
*PR created automatically by Jules for task [445203366701911042](https://jules.google.com/task/445203366701911042) started by @ford442*