### PR TITLE
Fix audio silence by correcting asset paths and adding synth fallback

### DIFF
--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -150,8 +150,8 @@ export const useAudioEngine = (pyodide: any) => {
             };
 
             const [sawBuf, sqrBuf] = await Promise.all([
-                loadWav('./assets/saw.wav'),
-                loadWav('./assets/square.wav')
+                loadWav('/saw.wav'),
+                loadWav('/square.wav')
             ]);
             wavSawBufferRef.current = sawBuf;
             wavSqrBufferRef.current = sqrBuf;
@@ -491,51 +491,53 @@ export const useAudioEngine = (pyodide: any) => {
 
                 if (isWavWave) {
                     const buffer = params.waveform === 'wav-saw' ? wavSawBufferRef.current : wavSqrBufferRef.current;
-                    if (!buffer) return null;
-                    const source = context.createBufferSource();
-                    source.buffer = buffer;
-                    source.loop = true;
+                    if (buffer) {
+                        const source = context.createBufferSource();
+                        source.buffer = buffer;
+                        source.loop = true;
 
-                    const baseFreq = noteToFrequency(note);
-                    const freqWithPitch = baseFreq * Math.pow(2, params.pitch / 12);
-                    const sampleRootFreq = params.waveform === 'wav-saw' ? 32.86 : 65.72;
-                    source.playbackRate.setValueAtTime(freqWithPitch / sampleRootFreq, now);
+                        const baseFreq = noteToFrequency(note);
+                        const freqWithPitch = baseFreq * Math.pow(2, params.pitch / 12);
+                        const sampleRootFreq = params.waveform === 'wav-saw' ? 32.86 : 65.72;
+                        source.playbackRate.setValueAtTime(freqWithPitch / sampleRootFreq, now);
 
-                    const envGain = context.createGain();
-                    envGain.gain.setValueAtTime(0, now);
-                    envGain.gain.linearRampToValueAtTime(params.volume, now + params.attack);
-                    const sustainLevel = params.volume * params.sustain;
-                    envGain.gain.linearRampToValueAtTime(sustainLevel, now + params.attack + params.decay);
+                        const envGain = context.createGain();
+                        envGain.gain.setValueAtTime(0, now);
+                        envGain.gain.linearRampToValueAtTime(params.volume, now + params.attack);
+                        const sustainLevel = params.volume * params.sustain;
+                        envGain.gain.linearRampToValueAtTime(sustainLevel, now + params.attack + params.decay);
 
-                    const filter = context.createBiquadFilter();
-                    filter.type = 'lowpass';
-                    filter.frequency.setValueAtTime(params.filterCutoff || 20000, now);
-                    filter.Q.setValueAtTime(params.filterResonance || 0, now);
+                        const filter = context.createBiquadFilter();
+                        filter.type = 'lowpass';
+                        filter.frequency.setValueAtTime(params.filterCutoff || 20000, now);
+                        filter.Q.setValueAtTime(params.filterResonance || 0, now);
 
-                    source.connect(filter);
-                    filter.connect(envGain);
-                    envGain.connect(masterGainRef.current!);
+                        source.connect(filter);
+                        filter.connect(envGain);
+                        envGain.connect(masterGainRef.current!);
 
-                    source.start(now);
+                        source.start(now);
 
-                    if (activeSynthNotes.current.size >= MAX_SYNTH_VOICES) {
-                        const oldestId = activeSynthNotes.current.keys().next().value;
-                        if (oldestId !== undefined) {
-                            const oldest = activeSynthNotes.current.get(oldestId as number);
-                            if (oldest && oldest.stop) oldest.stop();
+                        if (activeSynthNotes.current.size >= MAX_SYNTH_VOICES) {
+                            const oldestId = activeSynthNotes.current.keys().next().value;
+                            if (oldestId !== undefined) {
+                                const oldest = activeSynthNotes.current.get(oldestId as number);
+                                if (oldest && oldest.stop) oldest.stop();
+                            }
                         }
+                        const id = nextSynthNoteId.current++;
+                        const stop = () => {
+                            const t = context.currentTime;
+                            envGain.gain.cancelScheduledValues(t);
+                            envGain.gain.setValueAtTime(envGain.gain.value || sustainLevel, t);
+                            envGain.gain.linearRampToValueAtTime(0, t + params.release);
+                                try { source.stop(t + params.release + 0.05); } catch { /* ignore */ }
+                            activeSynthNotes.current.delete(id);
+                        };
+                        activeSynthNotes.current.set(id, { stop });
+                        return id;
                     }
-                    const id = nextSynthNoteId.current++;
-                    const stop = () => {
-                        const t = context.currentTime;
-                        envGain.gain.cancelScheduledValues(t);
-                        envGain.gain.setValueAtTime(envGain.gain.value || sustainLevel, t);
-                        envGain.gain.linearRampToValueAtTime(0, t + params.release);
-                            try { source.stop(t + params.release + 0.05); } catch { /* ignore */ }
-                        activeSynthNotes.current.delete(id);
-                    };
-                    activeSynthNotes.current.set(id, { stop });
-                    return id;
+                    console.warn('Wav buffer for ' + params.waveform + ' missing, falling back to oscillator.');
                 }
                 
                 if (isWgslWave || isWasmWave || isPyodideWave) {


### PR DESCRIPTION
Fixed incorrect paths for loading `saw.wav` and `square.wav` assets. Updated `noteOnSynth` in `useAudioEngine.ts` to check if the wav buffer is loaded before attempting to use it, preventing silent failures and allowing fallback to the native oscillator with a warning.

---
*PR created automatically by Jules for task [17993199876871593064](https://jules.google.com/task/17993199876871593064) started by @ford442*