### PR TITLE
Fix unused variables and types in AudioEngine

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,7 +17,7 @@ export default defineConfig([
     ],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: globals.browser, }, rules: { '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
     },
   },
 ])

--- a/lint_output.txt
+++ b/lint_output.txt
@@ -1,0 +1,927 @@
+
+> hyphon-daw@1.0.0 lint
+> eslint .
+
+
+/app/assembly/oscillators.ts
+  13:0  error  Parsing error: Decorators are not valid here
+
+/app/emsdk/upstream/emscripten/src/Fetch.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/IDBStore.js
+  9:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/audio_worklet.js
+  15:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libaddfunction.js
+  13:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libasync.js
+  22:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libatomic.js
+  17:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libautodebug.js
+  8:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libbase64.js
+  25:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libbootstrap.js
+  10:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libbrowser.js
+  14:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libc_preprocessor.js
+  46:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libccall.js
+  9:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libcore.js
+  49:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libdylink.js
+  9:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libegl.js
+  51:23  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libembind.js
+  6:1  error  Parsing error: Unexpected token #include
+
+/app/emsdk/upstream/emscripten/src/lib/libembind_gen.js
+  5:1  error  Parsing error: Unexpected token #include
+
+/app/emsdk/upstream/emscripten/src/lib/libembind_shared.js
+  108:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libemval.js
+  23:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libeventloop.js
+  47:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libexceptions.js
+  8:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libexceptions_stub.js
+  24:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libexports.js
+  19:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libfetch.js
+  7:1  error  Parsing error: Unexpected token #include
+
+/app/emsdk/upstream/emscripten/src/lib/libfs.js
+  12:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libfs_shared.js
+  11:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libgetvalue.js
+  16:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libglemu.js
+  38:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libglfw.js
+  92:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libglut.js
+  433:51  error  Parsing error: Unexpected token )
+
+/app/emsdk/upstream/emscripten/src/lib/libhtml5.js
+  9:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libhtml5_webgl.js
+  10:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libidbfs.js
+  16:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libidbstore.js
+  7:1  error  Parsing error: Unexpected token #include
+
+/app/emsdk/upstream/emscripten/src/lib/libint53.js
+  8:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/liblegacy.js
+  33:3  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/liblz4.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libmath.js
+  27:18  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libmemfs.js
+  12:43  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libmemoryprofiler.js
+  3:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libnodefs.js
+  8:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libnoderawfs.js
+  35:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libopenal.js
+  50:29  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libpath.js
+  77:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libpipefs.js
+  15:40  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libpromise.js
+  22:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libproxyfs.js
+  199:25  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libpthread.js
+  10:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libpthread_stub.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libsdl.js
+  65:19  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libsockfs.js
+  13:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libstack_trace.js
+  11:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libstrings.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libsyscall.js
+  9:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libtime.js
+  13:26  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libtrace.js
+  256:26  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libtty.js
+  13:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libuuid.js
+  44:18  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libwasi.js
+  8:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libwasm_worker.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libwasmfs.js
+  40:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libwasmfs_fetch.js
+  98:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libwasmfs_js_file.js
+  35:20  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libwasmfs_jsimpl.js
+  14:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libwasmfs_node.js
+  13:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libwasmfs_opfs.js
+  17:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libwebaudio.js
+  1:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libwebgl.js
+  48:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libwebgl2.js
+  18:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libwebsocket.js
+  23:37  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libwget.js
+  36:89  error  Parsing error: Unexpected token (
+
+/app/emsdk/upstream/emscripten/src/lib/libworkerfs.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/memoryprofiler.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/minimum_runtime_check.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/modularize.js
+  10:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/node_shell_read.js
+  11:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/polyfill/bigint64array.js
+  1:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/postamble.js
+  9:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/postamble_minimal.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/postamble_modularize.js
+  17:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/postlibrary.js
+  4:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/preamble.js
+  17:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/preamble_minimal.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/pthread_esm_startup.mjs
+  12:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/runtime_asan.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/runtime_common.js
+  7:1  error  Parsing error: Unexpected token #include
+
+/app/emsdk/upstream/emscripten/src/runtime_debug.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/runtime_exceptions.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/runtime_init_memory.js
+  8:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/runtime_pthread.js
+  11:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/runtime_safe_heap.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/runtime_stack_check.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/shell.js
+  6:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/shell_minimal.js
+  7:1  error  Parsing error: Unexpected token #include
+
+/app/emsdk/upstream/emscripten/src/source_map_support.js
+  94:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/threadprofiler.js
+  1:1  error  Parsing error: Unexpected token #preprocess
+
+/app/emsdk/upstream/emscripten/src/wasm2js.js
+  17:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/wasm_worker.js
+  10:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/web_or_worker_shell_read.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/test/core/test_jslib_i64_params.js
+  4:21  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/test/core/test_module_wasm_memory.js
+  1:1  error  Parsing error: Unexpected token #preprocess
+
+/app/emsdk/upstream/emscripten/test/embind/test.post.js
+  1:3  error  Parsing error: 'return' outside of function
+
+/app/emsdk/upstream/emscripten/test/embind/test.pre.js
+  2:1  error  Parsing error: Unexpected token
+
+/app/emsdk/upstream/emscripten/test/embind/test_i64_binding.js
+  10:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/test/error_in_js_libraries.js
+  1:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/test/jslib/test_jslib_custom_settings.js
+  3:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/test/modularize_post_js.js
+  1:1  error  Parsing error: Unexpected token #preprocess
+
+/app/emsdk/upstream/emscripten/test/other/embind_tsgen.d.ts
+   12:3   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free                                                                                                                                                                                                                                                                        @typescript-eslint/ban-ts-comment
+   31:18  error  An interface declaring no members is equivalent to its supertype                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-empty-object-type
+   78:18  error  An interface declaring no members is equivalent to its supertype                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-empty-object-type
+  124:8   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  132:14  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  145:8   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  156:14  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  157:17  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  159:19  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  160:34  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  160:40  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  162:21  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+
+/app/emsdk/upstream/emscripten/test/other/embind_tsgen_bigint.d.ts
+  2:11  error  An empty interface declaration allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowInterfaces' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+
+/app/emsdk/upstream/emscripten/test/other/embind_tsgen_constant_only.d.ts
+  2:11  error  An empty interface declaration allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowInterfaces' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+
+/app/emsdk/upstream/emscripten/test/other/embind_tsgen_ignore_1.d.ts
+    3:37   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    3:45   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    4:41   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    4:49   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    5:37   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    5:48   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    5:58   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    5:72   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    5:87   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    5:108  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    5:121  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    5:137  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    6:33   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    6:41   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    7:41   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    7:49   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    8:39   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    8:47   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    9:35   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+   10:38   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+   23:3    error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free                                                                                                                                                                                                                                                                        @typescript-eslint/ban-ts-comment
+   42:18   error  An interface declaring no members is equivalent to its supertype                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-empty-object-type
+   89:18   error  An interface declaring no members is equivalent to its supertype                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-empty-object-type
+  135:8    error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  143:14   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  156:8    error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  167:14   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  168:17   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  170:19   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  171:34   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  171:40   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  173:21   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+
+/app/emsdk/upstream/emscripten/test/other/embind_tsgen_ignore_2.d.ts
+    2:11  error  An empty interface declaration allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowInterfaces' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead   @typescript-eslint/no-empty-object-type
+   11:3   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free                                                                                                                                                                                                                                                                        @typescript-eslint/ban-ts-comment
+   30:18  error  An interface declaring no members is equivalent to its supertype                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-empty-object-type
+   77:18  error  An interface declaring no members is equivalent to its supertype                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-empty-object-type
+  123:8   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  131:14  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  144:8   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  155:14  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  156:17  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  158:19  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  159:34  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  159:40  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  161:21  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+
+/app/emsdk/upstream/emscripten/test/other/embind_tsgen_ignore_3.d.ts
+   12:3   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free                                                                                                                                                                                                                                                                        @typescript-eslint/ban-ts-comment
+   31:18  error  An interface declaring no members is equivalent to its supertype                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-empty-object-type
+   78:18  error  An interface declaring no members is equivalent to its supertype                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-empty-object-type
+  124:8   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  132:14  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  145:8   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  156:14  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  157:17  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  159:19  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  160:34  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  160:40  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  162:21  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+
+/app/emsdk/upstream/emscripten/test/other/embind_tsgen_jspi.d.ts
+  2:11  error  An empty interface declaration allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowInterfaces' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+
+/app/emsdk/upstream/emscripten/test/other/embind_tsgen_main.ts
+  45:9  error  'valString' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+/app/emsdk/upstream/emscripten/test/other/embind_tsgen_module.d.ts
+   12:3   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free                                                                                                                                                                                                                                                                        @typescript-eslint/ban-ts-comment
+   31:18  error  An interface declaring no members is equivalent to its supertype                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-empty-object-type
+   78:18  error  An interface declaring no members is equivalent to its supertype                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-empty-object-type
+  124:8   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  132:14  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  145:8   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  156:14  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  157:17  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  159:19  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  160:34  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  160:40  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  162:21  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+
+/app/emsdk/upstream/emscripten/test/other/embind_tsgen_wasm64.d.ts
+  2:11  error  An empty interface declaration allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowInterfaces' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+
+/app/emsdk/upstream/emscripten/test/other/test_emit_tsd.d.ts
+  13:45  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/emsdk/upstream/emscripten/test/other/test_extra_struct_info.js
+  1:38  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/test/other/test_parseTools.js
+  5:40  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/test/other/test_split_module.post.js
+  1:1  error  Parsing error: Unexpected token #preprocess
+
+/app/emsdk/upstream/emscripten/test/other/test_tsd.ts
+  3:16  error  'go' is defined but never used                     @typescript-eslint/no-unused-vars
+  6:7   error  'result' is never reassigned. Use 'const' instead  prefer-const
+  6:7   error  'result' is assigned a value but never used        @typescript-eslint/no-unused-vars
+
+/app/emsdk/upstream/emscripten/test/return64bit/testbindend.js
+  2:1  error  Parsing error: Unexpected token }
+
+/app/emsdk/upstream/emscripten/test/return64bit/testbindstart.js
+  2:1  error  Parsing error: Unexpected token
+
+/app/emsdk/upstream/emscripten/test/warning_in_js_libraries.js
+  1:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/tools/acorn-optimizer.mjs
+  397:40  warning  Unused eslint-disable directive (no problems were reported from 'no-empty')
+
+/app/src/App.tsx
+   77:20    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+   78:18    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+   84:20    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  167:39    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  172:37    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  192:79    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  223:80    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  224:76    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  227:73    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  228:69    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  233:60    error    Error: This value cannot be modified
+
+Modifying component props or hook arguments is not allowed. Consider using a local variable instead.
+
+/app/src/App.tsx:233:60
+  231 |
+  232 |     return (
+> 233 |         <g transform={`translate(${x}, 0)`} ref={(el) => { refsArray.current[stepIndex] = el; }} className="svg-step" role="button" tabIndex={0} aria-label={`${rowLabel} step ${stepIndex + 1}`} onPointerDown={handlePointerDown} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle(rowKey, stepIndex, e); } }} onContextMenu={(e) => e.preventDefault()} cursor="pointer" style={{ transition: 'all 0.1s ease', touchAction: 'none', '--focus-color': focusColor } as React.CSSProperties}>
+      |                                                            ^^^^^^^^^^^^^^^^^ `refsArray` cannot be modified
+  234 |             {active && <rect className="step-glow" x={-4} y={-4} width={totalWidth + 8} height={height + 8} rx={6} fill={color} fillOpacity={0.4} filter="blur(6px)" />}
+  235 |             <rect x={0} y={0} width={totalWidth} height={height} rx={3} fill="#050505" />
+  236 |             {active && isSlide && <rect x={4} y={height - 8} width={totalWidth - 8} height={3} rx={1} fill="#fbbf24" fillOpacity={1} style={{ mixBlendMode: 'plus-lighter' }} />}  react-hooks/immutability
+  262:64    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  263:73    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  263:92    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  264:51    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  265:22    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  471:34    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  474:38    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  474:92    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  542:17    error    Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                @typescript-eslint/ban-ts-comment
+  571:13    error    Error: This value cannot be modified
+
+Modifying a value previously passed as an argument to a hook is not allowed. Consider moving the modification before calling the hook.
+
+/app/src/App.tsx:571:13
+  569 |             isFirstStepRef.current = true;
+  570 |             rowRefs.current.forEach(r => r?.setHighlight(-1));
+> 571 |             currentStepRef.current = -1;
+      |             ^^^^^^^^^^^^^^ `currentStepRef` cannot be modified
+  572 |         }
+  573 |     }, [schedPlaying]);
+  574 |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  react-hooks/immutability
+  634:79    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  681:11    warning  The 'handleNoteSelect' function makes the dependencies of useMemo Hook (at line 929) change on every render. To fix this, wrap the definition of 'handleNoteSelect' in its own useCallback() Hook                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  react-hooks/exhaustive-deps
+  703:11    warning  The 'handleNoteLengthChange' function makes the dependencies of useMemo Hook (at line 929) change on every render. To fix this, wrap the definition of 'handleNoteLengthChange' in its own useCallback() Hook                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      react-hooks/exhaustive-deps
+  711:119   error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  722:435   error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  724:45    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  738:52    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  738:2924  warning  React Hook useCallback has an unnecessary dependency: 'sampleBuffers'. Either exclude it or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            react-hooks/exhaustive-deps
+  747:344   error    Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                @typescript-eslint/ban-ts-comment
+  751:86    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  775:348   error    Optional chain expressions can return undefined by design - using a non-null assertion is unsafe and wrong                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         @typescript-eslint/no-non-null-asserted-optional-chain
+  870:8     warning  React Hook useMemo has missing dependencies: 'handleGlobalPanReset' and 'handleMasterVolumeReset'. Either include them or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              react-hooks/exhaustive-deps
+  910:120   error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+
+/app/src/__tests__/FormantShifter.test.ts
+   20:46  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+   29:49  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  229:62  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  230:60  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/__tests__/HardwareModule.gpu.test.tsx
+  12:26  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  13:21  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  14:22  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  15:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  16:35  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  84:15  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  94:23  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/__tests__/NoteSelector.test.tsx
+  7:29  error  '_note' is defined but never used  @typescript-eslint/no-unused-vars
+
+/app/src/__tests__/SamplerPanel.perf.test.tsx
+  18:6  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/__tests__/SamplerPanel.test.tsx
+  22:6  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/__tests__/SingingVoice.integration.test.ts
+  47:55  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  54:50  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/__tests__/WasmOscillator.test.ts
+  24:51  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  25:27  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  31:78  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  32:87  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  39:14  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  51:24  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  57:24  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/__tests__/audioExport.perf.test.ts
+  25:45  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/__tests__/trackFreezer.test.ts
+   21:49  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+   79:18  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+   98:18  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  123:18  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  152:18  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/audio-worklets/open303-processor.ts
+  49:62  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  65:58  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  86:67  error  '_parameters' is defined but never used   @typescript-eslint/no-unused-vars
+  98:54  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/audio-worklets/rubberband-processor.ts
+   3:1   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free  @typescript-eslint/ban-ts-comment
+  12:1   error  Unexpected var, use let or const instead                                                                             no-var
+  14:18  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  17:81  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  24:23  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  54:5   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free  @typescript-eslint/ban-ts-comment
+  84:11  error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free  @typescript-eslint/ban-ts-comment
+
+/app/src/audio-worklets/sustain-processor.ts
+   7:1   error  Unexpected var, use let or const instead  no-var
+   9:18  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  12:81  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/components/CloudLibrary.tsx
+    9:24   error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+   11:24   error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+   12:24   error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+   13:27   error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+   66:8    warning  React Hook useEffect has a missing dependency: 'loadLibrary'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
+   70:100  error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+   77:31   error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+  108:23   error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+  133:89   error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+  167:36   error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+  194:67   error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+  222:79   error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+
+/app/src/components/CloudStatus.tsx
+  42:9  error    Error: Calling setState synchronously within an effect can trigger cascading renders
+
+Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
+* Update external systems with the latest state from React.
+* Subscribe for updates from some external system, calling setState in a callback function when external state changes.
+
+Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).
+
+/app/src/components/CloudStatus.tsx:42:9
+  40 |
+  41 |         // Initial Check
+> 42 |         checkHealth();
+     |         ^^^^^^^^^^^ Avoid calling setState() directly within an effect
+  43 |         // Poll every 30s
+  44 |         const interval = setInterval(checkHealth, 30000);
+  45 |         return () => {  react-hooks/set-state-in-effect
+  49:8  warning  React Hook useEffect has a missing dependency: 'checkHealth'. Either include it or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  react-hooks/exhaustive-deps
+
+/app/src/components/MagicKnob.tsx
+  82:64  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/components/SamplerPanel.tsx
+  18:61  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/components/Sequencer.tsx
+  90:13  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/components/Studio3D.tsx
+  86:61  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/custom.d.ts
+  7:3   warning  Unused eslint-disable directive (no problems were reported from 'no-var')
+  8:22  error    Unexpected any. Specify a different type                                   @typescript-eslint/no-explicit-any
+  9:3   warning  Unused eslint-disable directive (no problems were reported from 'no-var')
+
+/app/src/engines/Open303Oscillator.ts
+   7:37  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  17:25  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/engines/WasmOscillator.ts
+  42:50  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/engines/WebGpuOscillator.test.ts
+   7:23  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+   8:26  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+   9:25  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  10:26  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  11:17  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  12:20  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  13:25  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  15:18  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  16:13  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  23:20  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  67:5   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free  @typescript-eslint/ban-ts-comment
+  73:5   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free  @typescript-eslint/ban-ts-comment
+  75:5   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free  @typescript-eslint/ban-ts-comment
+  83:5   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free  @typescript-eslint/ban-ts-comment
+  98:5   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free  @typescript-eslint/ban-ts-comment
+
+/app/src/engines/rubberband/PhonemeAligner.ts
+  143:47  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/hooks/useAudioEngine.ts
+   21:13   error  'x' is never reassigned. Use 'const' instead         prefer-const
+   40:41   error  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
+   83:68   error  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
+  390:90   error  '_durationSteps' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  390:118  error  '_stepTime' is assigned a value but never used       @typescript-eslint/no-unused-vars
+  457:69   error  '_time' is defined but never used                    @typescript-eslint/no-unused-vars
+  485:52   error  Empty block statement                                no-empty
+  491:46   error  '_params' is defined but never used                  @typescript-eslint/no-unused-vars
+  491:68   error  '_sequence' is defined but never used                @typescript-eslint/no-unused-vars
+  491:93   error  '_tempo' is defined but never used                   @typescript-eslint/no-unused-vars
+  554:46   error  '_b' is defined but never used                       @typescript-eslint/no-unused-vars
+  555:43   error  '_sampleName' is defined but never used              @typescript-eslint/no-unused-vars
+  555:64   error  '_note' is defined but never used                    @typescript-eslint/no-unused-vars
+  555:79   error  '_steps' is defined but never used                   @typescript-eslint/no-unused-vars
+  555:95   error  '_tempo' is defined but never used                   @typescript-eslint/no-unused-vars
+  556:41   error  '_sampleName' is defined but never used              @typescript-eslint/no-unused-vars
+  556:62   error  '_note' is defined but never used                    @typescript-eslint/no-unused-vars
+  557:37   error  '_mode' is defined but never used                    @typescript-eslint/no-unused-vars
+  558:42   error  '_size' is defined but never used                    @typescript-eslint/no-unused-vars
+
+/app/src/hooks/useGamepad.ts
+  143:6  warning  React Hook useEffect has a missing dependency: 'updateLoop'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
+
+/app/src/hooks/useStableKnobConfig.ts
+  16:14  error  Error: Cannot access refs during render
+
+React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef).
+
+/app/src/hooks/useStableKnobConfig.ts:16:14
+  14 |
+  15 |          // If first run or length changed (layout change), return new entirely
+> 16 |          if (!oldConfigs || newConfigs.length !== oldConfigs.length) {
+     |              ^^^^^^^^^^^ Cannot access ref value during render
+  17 |              prevConfigs.current = newConfigs;
+  18 |              return newConfigs;
+  19 |          }                                                                                                                                                                                                                                                                     react-hooks/refs
+  16:14  error  Error: Cannot access refs during render
+
+React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef).
+
+/app/src/hooks/useStableKnobConfig.ts:16:14
+  14 |
+  15 |          // If first run or length changed (layout change), return new entirely
+> 16 |          if (!oldConfigs || newConfigs.length !== oldConfigs.length) {
+     |              ^^^^^^^^^^^ Cannot access ref value during render
+  17 |              prevConfigs.current = newConfigs;
+  18 |              return newConfigs;
+  19 |          }                                                                                                                                                                                                                                                                     react-hooks/refs
+  16:14  error  Error: Cannot access refs during render
+
+React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef).
+
+/app/src/hooks/useStableKnobConfig.ts:16:14
+  14 |
+  15 |          // If first run or length changed (layout change), return new entirely
+> 16 |          if (!oldConfigs || newConfigs.length !== oldConfigs.length) {
+     |              ^^^^^^^^^^^ Cannot access ref value during render
+  17 |              prevConfigs.current = newConfigs;
+  18 |              return newConfigs;
+  19 |          }                                                                                                                                                                                                                                                                     react-hooks/refs
+  16:15  error  Error: Cannot access refs during render
+
+React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef).
+
+/app/src/hooks/useStableKnobConfig.ts:16:15
+  14 |
+  15 |          // If first run or length changed (layout change), return new entirely
+> 16 |          if (!oldConfigs || newConfigs.length !== oldConfigs.length) {
+     |               ^^^^^^^^^^ Cannot access ref value during render
+  17 |              prevConfigs.current = newConfigs;
+  18 |              return newConfigs;
+  19 |          }
+
+To initialize a ref only once, check that the ref is null with the pattern `if (ref.current == null) { ref.current = ... }`                                                                                                                                        react-hooks/refs
+  16:51  error  Error: Cannot access refs during render
+
+React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef).
+
+/app/src/hooks/useStableKnobConfig.ts:16:51
+  14 |
+  15 |          // If first run or length changed (layout change), return new entirely
+> 16 |          if (!oldConfigs || newConfigs.length !== oldConfigs.length) {
+     |                                                   ^^^^^^^^^^^^^^^^^ Cannot access ref value during render
+  17 |              prevConfigs.current = newConfigs;
+  18 |              return newConfigs;
+  19 |          }                                                                                                                                                                                                                          react-hooks/refs
+  21:47  error  Error: Cannot access refs during render
+
+React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef).
+
+/app/src/hooks/useStableKnobConfig.ts:21:47
+  19 |          }
+  20 |
+> 21 |          const mergedConfigs = newConfigs.map((newCfg, i) => {
+     |                                               ^^^^^^^^^^^^^^^^
+> 22 |              const oldCfg = oldConfigs[i];
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+> 23 |
+     …
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+> 36 |              return newCfg;
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+> 37 |          });
+     | ^^^^^^^^^^^ Passing a ref to a function may read its value during render
+  38 |
+  39 |          prevConfigs.current = mergedConfigs;
+  40 |          return mergedConfigs;  react-hooks/refs
+  39:10  error  Error: Cannot access refs during render
+
+React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef).
+
+/app/src/hooks/useStableKnobConfig.ts:39:10
+  37 |          });
+  38 |
+> 39 |          prevConfigs.current = mergedConfigs;
+     |          ^^^^^^^^^^^^^^^^^^^ Cannot update ref during render
+  40 |          return mergedConfigs;
+  41 |     }, [params, generator]);
+  42 | }                                                                                                                                                                                                                                                                                                                                                                                               react-hooks/refs
+
+/app/src/services/CloudStorage.ts
+  23:11  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  57:66  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  92:21  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/types.ts
+  101:20  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  102:18  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  103:21  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  120:58  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  167:17  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  168:21  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  169:18  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/utils/noteColors.ts
+  27:12  error  '_' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+/app/src/utils/renderAudio.ts
+   19:24  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+   20:22  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+   21:19  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  187:13  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  188:15  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/vite-env.d.ts
+  9:16  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/vitest.setup.ts
+   15:12  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+   20:14  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  102:10  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  114:12  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+✖ 370 problems (360 errors, 10 warnings)
+  2 errors and 3 warnings potentially fixable with the `--fix` option.

--- a/lint_output_2.txt
+++ b/lint_output_2.txt
@@ -1,0 +1,919 @@
+
+> hyphon-daw@1.0.0 lint
+> eslint .
+
+
+/app/assembly/oscillators.ts
+  13:0  error  Parsing error: Decorators are not valid here
+
+/app/emsdk/upstream/emscripten/src/Fetch.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/IDBStore.js
+  9:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/audio_worklet.js
+  15:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libaddfunction.js
+  13:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libasync.js
+  22:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libatomic.js
+  17:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libautodebug.js
+  8:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libbase64.js
+  25:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libbootstrap.js
+  10:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libbrowser.js
+  14:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libc_preprocessor.js
+  46:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libccall.js
+  9:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libcore.js
+  49:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libdylink.js
+  9:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libegl.js
+  51:23  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libembind.js
+  6:1  error  Parsing error: Unexpected token #include
+
+/app/emsdk/upstream/emscripten/src/lib/libembind_gen.js
+  5:1  error  Parsing error: Unexpected token #include
+
+/app/emsdk/upstream/emscripten/src/lib/libembind_shared.js
+  108:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libemval.js
+  23:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libeventloop.js
+  47:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libexceptions.js
+  8:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libexceptions_stub.js
+  24:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libexports.js
+  19:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libfetch.js
+  7:1  error  Parsing error: Unexpected token #include
+
+/app/emsdk/upstream/emscripten/src/lib/libfs.js
+  12:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libfs_shared.js
+  11:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libgetvalue.js
+  16:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libglemu.js
+  38:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libglfw.js
+  92:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libglut.js
+  433:51  error  Parsing error: Unexpected token )
+
+/app/emsdk/upstream/emscripten/src/lib/libhtml5.js
+  9:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libhtml5_webgl.js
+  10:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libidbfs.js
+  16:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libidbstore.js
+  7:1  error  Parsing error: Unexpected token #include
+
+/app/emsdk/upstream/emscripten/src/lib/libint53.js
+  8:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/liblegacy.js
+  33:3  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/liblz4.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libmath.js
+  27:18  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libmemfs.js
+  12:43  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libmemoryprofiler.js
+  3:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libnodefs.js
+  8:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libnoderawfs.js
+  35:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libopenal.js
+  50:29  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libpath.js
+  77:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libpipefs.js
+  15:40  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libpromise.js
+  22:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libproxyfs.js
+  199:25  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libpthread.js
+  10:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libpthread_stub.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libsdl.js
+  65:19  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libsockfs.js
+  13:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libstack_trace.js
+  11:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libstrings.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libsyscall.js
+  9:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libtime.js
+  13:26  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libtrace.js
+  256:26  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libtty.js
+  13:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libuuid.js
+  44:18  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libwasi.js
+  8:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libwasm_worker.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libwasmfs.js
+  40:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libwasmfs_fetch.js
+  98:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libwasmfs_js_file.js
+  35:20  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libwasmfs_jsimpl.js
+  14:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libwasmfs_node.js
+  13:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libwasmfs_opfs.js
+  17:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libwebaudio.js
+  1:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libwebgl.js
+  48:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libwebgl2.js
+  18:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/lib/libwebsocket.js
+  23:37  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/src/lib/libwget.js
+  36:89  error  Parsing error: Unexpected token (
+
+/app/emsdk/upstream/emscripten/src/lib/libworkerfs.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/memoryprofiler.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/minimum_runtime_check.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/modularize.js
+  10:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/node_shell_read.js
+  11:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/polyfill/bigint64array.js
+  1:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/postamble.js
+  9:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/postamble_minimal.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/postamble_modularize.js
+  17:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/postlibrary.js
+  4:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/preamble.js
+  17:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/preamble_minimal.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/pthread_esm_startup.mjs
+  12:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/runtime_asan.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/runtime_common.js
+  7:1  error  Parsing error: Unexpected token #include
+
+/app/emsdk/upstream/emscripten/src/runtime_debug.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/runtime_exceptions.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/runtime_init_memory.js
+  8:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/runtime_pthread.js
+  11:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/runtime_safe_heap.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/runtime_stack_check.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/shell.js
+  6:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/shell_minimal.js
+  7:1  error  Parsing error: Unexpected token #include
+
+/app/emsdk/upstream/emscripten/src/source_map_support.js
+  94:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/threadprofiler.js
+  1:1  error  Parsing error: Unexpected token #preprocess
+
+/app/emsdk/upstream/emscripten/src/wasm2js.js
+  17:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/wasm_worker.js
+  10:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/src/web_or_worker_shell_read.js
+  7:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/test/core/test_jslib_i64_params.js
+  4:21  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/test/core/test_module_wasm_memory.js
+  1:1  error  Parsing error: Unexpected token #preprocess
+
+/app/emsdk/upstream/emscripten/test/embind/test.post.js
+  1:3  error  Parsing error: 'return' outside of function
+
+/app/emsdk/upstream/emscripten/test/embind/test.pre.js
+  2:1  error  Parsing error: Unexpected token
+
+/app/emsdk/upstream/emscripten/test/embind/test_i64_binding.js
+  10:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/test/error_in_js_libraries.js
+  1:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/test/jslib/test_jslib_custom_settings.js
+  3:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/test/modularize_post_js.js
+  1:1  error  Parsing error: Unexpected token #preprocess
+
+/app/emsdk/upstream/emscripten/test/other/embind_tsgen.d.ts
+   12:3   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free                                                                                                                                                                                                                                                                        @typescript-eslint/ban-ts-comment
+   31:18  error  An interface declaring no members is equivalent to its supertype                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-empty-object-type
+   78:18  error  An interface declaring no members is equivalent to its supertype                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-empty-object-type
+  124:8   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  132:14  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  145:8   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  156:14  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  157:17  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  159:19  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  160:34  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  160:40  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  162:21  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+
+/app/emsdk/upstream/emscripten/test/other/embind_tsgen_bigint.d.ts
+  2:11  error  An empty interface declaration allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowInterfaces' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+
+/app/emsdk/upstream/emscripten/test/other/embind_tsgen_constant_only.d.ts
+  2:11  error  An empty interface declaration allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowInterfaces' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+
+/app/emsdk/upstream/emscripten/test/other/embind_tsgen_ignore_1.d.ts
+    3:37   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    3:45   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    4:41   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    4:49   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    5:37   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    5:48   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    5:58   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    5:72   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    5:87   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    5:108  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    5:121  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    5:137  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    6:33   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    6:41   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    7:41   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    7:49   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    8:39   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    8:47   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+    9:35   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+   10:38   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+   23:3    error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free                                                                                                                                                                                                                                                                        @typescript-eslint/ban-ts-comment
+   42:18   error  An interface declaring no members is equivalent to its supertype                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-empty-object-type
+   89:18   error  An interface declaring no members is equivalent to its supertype                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-empty-object-type
+  135:8    error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  143:14   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  156:8    error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  167:14   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  168:17   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  170:19   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  171:34   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  171:40   error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  173:21   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+
+/app/emsdk/upstream/emscripten/test/other/embind_tsgen_ignore_2.d.ts
+    2:11  error  An empty interface declaration allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowInterfaces' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead   @typescript-eslint/no-empty-object-type
+   11:3   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free                                                                                                                                                                                                                                                                        @typescript-eslint/ban-ts-comment
+   30:18  error  An interface declaring no members is equivalent to its supertype                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-empty-object-type
+   77:18  error  An interface declaring no members is equivalent to its supertype                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-empty-object-type
+  123:8   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  131:14  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  144:8   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  155:14  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  156:17  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  158:19  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  159:34  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  159:40  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  161:21  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+
+/app/emsdk/upstream/emscripten/test/other/embind_tsgen_ignore_3.d.ts
+   12:3   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free                                                                                                                                                                                                                                                                        @typescript-eslint/ban-ts-comment
+   31:18  error  An interface declaring no members is equivalent to its supertype                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-empty-object-type
+   78:18  error  An interface declaring no members is equivalent to its supertype                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-empty-object-type
+  124:8   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  132:14  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  145:8   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  156:14  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  157:17  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  159:19  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  160:34  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  160:40  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  162:21  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+
+/app/emsdk/upstream/emscripten/test/other/embind_tsgen_jspi.d.ts
+  2:11  error  An empty interface declaration allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowInterfaces' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+
+/app/emsdk/upstream/emscripten/test/other/embind_tsgen_main.ts
+  45:9  error  'valString' is assigned a value but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
+
+/app/emsdk/upstream/emscripten/test/other/embind_tsgen_module.d.ts
+   12:3   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free                                                                                                                                                                                                                                                                        @typescript-eslint/ban-ts-comment
+   31:18  error  An interface declaring no members is equivalent to its supertype                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-empty-object-type
+   78:18  error  An interface declaring no members is equivalent to its supertype                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-empty-object-type
+  124:8   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  132:14  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  145:8   error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  156:14  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  157:17  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+  159:19  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  160:34  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  160:40  error  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-explicit-any
+  162:21  error  The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+
+/app/emsdk/upstream/emscripten/test/other/embind_tsgen_wasm64.d.ts
+  2:11  error  An empty interface declaration allows any non-nullish value, including literals like `0` and `""`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowInterfaces' rule option.
+- If you want a type meaning "any object", you probably want `object` instead.
+- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/no-empty-object-type
+
+/app/emsdk/upstream/emscripten/test/other/test_emit_tsd.d.ts
+  13:45  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/emsdk/upstream/emscripten/test/other/test_extra_struct_info.js
+  1:38  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/test/other/test_parseTools.js
+  5:40  error  Parsing error: Unexpected token {
+
+/app/emsdk/upstream/emscripten/test/other/test_split_module.post.js
+  1:1  error  Parsing error: Unexpected token #preprocess
+
+/app/emsdk/upstream/emscripten/test/other/test_tsd.ts
+  3:16  error  'go' is defined but never used. Allowed unused vars must match /^_/u               @typescript-eslint/no-unused-vars
+  6:7   error  'result' is never reassigned. Use 'const' instead                                  prefer-const
+  6:7   error  'result' is assigned a value but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
+
+/app/emsdk/upstream/emscripten/test/return64bit/testbindend.js
+  2:1  error  Parsing error: Unexpected token }
+
+/app/emsdk/upstream/emscripten/test/return64bit/testbindstart.js
+  2:1  error  Parsing error: Unexpected token
+
+/app/emsdk/upstream/emscripten/test/warning_in_js_libraries.js
+  1:1  error  Parsing error: Unexpected token #if
+
+/app/emsdk/upstream/emscripten/tools/acorn-optimizer.mjs
+  397:40  warning  Unused eslint-disable directive (no problems were reported from 'no-empty')
+
+/app/src/App.tsx
+   77:20    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+   78:18    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+   84:20    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  167:39    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  172:37    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  192:79    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  223:80    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  224:76    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  227:73    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  228:69    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  233:60    error    Error: This value cannot be modified
+
+Modifying component props or hook arguments is not allowed. Consider using a local variable instead.
+
+/app/src/App.tsx:233:60
+  231 |
+  232 |     return (
+> 233 |         <g transform={`translate(${x}, 0)`} ref={(el) => { refsArray.current[stepIndex] = el; }} className="svg-step" role="button" tabIndex={0} aria-label={`${rowLabel} step ${stepIndex + 1}`} onPointerDown={handlePointerDown} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle(rowKey, stepIndex, e); } }} onContextMenu={(e) => e.preventDefault()} cursor="pointer" style={{ transition: 'all 0.1s ease', touchAction: 'none', '--focus-color': focusColor } as React.CSSProperties}>
+      |                                                            ^^^^^^^^^^^^^^^^^ `refsArray` cannot be modified
+  234 |             {active && <rect className="step-glow" x={-4} y={-4} width={totalWidth + 8} height={height + 8} rx={6} fill={color} fillOpacity={0.4} filter="blur(6px)" />}
+  235 |             <rect x={0} y={0} width={totalWidth} height={height} rx={3} fill="#050505" />
+  236 |             {active && isSlide && <rect x={4} y={height - 8} width={totalWidth - 8} height={3} rx={1} fill="#fbbf24" fillOpacity={1} style={{ mixBlendMode: 'plus-lighter' }} />}  react-hooks/immutability
+  262:64    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  263:73    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  263:92    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  264:51    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  265:22    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  471:34    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  474:38    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  474:92    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  542:17    error    Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                @typescript-eslint/ban-ts-comment
+  571:13    error    Error: This value cannot be modified
+
+Modifying a value previously passed as an argument to a hook is not allowed. Consider moving the modification before calling the hook.
+
+/app/src/App.tsx:571:13
+  569 |             isFirstStepRef.current = true;
+  570 |             rowRefs.current.forEach(r => r?.setHighlight(-1));
+> 571 |             currentStepRef.current = -1;
+      |             ^^^^^^^^^^^^^^ `currentStepRef` cannot be modified
+  572 |         }
+  573 |     }, [schedPlaying]);
+  574 |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  react-hooks/immutability
+  634:79    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  681:11    warning  The 'handleNoteSelect' function makes the dependencies of useMemo Hook (at line 929) change on every render. To fix this, wrap the definition of 'handleNoteSelect' in its own useCallback() Hook                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  react-hooks/exhaustive-deps
+  703:11    warning  The 'handleNoteLengthChange' function makes the dependencies of useMemo Hook (at line 929) change on every render. To fix this, wrap the definition of 'handleNoteLengthChange' in its own useCallback() Hook                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      react-hooks/exhaustive-deps
+  711:119   error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  722:435   error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  724:45    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  738:52    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  738:2924  warning  React Hook useCallback has an unnecessary dependency: 'sampleBuffers'. Either exclude it or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            react-hooks/exhaustive-deps
+  747:344   error    Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                @typescript-eslint/ban-ts-comment
+  751:86    error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+  775:348   error    Optional chain expressions can return undefined by design - using a non-null assertion is unsafe and wrong                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         @typescript-eslint/no-non-null-asserted-optional-chain
+  870:8     warning  React Hook useMemo has missing dependencies: 'handleGlobalPanReset' and 'handleMasterVolumeReset'. Either include them or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              react-hooks/exhaustive-deps
+  910:120   error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           @typescript-eslint/no-explicit-any
+
+/app/src/__tests__/FormantShifter.test.ts
+   20:46  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+   29:49  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  229:62  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  230:60  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/__tests__/HardwareModule.gpu.test.tsx
+  12:26  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  13:21  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  14:22  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  15:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  16:35  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  84:15  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  94:23  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/__tests__/SamplerPanel.perf.test.tsx
+  18:6  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/__tests__/SamplerPanel.test.tsx
+  22:6  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/__tests__/SingingVoice.integration.test.ts
+  47:55  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  54:50  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/__tests__/WasmOscillator.test.ts
+  24:51  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  25:27  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  31:78  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  32:87  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  39:14  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  51:24  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  57:24  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/__tests__/audioExport.perf.test.ts
+  25:45  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/__tests__/trackFreezer.test.ts
+   21:49  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+   79:18  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+   98:18  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  123:18  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  152:18  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/audio-worklets/open303-processor.ts
+  49:62  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  65:58  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  98:54  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/audio-worklets/rubberband-processor.ts
+   3:1   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free  @typescript-eslint/ban-ts-comment
+  12:1   error  Unexpected var, use let or const instead                                                                             no-var
+  14:18  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  17:81  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  24:23  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  54:5   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free  @typescript-eslint/ban-ts-comment
+  84:11  error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free  @typescript-eslint/ban-ts-comment
+
+/app/src/audio-worklets/sustain-processor.ts
+   7:1   error  Unexpected var, use let or const instead  no-var
+   9:18  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  12:81  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/components/CloudLibrary.tsx
+    9:24   error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+   11:24   error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+   12:24   error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+   13:27   error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+   66:8    warning  React Hook useEffect has a missing dependency: 'loadLibrary'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
+   70:100  error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+   77:31   error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+  108:23   error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+  133:89   error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+  167:36   error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+  194:67   error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+  222:79   error    Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+
+/app/src/components/CloudStatus.tsx
+  42:9  error    Error: Calling setState synchronously within an effect can trigger cascading renders
+
+Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
+* Update external systems with the latest state from React.
+* Subscribe for updates from some external system, calling setState in a callback function when external state changes.
+
+Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).
+
+/app/src/components/CloudStatus.tsx:42:9
+  40 |
+  41 |         // Initial Check
+> 42 |         checkHealth();
+     |         ^^^^^^^^^^^ Avoid calling setState() directly within an effect
+  43 |         // Poll every 30s
+  44 |         const interval = setInterval(checkHealth, 30000);
+  45 |         return () => {  react-hooks/set-state-in-effect
+  49:8  warning  React Hook useEffect has a missing dependency: 'checkHealth'. Either include it or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  react-hooks/exhaustive-deps
+
+/app/src/components/MagicKnob.tsx
+  82:64  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/components/SamplerPanel.tsx
+  18:61  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/components/Sequencer.tsx
+  90:13  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/components/Studio3D.tsx
+  86:61  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/custom.d.ts
+  7:3   warning  Unused eslint-disable directive (no problems were reported from 'no-var')
+  8:22  error    Unexpected any. Specify a different type                                   @typescript-eslint/no-explicit-any
+  9:3   warning  Unused eslint-disable directive (no problems were reported from 'no-var')
+
+/app/src/engines/Open303Oscillator.ts
+   7:37  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  17:25  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/engines/WasmOscillator.ts
+  42:50  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/engines/WebGpuOscillator.test.ts
+   7:23  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+   8:26  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+   9:25  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  10:26  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  11:17  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  12:20  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  13:25  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  15:18  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  16:13  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  23:20  error  Unexpected any. Specify a different type                                                                             @typescript-eslint/no-explicit-any
+  67:5   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free  @typescript-eslint/ban-ts-comment
+  73:5   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free  @typescript-eslint/ban-ts-comment
+  75:5   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free  @typescript-eslint/ban-ts-comment
+  83:5   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free  @typescript-eslint/ban-ts-comment
+  98:5   error  Use "@ts-expect-error" instead of "@ts-ignore", as "@ts-ignore" will do nothing if the following line is error-free  @typescript-eslint/ban-ts-comment
+
+/app/src/engines/rubberband/ArtifactDetector.ts
+  219:5  warning  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-unused-vars')
+
+/app/src/engines/rubberband/ConcatenativeHybrid.ts
+  117:5  warning  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-unused-vars')
+
+/app/src/engines/rubberband/HybridNeuralPipeline.ts
+  135:5  warning  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-unused-vars')
+
+/app/src/engines/rubberband/PerformanceOptimizer.ts
+  130:5  warning  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-unused-vars')
+  198:5  warning  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-unused-vars')
+  232:5  warning  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-unused-vars')
+
+/app/src/engines/rubberband/PhonemeAligner.ts
+  143:47  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/hooks/useAudioEngine.ts
+   21:13  error  'x' is never reassigned. Use 'const' instead  prefer-const
+   40:41  error  Unexpected any. Specify a different type      @typescript-eslint/no-explicit-any
+   83:68  error  Unexpected any. Specify a different type      @typescript-eslint/no-explicit-any
+  485:52  error  Empty block statement                         no-empty
+
+/app/src/hooks/useGamepad.ts
+  143:6  warning  React Hook useEffect has a missing dependency: 'updateLoop'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
+
+/app/src/hooks/useStableKnobConfig.ts
+  16:14  error  Error: Cannot access refs during render
+
+React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef).
+
+/app/src/hooks/useStableKnobConfig.ts:16:14
+  14 |
+  15 |          // If first run or length changed (layout change), return new entirely
+> 16 |          if (!oldConfigs || newConfigs.length !== oldConfigs.length) {
+     |              ^^^^^^^^^^^ Cannot access ref value during render
+  17 |              prevConfigs.current = newConfigs;
+  18 |              return newConfigs;
+  19 |          }                                                                                                                                                                                                                                                                     react-hooks/refs
+  16:14  error  Error: Cannot access refs during render
+
+React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef).
+
+/app/src/hooks/useStableKnobConfig.ts:16:14
+  14 |
+  15 |          // If first run or length changed (layout change), return new entirely
+> 16 |          if (!oldConfigs || newConfigs.length !== oldConfigs.length) {
+     |              ^^^^^^^^^^^ Cannot access ref value during render
+  17 |              prevConfigs.current = newConfigs;
+  18 |              return newConfigs;
+  19 |          }                                                                                                                                                                                                                                                                     react-hooks/refs
+  16:14  error  Error: Cannot access refs during render
+
+React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef).
+
+/app/src/hooks/useStableKnobConfig.ts:16:14
+  14 |
+  15 |          // If first run or length changed (layout change), return new entirely
+> 16 |          if (!oldConfigs || newConfigs.length !== oldConfigs.length) {
+     |              ^^^^^^^^^^^ Cannot access ref value during render
+  17 |              prevConfigs.current = newConfigs;
+  18 |              return newConfigs;
+  19 |          }                                                                                                                                                                                                                                                                     react-hooks/refs
+  16:15  error  Error: Cannot access refs during render
+
+React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef).
+
+/app/src/hooks/useStableKnobConfig.ts:16:15
+  14 |
+  15 |          // If first run or length changed (layout change), return new entirely
+> 16 |          if (!oldConfigs || newConfigs.length !== oldConfigs.length) {
+     |               ^^^^^^^^^^ Cannot access ref value during render
+  17 |              prevConfigs.current = newConfigs;
+  18 |              return newConfigs;
+  19 |          }
+
+To initialize a ref only once, check that the ref is null with the pattern `if (ref.current == null) { ref.current = ... }`                                                                                                                                        react-hooks/refs
+  16:51  error  Error: Cannot access refs during render
+
+React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef).
+
+/app/src/hooks/useStableKnobConfig.ts:16:51
+  14 |
+  15 |          // If first run or length changed (layout change), return new entirely
+> 16 |          if (!oldConfigs || newConfigs.length !== oldConfigs.length) {
+     |                                                   ^^^^^^^^^^^^^^^^^ Cannot access ref value during render
+  17 |              prevConfigs.current = newConfigs;
+  18 |              return newConfigs;
+  19 |          }                                                                                                                                                                                                                          react-hooks/refs
+  21:47  error  Error: Cannot access refs during render
+
+React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef).
+
+/app/src/hooks/useStableKnobConfig.ts:21:47
+  19 |          }
+  20 |
+> 21 |          const mergedConfigs = newConfigs.map((newCfg, i) => {
+     |                                               ^^^^^^^^^^^^^^^^
+> 22 |              const oldCfg = oldConfigs[i];
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+> 23 |
+     …
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+> 36 |              return newCfg;
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+> 37 |          });
+     | ^^^^^^^^^^^ Passing a ref to a function may read its value during render
+  38 |
+  39 |          prevConfigs.current = mergedConfigs;
+  40 |          return mergedConfigs;  react-hooks/refs
+  39:10  error  Error: Cannot access refs during render
+
+React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef).
+
+/app/src/hooks/useStableKnobConfig.ts:39:10
+  37 |          });
+  38 |
+> 39 |          prevConfigs.current = mergedConfigs;
+     |          ^^^^^^^^^^^^^^^^^^^ Cannot update ref during render
+  40 |          return mergedConfigs;
+  41 |     }, [params, generator]);
+  42 | }                                                                                                                                                                                                                                                                                                                                                                                               react-hooks/refs
+
+/app/src/services/CloudStorage.ts
+  23:11  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  57:66  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  92:21  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/types.ts
+  101:20  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  102:18  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  103:21  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  120:58  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  167:17  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  168:21  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  169:18  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/utils/renderAudio.ts
+   19:24  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+   20:22  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+   21:19  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  187:13  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  188:15  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/src/vite-env.d.ts
+  9:16  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/app/vitest.setup.ts
+   15:12  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+   20:14  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  102:10  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  114:12  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+✖ 358 problems (342 errors, 16 warnings)
+  2 errors and 9 warnings potentially fixable with the `--fix` option.

--- a/src/__tests__/WaveformSelector.test.tsx
+++ b/src/__tests__/WaveformSelector.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { WaveformSelector } from '../components/WaveformSelector';
-import type { Waveform } from '../types';
 
 describe('WaveformSelector', () => {
   it('renders the wav-saw and wav-sqr buttons', async () => {

--- a/src/engines/Open303Oscillator.ts
+++ b/src/engines/Open303Oscillator.ts
@@ -9,7 +9,6 @@ declare global {
 }
 
 export class Open303Oscillator {
-    private audioContext: AudioContext | null = null;
 
     // -- Strategy 1: AudioWorklet --
     private workletNode: AudioWorkletNode | null = null;
@@ -26,7 +25,6 @@ export class Open303Oscillator {
     useWorklet: boolean = false;
 
     async init(audioContext: AudioContext, workletUrl?: string): Promise<boolean> {
-        this.audioContext = audioContext;
         this.outputNode = audioContext.createGain();
         this.gainNode = audioContext.createGain();
         this.gainNode.gain.value = 1.0;
@@ -119,7 +117,7 @@ export class Open303Oscillator {
                 }
             };
 
-            this.processorNode.connect(this.gainNode);
+            if (this.gainNode) { this.processorNode.connect(this.gainNode); }
             this.isReady = true;
             this.useWorklet = false;
             this.applyAllParameters();

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -1,11 +1,11 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import type { AudioEngine, SynthParams, DrumSound, KickParams, SnareParams, HatParams, SamplerBankParams, PartSequence } from '../types';
-import { noteToFrequency, NUM_STEPS } from '../constants';
+import { noteToFrequency } from '../constants';
 import { noteToMidi } from '../utils/musicTheory';
 import { WebGpuOscillator } from '../engines/WebGpuOscillator';
 import { WasmOscillator } from '../engines/WasmOscillator';
 import { Open303Oscillator } from '../engines/Open303Oscillator';
-import { SingingVoice, REFERENCE_FREQUENCIES, freqToMidi } from '../engines/SingingVoice';
+import { SingingVoice } from '../engines/SingingVoice';
 import sustainProcessorUrl from '../audio-worklets/sustain-processor.ts?worker&url';
 // Import the new processor URL (we will create this file next)
 import open303ProcessorUrl from '../audio-worklets/open303-processor.ts?worker&url';
@@ -18,16 +18,13 @@ function makeDistortionCurve(amount: number): Float32Array<ArrayBuffer> {
     if (distortionCurveCache.has(k)) return distortionCurveCache.get(k)!;
     const n_samples = 8192, curve = new Float32Array(n_samples), deg = Math.PI / 180;
     for (let i = 0; i < n_samples; ++i) {
-        let x = (i * 2) / n_samples - 1;
+        const x = (i * 2) / n_samples - 1;
         curve[i] = ((3 + k) * x * 20 * deg) / (Math.PI + k * Math.abs(x));
     }
     distortionCurveCache.set(k, curve);
     return curve;
 }
 
-const modeToWorkletValue = (mode: 'loop' | 'stretch' | 'wavetable'): number => {
-    return mode === 'loop' ? 0 : mode === 'stretch' ? 1 : 2;
-};
 
 // Map UI params to Engine params
 function apply303Params(engine: Open303Oscillator, params: SynthParams, waveType: string): void {
@@ -49,7 +46,6 @@ export const useAudioEngine = (pyodide: any) => {
     const ambianceSourceNodeRef = useRef<AudioBufferSourceNode | null>(null);
     const ambianceGainNodeRef = useRef<GainNode | null>(null);
     const loadedAmbianceBuffersRef = useRef<Map<string, AudioBuffer>>(new Map());
-    const rendererWorkerRef = useRef<Worker | null>(null);
     const gpuEngineRef = useRef<WebGpuOscillator | null>(null);
     const wasmEngineRef = useRef<WasmOscillator | null>(null);
     const open303EngineRef = useRef<Open303Oscillator | null>(null);
@@ -391,7 +387,7 @@ export const useAudioEngine = (pyodide: any) => {
                 loadedSampleBuffersRef.current.set(name, buffer);
             };
 
-            const playSampler = (params: SamplerBankParams, note: string, time: number, durationSteps: number = 1, stepTime: number = 0.2) => {
+            const playSampler = (params: SamplerBankParams, _note: string, time: number, _durationSteps: number = 1, _stepTime: number = 0.2) => {
                 const buffer = loadedSampleBuffersRef.current.get(params.sampleName);
                 if (!buffer || !masterGainRef.current) return;
 
@@ -425,7 +421,7 @@ export const useAudioEngine = (pyodide: any) => {
                 // No auto-stop for one-shots usually, unless gated
             };
 
-            const noteOnSampler = (params: SamplerBankParams, note: string, time?: number): number | null => {
+            const noteOnSampler = (params: SamplerBankParams, _note: string, time?: number): number | null => {
                 // Interactive trigger (e.g. keyboard)
                 const now = time || context.currentTime;
                 const buffer = loadedSampleBuffersRef.current.get(params.sampleName);
@@ -458,7 +454,7 @@ export const useAudioEngine = (pyodide: any) => {
                 }
             };
 
-            const noteOnSynth = (params: SynthParams, note: string, time?: number) => {
+            const noteOnSynth = (params: SynthParams, note: string, _time?: number) => {
                  // Interactive Synth trigger
                  if (params.waveform === '303-saw' || params.waveform === '303-sqr') {
                      if (open303EngineRef.current) {
@@ -492,7 +488,7 @@ export const useAudioEngine = (pyodide: any) => {
             };
 
             // Helpers for Render/Ambiance
-            const renderSynthPartToBuffer = (params: SynthParams, sequence: PartSequence, tempo: number): Promise<AudioBuffer> => {
+            const renderSynthPartToBuffer = (_params: SynthParams, _sequence: PartSequence, _tempo: number): Promise<AudioBuffer> => {
                  // Placeholder for actual offline rendering logic
                  return Promise.resolve(context.createBuffer(2, context.sampleRate * 2, context.sampleRate));
             };
@@ -555,11 +551,11 @@ export const useAudioEngine = (pyodide: any) => {
                 }
             };
 
-            const detectSamplePitch = async (b: AudioBuffer) => null;
-            const processSinging = async (sampleName: string, note: string, steps: number, tempo: number) => null;
-            const processSpoon = async (sampleName: string, note: string) => null;
-            const setSustainMode = (mode: 'loop' | 'stretch' | 'wavetable') => {};
-            const setSustainGrainSize = (size: number) => {};
+            const detectSamplePitch = async (_b: AudioBuffer) => null;
+            const processSinging = async (_sampleName: string, _note: string, _steps: number, _tempo: number) => null;
+            const processSpoon = async (_sampleName: string, _note: string) => null;
+            const setSustainMode = (_mode: 'loop' | 'stretch' | 'wavetable') => {};
+            const setSustainGrainSize = (_size: number) => {};
 
 
             // Re-assign the refs and state


### PR DESCRIPTION
Resolved multiple TypeScript and ESLint errors in the audio engine components:
- Removed unused imports (`Waveform`, `NUM_STEPS`, etc.)
- Prefixed unused parameters with `_` in `useAudioEngine.ts` to satisfy interface requirements while suppressing errors.
- Cleaned up `Open303Oscillator.ts` by removing the unused `audioContext` property and adding a null check for `gainNode`.
- Updated `eslint.config.js` to allow unused variables starting with `_`.

---
*PR created automatically by Jules for task [1721512788041375346](https://jules.google.com/task/1721512788041375346) started by @ford442*