### PR TITLE
Fix LiveKeyboard Input Interference

### DIFF
--- a/src/__tests__/LiveKeyboard.test.tsx
+++ b/src/__tests__/LiveKeyboard.test.tsx
@@ -1,4 +1,3 @@
-
 import { render, fireEvent } from '@testing-library/react';
 import { LiveKeyboard } from '../components/LiveKeyboard';
 
@@ -26,5 +25,26 @@ describe('LiveKeyboard', () => {
     expect(onPlay).toHaveBeenCalled();
     fireEvent.mouseUp(key);
     expect(onStop).toHaveBeenCalled();
+  });
+
+  test('ignores key events when typing in an input', () => {
+    const onPlay = vi.fn();
+    const onStop = vi.fn();
+    const { getByTestId } = render(
+      <div>
+        <input data-testid="test-input" />
+        <LiveKeyboard onPlayNote={onPlay} onStopNote={onStop} activeTrackColor="#ffffff" />
+      </div>
+    );
+
+    const input = getByTestId('test-input');
+    input.focus();
+
+    // Simulate keydown on the input (bubbling up to window)
+    fireEvent.keyDown(input, { code: 'F1', bubbles: true });
+    expect(onPlay).not.toHaveBeenCalled();
+
+    fireEvent.keyUp(input, { code: 'F1', bubbles: true });
+    expect(onStop).not.toHaveBeenCalled();
   });
 });

--- a/src/components/LiveKeyboard.tsx
+++ b/src/components/LiveKeyboard.tsx
@@ -333,6 +333,10 @@ export const LiveKeyboard = memo(({ onPlayNote, onStopNote, activeTrackColor }: 
     // --- KEYBOARD INTERACTION ---
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
+            const target = e.target as HTMLElement;
+            if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+                return;
+            }
             const note = KEY_TO_NOTE[e.code];
             if (note) {
                 // Prevent default browser actions for F-keys (Help, Find, Refresh, etc.)
@@ -349,6 +353,10 @@ export const LiveKeyboard = memo(({ onPlayNote, onStopNote, activeTrackColor }: 
         };
 
         const handleKeyUp = (e: KeyboardEvent) => {
+            const target = e.target as HTMLElement;
+            if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+                return;
+            }
             const note = KEY_TO_NOTE[e.code];
             if (note) {
                 e.preventDefault();


### PR DESCRIPTION
Modified `LiveKeyboard` component to check the event target in global `keydown` and `keyup` listeners. If the target is an `INPUT`, `TEXTAREA`, or `contentEditable` element, the event is ignored, allowing normal text input behavior without triggering musical notes.

Added a unit test to verify this behavior.

---
*PR created automatically by Jules for task [13718716514804599988](https://jules.google.com/task/13718716514804599988) started by @ford442*