### PR TITLE
Implement Phoneme Elasticity for Sampler

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -10,9 +10,10 @@
 ## 🚀 Active Backlog (Prioritized)
 
 ### Domain A: Audio Engine (Synth & Sampler)
+- [ ] **Refactor SingingVoice State:** Expose alignment state setters in `SingingVoice` to avoid type casting hacks and improve multi-bank alignment handling.
 - [ ] **Hybrid Polyphony:** Finalize `VoiceManager` to handle 8-voice polyphony for `synth-1` while keeping `synth-2` strictly monophonic (legato priority).
 - [ ] **TTS Slice Triggering:** Implement a logic where a MIDI Note NoteOn event can trigger a specific *slice* or *word* from the TTS buffer (e.g., Note C3 = "Hello", Note D3 = "World").
-- [ ] **Phoneme Elasticity:** Connect `rubberband.wasm` to the sequencer steps. If a note is dragged longer, the specific phoneme should time-stretch to match the duration without altering pitch.
+- [x] **Phoneme Elasticity:** Connect `rubberband.wasm` to the sequencer steps. If a note is dragged longer, the specific phoneme should time-stretch to match the duration without altering pitch.
 
 ### Domain B: Editor Workflow (The "Cubase" Feel)
 - [ ] **Rubber-Band Selection:** Implement multi-note selection via mouse drag in `Sequencer.tsx`.
@@ -36,3 +37,4 @@
 
 ## 📜 Changelog
 * [Date] - Roadmap re-initialized for long-term recursion.
+* [2026-02-05] - Implemented Phoneme Elasticity in Sampler Engine.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -728,7 +728,18 @@ export const App: React.FC = () => {
     const handleAddMeasure = useCallback(() => setSongStructure(prev => [...prev, { partA: null, partB: null, kick: null, snare: null, closedHat: null, openHat: null, sampler: null }]), []);
     const handleExportXM = useCallback(() => { exportSongToXM(songStructureRef.current, trackStorageRef.current, { synthA: synthARef.current, synthB: synthBRef.current, kick: kickRef.current, snare: snareRef.current, closedHat: closedHatRef.current, openHat: openHatRef.current, sampler: samplerRef.current }, tempoRef.current, patternRef.current, { webGpuEngine: audioEngine?.webGpuEngine, wasmEngine: audioEngine?.wasmEngine, pyodide: pyodide }, sampleBuffers); }, [audioEngine, pyodide, sampleBuffers]);
     const handleRemoveMeasure = useCallback(() => { const currentStructure = songStructure; if (currentStructure.length === 0) return; const last = currentStructure[currentStructure.length - 1]; const hasData = Object.values(last).some(v => v !== null); if (hasData) { if (!window.confirm("The last measure contains patterns. Are you sure you want to remove it?")) return; } setSongStructure(prev => prev.slice(0, -1)); }, [songStructure]);
-    const handleLoadSample = useCallback((name: string, buffer: AudioBuffer) => { if (!audioEngine) return; audioEngine.loadSampleToEngine(name, buffer); setSampleBuffers(prev => { const next = [...prev]; next[activeSamplerBank] = buffer; return next; }); const bankName = `bank_${activeSamplerBank}`; setSampler(prev => { const newParams = [...prev]; newParams[activeSamplerBank] = { ...newParams[activeSamplerBank], sampleName: bankName }; return newParams; }); }, [audioEngine, activeSamplerBank]);
+    const handleLoadSample = useCallback((name: string, buffer: AudioBuffer) => {
+        if (!audioEngine) return;
+        audioEngine.loadSampleToEngine(name, buffer);
+        setSampleBuffers(prev => { const next = [...prev]; next[activeSamplerBank] = buffer; return next; });
+        const bankName = `bank_${activeSamplerBank}`;
+        setSampler(prev => { const newParams = [...prev]; newParams[activeSamplerBank] = { ...newParams[activeSamplerBank], sampleName: bankName }; return newParams; });
+
+        if (audioEngine.prepareVocal) {
+            const text = ttsPhrases[activeSamplerBank] || "Hello World";
+            audioEngine.prepareVocal(activeSamplerBank, text);
+        }
+    }, [audioEngine, activeSamplerBank, ttsPhrases]);
 
     const handleSaveSong = async (slot: number) => { const encodedSamples: { [k: number]: string } = {}; await Promise.all(sampleBuffers.map(async (buf, idx) => { if (buf) { const wavBlob = audioBufferToWav(buf); const b64 = await blobToBase64(wavBlob); encodedSamples[idx] = b64; } })); const snapshot: SongSnapshot = { pattern, tempo, ambianceUrl, backgroundImage, params: { synthA, synthB, kick, snare, closedHat, openHat, sampler } }; setSongStorage(prev => { const copy = [...prev]; copy[slot] = snapshot; return copy; }); setActiveSongSlot(slot); };
     const loadSong = useCallback((slot: number) => { const snapshot = songStorage[slot]; if (!snapshot) return; setPattern(snapshot.pattern); setTempo(snapshot.tempo); setAmbianceUrl(snapshot.ambianceUrl); setBackgroundImage(snapshot.backgroundImage); setSynthA(snapshot.params.synthA); setSynthB(snapshot.params.synthB); setKick(snapshot.params.kick); setSnare(snapshot.params.snare); setClosedHat(snapshot.params.closedHat); setOpenHat(snapshot.params.openHat); setSampler(snapshot.params.sampler); setActiveSongSlot(slot); synthARef.current = snapshot.params.synthA; synthBRef.current = snapshot.params.synthB; kickRef.current = snapshot.params.kick; snareRef.current = snapshot.params.snare; closedHatRef.current = snapshot.params.closedHat; openHatRef.current = snapshot.params.openHat; samplerRef.current = snapshot.params.sampler; }, [songStorage]);
@@ -759,6 +770,15 @@ export const App: React.FC = () => {
         });
     }, []);
 
+
+    const handleTtsPhraseChange = useCallback((newPhrases: string[]) => {
+        setTtsPhrases(newPhrases);
+        if (audioEngine?.prepareVocal) {
+             const text = newPhrases[activeSamplerBank];
+             audioEngine.prepareVocal(activeSamplerBank, text);
+        }
+    }, [audioEngine, activeSamplerBank]);
+
     const onSynthAParamChange = useCallback((id: string, v: number) => handleSynthChange(true, id, v), [handleSynthChange]);
     const onSynthBParamChange = useCallback((id: string, v: number) => handleSynthChange(false, id, v), [handleSynthChange]);
 
@@ -772,7 +792,7 @@ export const App: React.FC = () => {
 
     const synthAChild = useMemo(() => (<div className="absolute top-4 right-6 pointer-events-auto"><WaveformSelector selected={synthA.waveform} onChange={(w) => updateSynthA({ waveform: w })} accentColor="cyan" /></div>), [synthA.waveform, updateSynthA]);
     const synthBChild = useMemo(() => (<div className="absolute top-4 right-6 pointer-events-auto"><WaveformSelector selected={synthB.waveform} onChange={(w) => updateSynthB({ waveform: w })} accentColor="pink" /></div>), [synthB.waveform, updateSynthB]);
-    const samplerChild = useMemo(() => (<div className="absolute top-4 left-[30%] w-[40%] h-auto pointer-events-auto z-10 bg-gray-900/80 rounded-lg border border-purple-500/30 backdrop-blur-sm"><SamplerPanel params={sampler} onChange={(u) => updateSampler(u)} onParamChange={handleSamplerParamChange} onLoadSample={handleLoadSample} audioContext={audioEngine?.context!} audioEngine={audioEngine || undefined} activeBankIdx={activeSamplerBank} onBankChange={setActiveSamplerBank} onOpenEditor={() => setIsVoiceEditorOpen(true)} ttsPhrases={ttsPhrases} onTtsPhraseChange={setTtsPhrases} /></div>), [sampler, updateSampler, handleSamplerParamChange, audioEngine, setIsVoiceEditorOpen, activeSamplerBank, handleLoadSample, ttsPhrases]);
+    const samplerChild = useMemo(() => (<div className="absolute top-4 left-[30%] w-[40%] h-auto pointer-events-auto z-10 bg-gray-900/80 rounded-lg border border-purple-500/30 backdrop-blur-sm"><SamplerPanel params={sampler} onChange={(u) => updateSampler(u)} onParamChange={handleSamplerParamChange} onLoadSample={handleLoadSample} audioContext={audioEngine?.context!} audioEngine={audioEngine || undefined} activeBankIdx={activeSamplerBank} onBankChange={setActiveSamplerBank} onOpenEditor={() => setIsVoiceEditorOpen(true)} ttsPhrases={ttsPhrases} onTtsPhraseChange={handleTtsPhraseChange} /></div>), [sampler, updateSampler, handleSamplerParamChange, audioEngine, setIsVoiceEditorOpen, activeSamplerBank, handleLoadSample, ttsPhrases]);
 
     // --- RENDER PARTS FOR 3D ---
     // Extract parts so they can be passed to either normal view or 3D view

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -1,3 +1,4 @@
+import { type AlignmentResult } from '../engines/rubberband/PhonemeAligner';
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import type { AudioEngine, SynthParams, DrumSound, KickParams, SnareParams, HatParams, SamplerBankParams, PartSequence } from '../types';
 import { noteToFrequency } from '../constants';
@@ -70,6 +71,7 @@ export const useAudioEngine = (pyodide: any) => {
     // In this implementation, we create new nodes per trigger, so this might be for loaded buffers or similar.
     // Assuming standard implementation:
     const loadedSampleBuffersRef = useRef<Map<string, AudioBuffer>>(new Map());
+    const vocalAlignmentsRef = useRef<Map<string, AlignmentResult>>(new Map());
 
 
     useEffect(() => {
@@ -167,7 +169,8 @@ export const useAudioEngine = (pyodide: any) => {
                     useHighQuality: false,
                     preserveFormants: true,
                     channels: 1,
-                    bufferSize: 16384
+                    bufferSize: 16384,
+                    enablePhonemeStretching: true
                 });
                 await singingVoiceRef.current.initWorklet();
                 singingVoiceRef.current.getSourceNode().connect(masterGainRef.current!);
@@ -387,11 +390,100 @@ export const useAudioEngine = (pyodide: any) => {
                 loadedSampleBuffersRef.current.set(name, buffer);
             };
 
-            const playSampler = (params: SamplerBankParams, _note: string, time: number, _durationSteps: number = 1, _stepTime: number = 0.2) => {
+
+            const prepareVocal = async (bankIndex: number, text: string) => {
+                if (!singingVoiceRef.current) return;
+                const bankName = `bank_${bankIndex}`;
+                const buffer = loadedSampleBuffersRef.current.get(bankName);
+                if (!buffer) return;
+
+                const audio = buffer.getChannelData(0);
+                try {
+                    const alignment = await singingVoiceRef.current.alignPhonemes(audio, text);
+                    if (alignment) {
+                        vocalAlignmentsRef.current.set(bankName, alignment);
+                        console.log(`Aligned phonemes for ${bankName}: ${alignment.phonemes.length}`);
+                    }
+                } catch (e) {
+                    console.warn('Phoneme alignment failed:', e);
+                }
+            };
+
+            const playSampler = (params: SamplerBankParams, note: string, time: number, durationSteps: number = 1, stepTime: number = 0.2) => {
                 const buffer = loadedSampleBuffersRef.current.get(params.sampleName);
                 if (!buffer || !masterGainRef.current) return;
 
-                // Simple One-shot for now (or basic loop if implemented)
+                if (params.mode === 'stretch' && singingVoiceRef.current) {
+                    // PHONEME ELASTICITY & SINGING VOICE MODE
+                    const voice = singingVoiceRef.current;
+                    const targetDuration = durationSteps * stepTime;
+                    const originalDuration = buffer.duration;
+
+                    // 1. Calculate Time Ratio
+                    // If target is 2s and original is 1s, ratio should be 2.0 (slower? no, Rubber Band ratio > 1 means longer/slower)
+                    // Wait, RubberBandStretcher setTimeRatio(r): r > 1 means slower?
+                    // Usually timeRatio = output_duration / input_duration.
+                    const timeRatio = targetDuration / originalDuration;
+                    voice.setTimeRatio(timeRatio);
+
+                    // 2. Pitch Shift
+                    // Assuming base note C4 (60) for the sample
+                    const targetMidi = noteToMidi(note);
+                    voice.setPitchFromMidi(targetMidi, 60);
+
+                    // 3. Phoneme Awareness
+                    const alignment = vocalAlignmentsRef.current.get(params.sampleName);
+                    // We need to inject the alignment into the voice engine state BEFORE processing
+                    // But SingingVoice 'process' is stateless for the alignment unless we set it.
+                    // The SingingVoice class has 'lastAlignment'.
+                    // We should probably explicitly set the alignment if we have it.
+                    // But SingingVoice doesn't expose a setter for lastAlignment directly,
+                    // but 'sendPhonemeDataToWorklet' uses 'lastAlignment'.
+                    // HACK: We rely on the fact that if we just called alignPhonemes it's set.
+                    // But here we might be switching banks.
+                    // We need to ensure the engine uses THIS alignment.
+                    // We'll update SingingVoice to allow setting alignment or assume it handles it.
+                    // Actually, let's just send the data if we have it.
+                    // But 'sendPhonemeDataToWorklet' reads from 'this.lastAlignment'.
+                    // We should assume 'prepareVocal' was called and likely set it?
+                    // No, 'prepareVocal' sets OUR ref 'vocalAlignmentsRef'.
+                    // We need to tell SingingVoice to use THIS alignment.
+                    // Let's modify SingingVoice class? No, let's treat it as a black box for now
+                    // and realize that 'sendPhonemeDataToWorklet' takes 'targetDuration' and uses internal state.
+                    // Wait, if I can't set internal state, I can't swap alignments.
+                    // I will look at SingingVoice.ts again.
+                    // It has 'alignPhonemes' which sets 'this.lastAlignment'.
+                    // So I should call 'alignPhonemes' again? No, that's expensive.
+                    // I should modify SingingVoice to accept alignment in 'sendPhonemeDataToWorklet' OR 'setAlignment'.
+                    // For now, I will assume the user has selected the bank and 'prepareVocal' might have just run?
+                    // Or I can add a method to SingingVoice to set current alignment.
+                    // Since I can't modify SingingVoice easily in this script without complex regex,
+                    // I'll stick to basic stretch.
+                    // WAIT! I can modify SingingVoice.ts easily with sed later if needed.
+                    // But I recall SingingVoice.ts:
+                    // private lastAlignment: AlignmentResult | null = null;
+                    // ...
+                    // sendPhonemeDataToWorklet(...) { if (!this.lastAlignment) return; ... }
+
+                    // So I MUST set 'lastAlignment'.
+                    // I will cast to any to force set it, or add a method.
+                    // Let's add a method 'setAlignment' to SingingVoice in the same plan step if possible,
+                    // or just use 'any' for now to keep it simple.
+
+                    if (alignment) {
+                        (voice as any).lastAlignment = alignment; // TypeScript hack for now
+                        voice.sendPhonemeDataToWorklet(targetDuration);
+                    }
+
+                    // 4. Process
+                    // 'process' sends the buffer.
+                    voice.process(buffer.getChannelData(0));
+
+                    // Note: SingingVoice output is connected to masterGain in initializeAudio.
+                    return;
+                }
+
+                // Standard Loop / One-shot
                 const source = context.createBufferSource();
                 source.buffer = buffer;
                 source.playbackRate.value = params.playbackSpeed;
@@ -584,6 +676,7 @@ export const useAudioEngine = (pyodide: any) => {
                 detectSamplePitch,
                 processSinging,
                 processSpoon,
+                prepareVocal,
                 setSustainMode,
                 setSustainGrainSize
             };

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,6 +120,7 @@ export interface AudioEngine {
     detectSamplePitch?: (buffer: AudioBuffer) => Promise<any>;
     processSinging?: (sampleName: string, note: string, steps: number, tempo: number) => Promise<AudioBuffer | null>;
     processSpoon?: (sampleName: string, note: string) => Promise<AudioBuffer | null>;
+    prepareVocal?: (bankIndex: number, text: string) => Promise<void>;
     setSustainMode?: (mode: 'loop' | 'stretch' | 'wavetable') => void;
     setSustainGrainSize?: (size: number) => void;
     playSinging?: (buffer: AudioBuffer, targetNote: string, duration: number, sourceNote?: string) => void;

--- a/update_app.py
+++ b/update_app.py
@@ -1,0 +1,46 @@
+import re
+
+with open('src/App.tsx', 'r') as f:
+    content = f.read()
+
+original_str = "const handleLoadSample = useCallback((name: string, buffer: AudioBuffer) => { if (!audioEngine) return; audioEngine.loadSampleToEngine(name, buffer); setSampleBuffers(prev => { const next = [...prev]; next[activeSamplerBank] = buffer; return next; }); const bankName = `bank_${activeSamplerBank}`; setSampler(prev => { const newParams = [...prev]; newParams[activeSamplerBank] = { ...newParams[activeSamplerBank], sampleName: bankName }; return newParams; }); }, [audioEngine, activeSamplerBank]);"
+
+replacement = """const handleLoadSample = useCallback((name: string, buffer: AudioBuffer) => {
+        if (!audioEngine) return;
+        audioEngine.loadSampleToEngine(name, buffer);
+        setSampleBuffers(prev => { const next = [...prev]; next[activeSamplerBank] = buffer; return next; });
+        const bankName = `bank_${activeSamplerBank}`;
+        setSampler(prev => { const newParams = [...prev]; newParams[activeSamplerBank] = { ...newParams[activeSamplerBank], sampleName: bankName }; return newParams; });
+
+        if (audioEngine.prepareVocal) {
+            const text = ttsPhrases[activeSamplerBank] || "Hello World";
+            audioEngine.prepareVocal(activeSamplerBank, text);
+        }
+    }, [audioEngine, activeSamplerBank, ttsPhrases]);"""
+
+if original_str in content:
+    content = content.replace(original_str, replacement)
+    print("Replaced handleLoadSample")
+else:
+    print("Could not find exact match, attempting loose match")
+    # Use regex to find the function, assuming it starts with const handleLoadSample
+    # and ends with [audioEngine, activeSamplerBank]);
+    pattern = r"const handleLoadSample = useCallback\(\(name: string, buffer: AudioBuffer\) => \{.*?\}, \[audioEngine, activeSamplerBank\]\);"
+    match = re.search(pattern, content, re.DOTALL)
+    if match:
+        print("Found regex match")
+        content = content.replace(match.group(0), replacement)
+    else:
+        print("Regex failed too")
+
+        # Debug: print snippet of content around where we expect it
+        idx = content.find("const handleLoadSample")
+        if idx != -1:
+            print("Snippet found in file:")
+            print(content[idx:idx+500])
+        else:
+            print("Snippet start NOT found")
+        exit(1)
+
+with open('src/App.tsx', 'w') as f:
+    f.write(content)

--- a/update_app_2.py
+++ b/update_app_2.py
@@ -1,0 +1,32 @@
+import re
+
+with open('src/App.tsx', 'r') as f:
+    content = f.read()
+
+# Insert handleTtsPhraseChange
+handler_code = """
+    const handleTtsPhraseChange = useCallback((newPhrases: string[]) => {
+        setTtsPhrases(newPhrases);
+        if (audioEngine?.prepareVocal) {
+             const text = newPhrases[activeSamplerBank];
+             audioEngine.prepareVocal(activeSamplerBank, text);
+        }
+    }, [audioEngine, activeSamplerBank]);
+"""
+
+# Insert before onSynthAParamChange
+if "const onSynthAParamChange =" in content:
+    content = content.replace("const onSynthAParamChange =", handler_code + "\n    const onSynthAParamChange =")
+    print("Inserted handler")
+else:
+    print("Could not find onSynthAParamChange")
+
+# Update prop
+if "onTtsPhraseChange={setTtsPhrases}" in content:
+    content = content.replace("onTtsPhraseChange={setTtsPhrases}", "onTtsPhraseChange={handleTtsPhraseChange}")
+    print("Updated prop")
+else:
+    print("Could not find prop")
+
+with open('src/App.tsx', 'w') as f:
+    f.write(content)

--- a/update_audio_engine.py
+++ b/update_audio_engine.py
@@ -1,0 +1,157 @@
+import re
+
+with open('src/hooks/useAudioEngine.ts', 'r') as f:
+    content = f.read()
+
+# Insert prepareVocal definition before playSampler
+prepare_vocal_code = """
+            const prepareVocal = async (bankIndex: number, text: string) => {
+                if (!singingVoiceRef.current) return;
+                const bankName = `bank_${bankIndex}`;
+                const buffer = loadedSampleBuffersRef.current.get(bankName);
+                if (!buffer) return;
+
+                const audio = buffer.getChannelData(0);
+                try {
+                    const alignment = await singingVoiceRef.current.alignPhonemes(audio, text);
+                    if (alignment) {
+                        vocalAlignmentsRef.current.set(bankName, alignment);
+                        console.log(`Aligned phonemes for ${bankName}: ${alignment.phonemes.length}`);
+                    }
+                } catch (e) {
+                    console.warn('Phoneme alignment failed:', e);
+                }
+            };
+"""
+
+# New playSampler code
+play_sampler_code = """            const playSampler = (params: SamplerBankParams, note: string, time: number, durationSteps: number = 1, stepTime: number = 0.2) => {
+                const buffer = loadedSampleBuffersRef.current.get(params.sampleName);
+                if (!buffer || !masterGainRef.current) return;
+
+                if (params.mode === 'stretch' && singingVoiceRef.current) {
+                    // PHONEME ELASTICITY & SINGING VOICE MODE
+                    const voice = singingVoiceRef.current;
+                    const targetDuration = durationSteps * stepTime;
+                    const originalDuration = buffer.duration;
+
+                    // 1. Calculate Time Ratio
+                    // If target is 2s and original is 1s, ratio should be 2.0 (slower? no, Rubber Band ratio > 1 means longer/slower)
+                    // Wait, RubberBandStretcher setTimeRatio(r): r > 1 means slower?
+                    // Usually timeRatio = output_duration / input_duration.
+                    const timeRatio = targetDuration / originalDuration;
+                    voice.setTimeRatio(timeRatio);
+
+                    // 2. Pitch Shift
+                    // Assuming base note C4 (60) for the sample
+                    const targetMidi = noteToMidi(note);
+                    voice.setPitchFromMidi(targetMidi, 60);
+
+                    // 3. Phoneme Awareness
+                    const alignment = vocalAlignmentsRef.current.get(params.sampleName);
+                    // We need to inject the alignment into the voice engine state BEFORE processing
+                    // But SingingVoice 'process' is stateless for the alignment unless we set it.
+                    // The SingingVoice class has 'lastAlignment'.
+                    // We should probably explicitly set the alignment if we have it.
+                    // But SingingVoice doesn't expose a setter for lastAlignment directly,
+                    // but 'sendPhonemeDataToWorklet' uses 'lastAlignment'.
+                    // HACK: We rely on the fact that if we just called alignPhonemes it's set.
+                    // But here we might be switching banks.
+                    // We need to ensure the engine uses THIS alignment.
+                    // We'll update SingingVoice to allow setting alignment or assume it handles it.
+                    // Actually, let's just send the data if we have it.
+                    // But 'sendPhonemeDataToWorklet' reads from 'this.lastAlignment'.
+                    // We should assume 'prepareVocal' was called and likely set it?
+                    // No, 'prepareVocal' sets OUR ref 'vocalAlignmentsRef'.
+                    // We need to tell SingingVoice to use THIS alignment.
+                    // Let's modify SingingVoice class? No, let's treat it as a black box for now
+                    // and realize that 'sendPhonemeDataToWorklet' takes 'targetDuration' and uses internal state.
+                    // Wait, if I can't set internal state, I can't swap alignments.
+                    // I will look at SingingVoice.ts again.
+                    // It has 'alignPhonemes' which sets 'this.lastAlignment'.
+                    // So I should call 'alignPhonemes' again? No, that's expensive.
+                    // I should modify SingingVoice to accept alignment in 'sendPhonemeDataToWorklet' OR 'setAlignment'.
+                    // For now, I will assume the user has selected the bank and 'prepareVocal' might have just run?
+                    // Or I can add a method to SingingVoice to set current alignment.
+                    // Since I can't modify SingingVoice easily in this script without complex regex,
+                    // I'll stick to basic stretch.
+                    // WAIT! I can modify SingingVoice.ts easily with sed later if needed.
+                    // But I recall SingingVoice.ts:
+                    // private lastAlignment: AlignmentResult | null = null;
+                    // ...
+                    // sendPhonemeDataToWorklet(...) { if (!this.lastAlignment) return; ... }
+
+                    // So I MUST set 'lastAlignment'.
+                    // I will cast to any to force set it, or add a method.
+                    // Let's add a method 'setAlignment' to SingingVoice in the same plan step if possible,
+                    // or just use 'any' for now to keep it simple.
+
+                    if (alignment) {
+                        (voice as any).lastAlignment = alignment; // TypeScript hack for now
+                        voice.sendPhonemeDataToWorklet(targetDuration);
+                    }
+
+                    // 4. Process
+                    // 'process' sends the buffer.
+                    voice.process(buffer.getChannelData(0));
+
+                    // Note: SingingVoice output is connected to masterGain in initializeAudio.
+                    return;
+                }
+
+                // Standard Loop / One-shot
+                const source = context.createBufferSource();
+                source.buffer = buffer;
+                source.playbackRate.value = params.playbackSpeed;
+
+                const gain = context.createGain();
+                gain.gain.value = params.volume;
+
+                const filter = context.createBiquadFilter();
+                filter.type = 'lowpass';
+                filter.frequency.value = params.filterCutoff;
+                filter.Q.value = params.filterResonance;
+
+                // Distortion (Simple waveshaper)
+                const shaper = context.createWaveShaper();
+                if (params.drive > 0) {
+                    shaper.curve = makeDistortionCurve(params.drive * 100);
+                } else {
+                    shaper.curve = null; // Bypass
+                }
+
+                source.connect(filter);
+                filter.connect(shaper);
+                shaper.connect(gain);
+                gain.connect(masterGainRef.current);
+
+                source.start(time);
+                // No auto-stop for one-shots usually, unless gated
+            };"""
+
+# Replace playSampler
+# Regex to find the existing playSampler function
+# It starts with "const playSampler =" and ends before "const noteOnSampler ="
+pattern = r"const playSampler = \(params: SamplerBankParams.*?\n\s+};"
+replacement = prepare_vocal_code + "\n" + play_sampler_code
+
+# We need to be careful with regex matching multiline nested braces.
+# Since the code is indented and structured, we can match until the next const definition.
+# The next function is "const noteOnSampler ="
+content = re.sub(
+    r"const playSampler = [\s\S]*?(?=const noteOnSampler =)",
+    play_sampler_code + "\n\n            ",
+    content
+)
+
+# Insert prepareVocal before playSampler (which is now replaced)
+content = content.replace("const playSampler =", prepare_vocal_code + "\n            const playSampler =")
+
+# Add prepareVocal to returned object
+content = content.replace(
+    "processSpoon,",
+    "processSpoon,\n                prepareVocal,"
+)
+
+with open('src/hooks/useAudioEngine.ts', 'w') as f:
+    f.write(content)

--- a/update_plan.py
+++ b/update_plan.py
@@ -1,0 +1,8 @@
+import re
+with open('agent_plan.md', 'r') as f:
+    content = f.read()
+
+content = re.sub(r"-\s*\[\s*\]\s*\*\*Phoneme Elasticity\*\*", "- [x] **Phoneme Elasticity**", content)
+
+with open('agent_plan.md', 'w') as f:
+    f.write(content)

--- a/update_plan_final.py
+++ b/update_plan_final.py
@@ -1,0 +1,18 @@
+with open('agent_plan.md', 'r') as f:
+    content = f.read()
+
+target = "- [ ] **Phoneme Elasticity:**"
+replacement = "- [x] **Phoneme Elasticity:**"
+
+if target in content:
+    content = content.replace(target, replacement)
+    print("Replaced string literal")
+else:
+    print("String literal not found")
+    print("Content snippet around Phoneme:")
+    idx = content.find("Phoneme Elasticity")
+    if idx != -1:
+        print(repr(content[idx-10:idx+30]))
+
+with open('agent_plan.md', 'w') as f:
+    f.write(content)


### PR DESCRIPTION
Added prepareVocal method to AudioEngine interface to align phonemes for TTS. Updated useAudioEngine to integrate SingingVoice engine into playSampler when mode === 'stretch'. Implemented time-stretching logic using SingingVoice.setTimeRatio based on sequencer step duration. Wired up prepareVocal in App.tsx to align phonemes when samples are loaded or text is updated. Updated agent_plan.md to reflect progress on Phoneme Elasticity.

---
*PR created automatically by Jules for task [8976979725902421008](https://jules.google.com/task/8976979725902421008) started by @ford442*