### PR TITLE
Fix Open303 WASM Import Error

### DIFF
--- a/src/audio-worklets/open303-processor.ts
+++ b/src/audio-worklets/open303-processor.ts
@@ -23,32 +23,44 @@ class Open303Processor extends AudioWorkletProcessor {
 
         if (type === 'init-wasm') {
             try {
-                // compile the WASM module
+                // 1. Compile the WASM module
                 const module = await WebAssembly.compile(data.wasmBytes);
 
-                // Instantiate
-                this.wasmInstance = await WebAssembly.instantiate(module, {
-                    env: {
-                        // Minimal environment for WASM.
-                        // If jc303.wasm was built with Emscripten, it might expect more imports here.
-                        // We provide stubs for common math if needed, though usually they are self-contained or use built-ins.
-                        abort: () => console.error("WASM Abort"),
-                        emscripten_notify_memory_growth: () => this.updateHeap(),
-                        // Basic math needed by some builds
-                        exp: Math.exp,
-                        pow: Math.pow,
-                        sin: Math.sin,
-                        cos: Math.cos,
-                        fmod: (x: number, y: number) => x % y
+                // 2. Prepare Environment Imports
+                // We define the standard Emscripten imports plus stubs for runtime safety.
+                const env = {
+                    abort: () => console.error("WASM Abort"),
+                    emscripten_notify_memory_growth: () => this.updateHeap(),
+                    exp: Math.exp,
+                    pow: Math.pow,
+                    sin: Math.sin,
+                    cos: Math.cos,
+                    fmod: (x: number, y: number) => x % y,
+
+                    // Emscripten Runtime Stubs (Prevent crashes on missing symbols)
+                    _emscripten_resize_heap: (_size: number) => false, // Return false to indicate failure if dynamic growth isn't supported/needed
+                    _emscripten_memcpy_big: (dest: number, src: number, num: number) => {
+                        // Safety check: Instance might not be ready during immediate instantiation
+                        if (!this.wasmInstance) return;
+
+                        const memory = this.wasmInstance.exports.memory as WebAssembly.Memory;
+                        const heap = new Uint8Array(memory.buffer);
+                        heap.set(heap.subarray(src, src + num), dest);
                     }
+                };
+
+                // 3. Instantiate with Alias
+                // Emscripten -O3 builds often minify 'env' to 'a'. We provide both to be safe.
+                this.wasmInstance = await WebAssembly.instantiate(module, {
+                    env: env,
+                    a: env
                 });
 
                 this.updateHeap();
 
-                // Initialize the DSP in the WASM
+                // 4. Initialize the DSP in the WASM
                 const exports = this.wasmInstance.exports as any;
                 if (exports.jc303_init) {
-                    // Initialize with Sample Rate and Buffer Size (128 for Worklets)
                     exports.jc303_init(data.sampleRate || 44100, 128);
                 }
 
@@ -90,7 +102,6 @@ class Open303Processor extends AudioWorkletProcessor {
         const channelL = output[0];
         const channelR = output[1];
 
-        // If not ready, output silence
         if (!this.isWasmReady || !this.wasmInstance || !this.heapFloat32) {
             return true;
         }
@@ -99,20 +110,17 @@ class Open303Processor extends AudioWorkletProcessor {
         const processFunc = exports.jc303_process;
 
         if (processFunc) {
-            // Ask WASM to process 128 samples. It usually returns a pointer to the buffer.
+            // Ask WASM to process 128 samples
             const ptr = processFunc(128);
 
-            // Pointer arithmetic to find the data in the heap
-            // ptr is in bytes, divide by 4 for Float32 index
+            // Pointer is in bytes, divide by 4 for Float32 index
             const offset = ptr >> 2;
 
-            // Copy to AudioWorklet outputs
-            // Safety check to ensure we don't read out of bounds
+            // Safety check
             if (offset + 128 < this.heapFloat32.length) {
                 for (let i = 0; i < 128; i++) {
                     const sample = this.heapFloat32[offset + i];
                     if (channelL) channelL[i] = sample;
-                    // Duplicate to stereo if needed, or if the synth is mono
                     if (channelR) channelR[i] = sample;
                 }
             }


### PR DESCRIPTION
Aliases the 'env' import to 'a' to support Emscripten -O3 builds. Adds stubs for _emscripten_memcpy_big and _emscripten_resize_heap to prevent runtime crashes.

---
*PR created automatically by Jules for task [12012976217467479656](https://jules.google.com/task/12012976217467479656) started by @ford442*