### PR TITLE
🎨 Palette: Make Keyboard Guide accessible

### DIFF
--- a/src/components/LiveKeyboard.tsx
+++ b/src/components/LiveKeyboard.tsx
@@ -56,22 +56,80 @@ const formatKeyLabel = (code: string) => {
 
 // --- KEYBOARD GUIDE COMPONENT ---
 const KeyboardGuide = ({ onClose }: { onClose: () => void }) => {
+    const modalRef = useRef<HTMLDivElement>(null);
+    const buttonRef = useRef<HTMLButtonElement>(null);
+
+    useEffect(() => {
+        // 1. Capture previously focused element to restore later
+        const previousFocus = document.activeElement as HTMLElement;
+
+        // 2. Focus the primary action button on mount
+        buttonRef.current?.focus();
+
+        // 3. Handle Keyboard Interactions (Escape + Focus Trap)
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                e.preventDefault();
+                onClose();
+            } else if (e.key === 'Tab') {
+                // Simple Focus Trap
+                const focusableElements = modalRef.current?.querySelectorAll(
+                    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+                );
+
+                if (!focusableElements || focusableElements.length === 0) return;
+
+                const firstElement = focusableElements[0] as HTMLElement;
+                const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
+
+                if (e.shiftKey) {
+                    if (document.activeElement === firstElement) {
+                        e.preventDefault();
+                        lastElement.focus();
+                    }
+                } else {
+                    if (document.activeElement === lastElement) {
+                        e.preventDefault();
+                        firstElement.focus();
+                    }
+                }
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+
+        // 4. Cleanup: Restore focus
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+            // We use a small timeout to ensure the modal unmount doesn't interfere with focus restoration
+            setTimeout(() => previousFocus?.focus(), 0);
+        };
+    }, [onClose]);
+
     return (
         <div
             className="absolute inset-0 z-30 flex items-center justify-center bg-black/80 backdrop-blur-sm rounded-xl animate-fadeIn"
             onClick={onClose}
         >
-            <div className="relative p-8 border-2 border-dashed border-cyan-500/50 rounded-2xl bg-[#0d1015] shadow-[0_0_50px_rgba(6,182,212,0.15)] max-w-2xl w-full mx-4" onClick={e => e.stopPropagation()}>
+            <div
+                ref={modalRef}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="keyboard-guide-title"
+                className="relative p-8 border-2 border-dashed border-cyan-500/50 rounded-2xl bg-[#0d1015] shadow-[0_0_50px_rgba(6,182,212,0.15)] max-w-2xl w-full mx-4 outline-none"
+                onClick={e => e.stopPropagation()}
+                tabIndex={-1}
+            >
                 <button
                     onClick={onClose}
-                    className="absolute top-4 right-4 text-gray-500 hover:text-white transition-colors"
+                    className="absolute top-4 right-4 text-gray-500 hover:text-white transition-colors focus:outline-none focus:text-white"
                     aria-label="Close Guide"
                 >
                     ✕
                 </button>
 
                 <div className="text-center mb-8">
-                    <h3 className="text-2xl font-orbitron font-bold text-cyan-400 mb-2 tracking-widest">FLIPPED MODE</h3>
+                    <h3 id="keyboard-guide-title" className="text-2xl font-orbitron font-bold text-cyan-400 mb-2 tracking-widest">FLIPPED MODE</h3>
                     <p className="text-gray-400 font-mono text-sm">Rotate your physical keyboard 180° to play chromatically.</p>
                 </div>
 
@@ -116,8 +174,9 @@ const KeyboardGuide = ({ onClose }: { onClose: () => void }) => {
 
                 <div className="text-center">
                     <button
+                        ref={buttonRef}
                         onClick={onClose}
-                        className="px-6 py-2 bg-cyan-900/30 hover:bg-cyan-800/50 text-cyan-300 border border-cyan-700/50 rounded font-orbitron text-xs tracking-wider transition-all"
+                        className="px-6 py-2 bg-cyan-900/30 hover:bg-cyan-800/50 text-cyan-300 border border-cyan-700/50 rounded font-orbitron text-xs tracking-wider transition-all focus:outline-none focus:ring-2 focus:ring-cyan-500"
                     >
                         GOT IT
                     </button>

--- a/src/components/__tests__/LiveKeyboardA11y.test.tsx
+++ b/src/components/__tests__/LiveKeyboardA11y.test.tsx
@@ -1,0 +1,37 @@
+import { render, fireEvent, screen, act } from '@testing-library/react';
+import { LiveKeyboard } from '../LiveKeyboard';
+import { vi } from 'vitest';
+
+describe('LiveKeyboard Accessibility', () => {
+    test('opens KeyboardGuide with correct ARIA attributes and focus management', async () => {
+        const onPlay = vi.fn();
+        const onStop = vi.fn();
+        render(<LiveKeyboard onPlayNote={onPlay} onStopNote={onStop} activeTrackColor="#ffffff" />);
+
+        // 1. Open the guide
+        const openButton = screen.getByTitle('Show Keyboard Layout Guide');
+        fireEvent.click(openButton);
+
+        // 2. Check for Dialog Role
+        const dialog = screen.getByRole('dialog');
+        expect(dialog).toBeInTheDocument();
+        expect(dialog).toHaveAttribute('aria-modal', 'true');
+        expect(dialog).toHaveAttribute('aria-labelledby', 'keyboard-guide-title');
+
+        // 3. Check for Title ID matching aria-labelledby
+        const title = screen.getByText('FLIPPED MODE');
+        expect(title).toHaveAttribute('id', 'keyboard-guide-title');
+
+        // 4. Verify Initial Focus on "GOT IT" button
+        const gotItButton = screen.getByText('GOT IT');
+        // Wait for useEffect to fire
+        await new Promise(r => setTimeout(r, 0));
+        expect(document.activeElement).toBe(gotItButton);
+
+        // 5. Close with Escape
+        fireEvent.keyDown(window, { key: 'Escape' });
+
+        // 6. Verify Dialog is gone
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
Improved the accessibility of the `KeyboardGuide` modal in `LiveKeyboard.tsx`. The modal now correctly traps focus, announces itself as a dialog to screen readers, and supports standard keyboard navigation (Escape to close). A regression test was added to verify these behaviors.

---
*PR created automatically by Jules for task [7142951565357802626](https://jules.google.com/task/7142951565357802626) started by @ford442*