### PR TITLE
feat: Implement TTS Slice Triggering by Phoneme

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -11,11 +11,12 @@
 
 ### Domain A: Audio Engine (Synth & Sampler)
 - [x] **Refactor SingingVoice State:** Expose alignment state setters in `SingingVoice` to avoid type casting hacks and improve multi-bank alignment handling.
+- [x] **TTS Slice Triggering:** Implement a logic where a MIDI Note NoteOn event can trigger a specific *slice* or *word* from the TTS buffer (e.g., Note C3 = "Hello", Note D3 = "World").
 - [ ] **Hybrid Polyphony:** Finalize `VoiceManager` to handle 8-voice polyphony for `synth-1` while keeping `synth-2` strictly monophonic (legato priority).
-- [ ] **TTS Slice Triggering:** Implement a logic where a MIDI Note NoteOn event can trigger a specific *slice* or *word* from the TTS buffer (e.g., Note C3 = "Hello", Note D3 = "World").
 - [x] **Phoneme Elasticity:** Connect `rubberband.wasm` to the sequencer steps. If a note is dragged longer, the specific phoneme should time-stretch to match the duration without altering pitch.
 
 ### Domain B: Editor Workflow (The "Cubase" Feel)
+- [ ] **Slice Mode UI:** Add a toggle in `SamplerPanel` to enable "Phoneme Slice Mode", allowing users to play slices via MIDI keyboard.
 - [ ] **Rubber-Band Selection:** Implement multi-note selection via mouse drag in `Sequencer.tsx`.
 - [ ] **Clipboard Operations:** Standardize `Ctrl+C` / `Ctrl+V` logic to handle both Note Data *and* associated TTS Metadata (which word is attached to the note).
 - [ ] **Per-Step Parameters:** Create a UI to edit "Expression" or "Timbre" for individual sequencer steps (vital for humanizing TTS output).
@@ -39,3 +40,4 @@
 * [Date] - Roadmap re-initialized for long-term recursion.
 * [2026-02-05] - Implemented Phoneme Elasticity in Sampler Engine.
 * [2026-05-21] - Refactored SingingVoice state management to eliminate type casting hacks and improve multi-bank alignment handling.
+* [2026-05-22] - Implemented TTS Slice Triggering (Phoneme Mode) in Audio Engine.

--- a/src/__tests__/SingingVoiceSlice.test.ts
+++ b/src/__tests__/SingingVoiceSlice.test.ts
@@ -1,0 +1,138 @@
+// src/__tests__/SingingVoiceSlice.test.ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SingingVoice } from '../engines/SingingVoice';
+import { AlignmentResult } from '../engines/rubberband/PhonemeAligner';
+
+// Mock AudioContext and related APIs
+class MockAudioWorkletNode {
+    port = {
+        postMessage: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn()
+    };
+
+    parameters = new Map([
+        ['pitchScale', { setValueAtTime: vi.fn() }],
+        ['timeRatio', { setValueAtTime: vi.fn() }],
+        ['vibratoDepth', { setValueAtTime: vi.fn() }],
+        ['vibratoRate', { setValueAtTime: vi.fn() }],
+        ['tremoloDepth', { setValueAtTime: vi.fn() }],
+        ['tremoloRate', { setValueAtTime: vi.fn() }],
+        ['breathIntensity', { setValueAtTime: vi.fn() }]
+    ]);
+
+    connect = vi.fn().mockReturnThis();
+    disconnect = vi.fn();
+}
+
+class MockAudioContext {
+    sampleRate = 44100;
+    currentTime = 0;
+    audioWorklet = {
+        addModule: vi.fn().mockResolvedValue(undefined)
+    };
+
+    createBiquadFilter() {
+        return {
+            type: 'peaking',
+            frequency: { value: 0, setValueAtTime: vi.fn() },
+            Q: { value: 0, setValueAtTime: vi.fn() },
+            gain: { value: 0, setValueAtTime: vi.fn() },
+            connect: vi.fn().mockReturnThis(),
+            disconnect: vi.fn()
+        };
+    }
+}
+
+globalThis.AudioWorkletNode = MockAudioWorkletNode as any;
+
+describe('SingingVoice Slice Triggering', () => {
+    let audioContext: AudioContext;
+    let voice: SingingVoice;
+    let mockWorkletNode: any;
+
+    beforeEach(async () => {
+        audioContext = new MockAudioContext() as any;
+        voice = new SingingVoice(audioContext, { enablePhonemeStretching: true });
+
+        // Manual setup to bypass initWorklet complexity and timeouts
+        mockWorkletNode = new MockAudioWorkletNode();
+
+        // Inject dependencies into private fields
+        Object.defineProperty(voice, 'workletNode', { value: mockWorkletNode, writable: true });
+        Object.defineProperty(voice, 'inputRingBuffer', { value: {}, writable: true });
+
+        vi.clearAllMocks();
+    });
+
+    const mockAlignment: AlignmentResult = {
+        phonemes: [
+            { phoneme: 'HH', start: 0.0, end: 0.1, isVowel: false },
+            { phoneme: 'EH', start: 0.1, end: 0.3, isVowel: true },
+            { phoneme: 'L',  start: 0.3, end: 0.4, isVowel: false },
+            { phoneme: 'OW', start: 0.4, end: 0.6, isVowel: true }
+        ],
+        sampleRate: 44100,
+        duration: 0.6,
+        text: 'hello'
+    };
+
+    it('should trigger correct slice for valid index', async () => {
+        const audio = new Float32Array(44100 * 0.6);
+        const sliceIndex = 1; // 'EH' 0.1 to 0.3
+
+        await voice.triggerSlice(audio, sliceIndex, mockAlignment);
+
+        expect(mockWorkletNode.port.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'noteOn',
+                data: expect.objectContaining({
+                    startSample: 4410,  // 0.1 * 44100
+                    endSample: 13230    // 0.3 * 44100
+                })
+            })
+        );
+    });
+
+    it('should handle out of bounds index gracefully', async () => {
+        const audio = new Float32Array(100);
+        const spy = vi.spyOn(console, 'warn');
+
+        await voice.triggerSlice(audio, 99, mockAlignment);
+
+        expect(spy).toHaveBeenCalled();
+        expect(mockWorkletNode.port.postMessage).not.toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'noteOn' })
+        );
+    });
+
+    it('should reset time stretch when triggering slice', async () => {
+        const audio = new Float32Array(100);
+        await voice.triggerSlice(audio, 0, mockAlignment);
+
+        expect(mockWorkletNode.parameters.get('timeRatio').setValueAtTime).toHaveBeenCalledWith(1.0, 0);
+    });
+
+    it('should set pitch when triggering slice', async () => {
+        const audio = new Float32Array(100);
+        const pitch = 1.5;
+        await voice.triggerSlice(audio, 0, mockAlignment, pitch);
+
+        expect(mockWorkletNode.parameters.get('pitchScale').setValueAtTime).toHaveBeenCalledWith(pitch, 0);
+    });
+
+    it('should pass startSample and endSample via process', async () => {
+        const audio = new Float32Array(100);
+        await voice.process(audio, 50, 80);
+
+        expect(mockWorkletNode.port.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'noteOn',
+                data: expect.objectContaining({
+                    startSample: 50,
+                    endSample: 80
+                })
+            })
+        );
+    });
+});

--- a/src/audio-worklets/rubberband-processor.ts
+++ b/src/audio-worklets/rubberband-processor.ts
@@ -132,9 +132,23 @@ class RubberBandProcessor extends AudioWorkletProcessor {
         this.rubberBand.setPitchScale(data.pitch || 1.0);
         this.rubberBand.setTimeRatio(1.0);
         this.expressiveProcessor.reset();
-        this.ensureHeapSize(this.fullSampleBuffer.length);
-        this.rubberBand.module.HEAPF32.set(this.fullSampleBuffer, this.inputHeapPtr >> 2);
-        this.rubberBand.process(this.inputHeapPtr, this.fullSampleBuffer.length, false);
+
+        // Support for slicing (start/end sample)
+        const startSample = Math.max(0, Math.floor(data.startSample || 0));
+        const endSample = data.endSample
+            ? Math.min(this.fullSampleBuffer.length, Math.floor(data.endSample))
+            : this.fullSampleBuffer.length;
+
+        if (startSample >= endSample) return;
+
+        const sliceLength = endSample - startSample;
+        this.ensureHeapSize(sliceLength);
+
+        // Copy only the requested slice to the WASM heap
+        const slice = this.fullSampleBuffer.subarray(startSample, endSample);
+        this.rubberBand.module.HEAPF32.set(slice, this.inputHeapPtr >> 2);
+
+        this.rubberBand.process(this.inputHeapPtr, sliceLength, false);
         break;
 
       case 'noteOff':

--- a/src/engines/SingingVoice.ts
+++ b/src/engines/SingingVoice.ts
@@ -290,9 +290,11 @@ export class SingingVoice {
     /**
      * Process audio through the Rubber Band worklet.
      * @param audio Float32Array of mono audio samples
+     * @param startSample Optional start sample index for slicing
+     * @param endSample Optional end sample index for slicing
      * @returns Promise that resolves when processing is complete
      */
-    async process(audio: Float32Array): Promise<void> {
+    async process(audio: Float32Array, startSample?: number, endSample?: number): Promise<void> {
         if (!this.workletNode || !this.inputRingBuffer) {
             throw new Error('SingingVoice not initialized. Call initWorklet() first.');
         }
@@ -306,8 +308,36 @@ export class SingingVoice {
         // Trigger processing
         this.workletNode.port.postMessage({
             type: 'noteOn',
-            data: { pitch: 1.0 } // Pitch will be set via parameter
+            data: {
+                pitch: 1.0, // Pitch will be set via parameter
+                startSample,
+                endSample
+            }
         });
+    }
+
+    /**
+     * Trigger a specific phoneme slice based on index.
+     *
+     * @param audio Audio buffer
+     * @param sliceIndex Index of the phoneme to play (e.g. from MIDI note)
+     * @param alignment Alignment result containing phoneme timings
+     * @param pitch Optional pitch override (default 1.0)
+     */
+    async triggerSlice(audio: Float32Array, sliceIndex: number, alignment: AlignmentResult, pitch: number = 1.0): Promise<void> {
+        if (sliceIndex < 0 || sliceIndex >= alignment.phonemes.length) {
+            console.warn(`Slice index ${sliceIndex} out of bounds (max ${alignment.phonemes.length - 1})`);
+            return;
+        }
+
+        const phoneme = alignment.phonemes[sliceIndex];
+        const startSample = Math.floor(phoneme.start * alignment.sampleRate);
+        const endSample = Math.floor(phoneme.end * alignment.sampleRate);
+
+        this.setPitch(pitch);
+        this.setTimeRatio(1.0); // Reset time stretch for slice playback usually
+
+        await this.process(audio, startSample, endSample);
     }
 
     /**

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -419,6 +419,21 @@ export const useAudioEngine = (pyodide: any) => {
                     const targetDuration = durationSteps * stepTime;
                     const originalDuration = buffer.duration;
 
+                    // CHECK FOR SLICE TRIGGER MODE
+                    if (params.sliceMode === 'phoneme') {
+                         const alignment = vocalAlignmentsRef.current.get(params.sampleName);
+                         if (alignment) {
+                             const targetMidi = noteToMidi(note);
+                             // Map MIDI C3 (60) to slice 0
+                             const sliceIndex = targetMidi - 60;
+
+                             if (sliceIndex >= 0) {
+                                 voice.triggerSlice(buffer.getChannelData(0), sliceIndex, alignment);
+                                 return;
+                             }
+                         }
+                    }
+
                     // 1. Calculate Time Ratio
                     // If target is 2s and original is 1s, ratio should be 2.0 (slower? no, Rubber Band ratio > 1 means longer/slower)
                     // Wait, RubberBandStretcher setTimeRatio(r): r > 1 means slower?

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,7 @@ export interface SamplerBankParams {
   delaySend: number; // 0-1 (Amount sent to delay bus)
   mode?: 'loop' | 'stretch' | 'wavetable'; // Sustain processor mode (0=loop, 1=stretch, 2=wavetable)
   grainSize?: number; // Grain size for stretch mode (in samples)
+  sliceMode?: 'off' | 'phoneme'; // Slice triggering mode
 }
 
 // SamplerParams is now an array of banks


### PR DESCRIPTION
Implemented logic to trigger specific phoneme slices from a TTS buffer using MIDI notes.
When `sliceMode` is set to 'phoneme' in `SamplerBankParams`, MIDI note C3 (60) triggers the first phoneme, C#3 (61) the second, etc.
This enables rhythmic re-sequencing of synthesized vocals ("chopped vocals" effect).
Modified the RubberBand AudioWorklet to handle efficient slicing of the pre-loaded buffer.

---
*PR created automatically by Jules for task [9159137453974273225](https://jules.google.com/task/9159137453974273225) started by @ford442*