### PR TITLE
🎨 Palette: Enhance modal accessibility with Focus Trap

### DIFF
--- a/src/components/CloudLibrary.tsx
+++ b/src/components/CloudLibrary.tsx
@@ -1,6 +1,7 @@
 // src/components/CloudLibrary.tsx
 import React, { useEffect, useState } from 'react';
 import { CloudStorage } from '../services/CloudStorage';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import type { CloudSongMeta, CloudItemType } from '../services/CloudStorage';
 
 interface CloudLibraryProps {
@@ -170,11 +171,13 @@ export const CloudLibrary: React.FC<CloudLibraryProps> = ({
 
     const filteredSongs = songs.filter(s => filterType === 'all' || s.type === filterType);
 
+    const modalRef = useFocusTrap(isOpen, onClose);
+
     if (!isOpen) return null;
 
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm p-4">
-            <div className="w-full max-w-2xl bg-[#0f1215] border border-cyan-900/50 rounded-xl shadow-[0_0_50px_rgba(6,182,212,0.2)] overflow-hidden flex flex-col max-h-[80vh]">
+            <div ref={modalRef} className="w-full max-w-2xl bg-[#0f1215] border border-cyan-900/50 rounded-xl shadow-[0_0_50px_rgba(6,182,212,0.2)] overflow-hidden flex flex-col max-h-[80vh]">
 
                 {/* Header Tabs */}
                 <div

--- a/src/components/LiveKeyboard.tsx
+++ b/src/components/LiveKeyboard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, memo, useRef, useMemo, useCallback } from 'react';
 import { getNoteColor } from '../utils/noteColors';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 
 interface LiveKeyboardProps { onPlayNote: (note: string) => void; onStopNote?: (note: string) => void; activeTrackColor: string; }
 
@@ -56,55 +57,8 @@ const formatKeyLabel = (code: string) => {
 
 // --- KEYBOARD GUIDE COMPONENT ---
 const KeyboardGuide = ({ onClose }: { onClose: () => void }) => {
-    const modalRef = useRef<HTMLDivElement>(null);
     const buttonRef = useRef<HTMLButtonElement>(null);
-
-    useEffect(() => {
-        // 1. Capture previously focused element to restore later
-        const previousFocus = document.activeElement as HTMLElement;
-
-        // 2. Focus the primary action button on mount
-        buttonRef.current?.focus();
-
-        // 3. Handle Keyboard Interactions (Escape + Focus Trap)
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') {
-                e.preventDefault();
-                onClose();
-            } else if (e.key === 'Tab') {
-                // Simple Focus Trap
-                const focusableElements = modalRef.current?.querySelectorAll(
-                    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-                );
-
-                if (!focusableElements || focusableElements.length === 0) return;
-
-                const firstElement = focusableElements[0] as HTMLElement;
-                const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
-
-                if (e.shiftKey) {
-                    if (document.activeElement === firstElement) {
-                        e.preventDefault();
-                        lastElement.focus();
-                    }
-                } else {
-                    if (document.activeElement === lastElement) {
-                        e.preventDefault();
-                        firstElement.focus();
-                    }
-                }
-            }
-        };
-
-        window.addEventListener('keydown', handleKeyDown);
-
-        // 4. Cleanup: Restore focus
-        return () => {
-            window.removeEventListener('keydown', handleKeyDown);
-            // We use a small timeout to ensure the modal unmount doesn't interfere with focus restoration
-            setTimeout(() => previousFocus?.focus(), 0);
-        };
-    }, [onClose]);
+    const modalRef = useFocusTrap(true, onClose, buttonRef);
 
     return (
         <div

--- a/src/components/NoteSelector.tsx
+++ b/src/components/NoteSelector.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { NOTES } from '../utils/musicTheory';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 
 interface NoteSelectorProps {
     x: number;
@@ -19,24 +20,7 @@ export const NoteSelector: React.FC<NoteSelectorProps> = ({
     // Determine octave range based on track type
     const octaves = trackType === 'synth' ? [2, 3, 4] : [2];
 
-    const dialogRef = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-        // Focus dialog on mount
-        if (dialogRef.current) {
-            dialogRef.current.focus();
-        }
-
-        // Handle Escape key
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') {
-                onClose();
-            }
-        };
-
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [onClose]);
+    const dialogRef = useFocusTrap(true, onClose);
 
     return (
         <>

--- a/src/components/PatternSelector.tsx
+++ b/src/components/PatternSelector.tsx
@@ -1,6 +1,7 @@
 
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { getNoteColor } from '../utils/noteColors';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 
 interface PatternSelectorProps {
     x: number;
@@ -20,24 +21,7 @@ const getPatternColor = (slotIndex: number): string => {
 export const PatternSelector: React.FC<PatternSelectorProps> = ({
     x, y, currentPattern, onSelect, onClose
 }) => {
-    const dialogRef = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-        // Focus dialog on mount
-        if (dialogRef.current) {
-            dialogRef.current.focus();
-        }
-
-        // Handle Escape key
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') {
-                onClose();
-            }
-        };
-
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [onClose]);
+    const dialogRef = useFocusTrap(true, onClose);
 
     return (
         <>

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -1,6 +1,6 @@
 import { type AlignmentResult } from '../engines/rubberband/PhonemeAligner';
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
-import {
+import type {
     SamplerBankParams, SynthParams, AudioEngine, KickParams, SnareParams, HatParams,
     DrumSound, PartSequence, SamplerParams
 } from '../types';
@@ -8,7 +8,8 @@ import { WebGpuOscillator } from '../engines/WebGpuOscillator';
 import { WasmOscillator } from '../engines/WasmOscillator';
 import { Open303Oscillator } from '../engines/Open303Oscillator';
 import { SingingVoice } from '../engines/SingingVoice';
-import { noteToFrequency, noteToMidi } from '../utils/noteUtils';
+import { noteToMidi } from '../utils/musicTheory';
+import { noteToFrequency } from '../constants';
 
 // URLs for worklets
 const sustainProcessorUrl = new URL('../audio-worklets/sustain-processor.ts', import.meta.url).href;

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,99 @@
+import { useEffect, useRef, type RefObject } from 'react';
+
+/**
+ * Traps focus within a container when active.
+ * Restores focus to the previously focused element on cleanup.
+ *
+ * @param isActive Whether the focus trap is active
+ * @param onClose Optional callback when Escape is pressed
+ * @param initialFocusRef Optional ref to an element to focus on mount. Defaults to the first focusable element.
+ */
+export const useFocusTrap = <T extends HTMLElement = HTMLDivElement>(
+    isActive: boolean,
+    onClose?: () => void,
+    initialFocusRef?: RefObject<HTMLElement | null>
+) => {
+    const containerRef = useRef<T>(null);
+
+    // 1. Capture/Restore Focus & Initial Focus
+    useEffect(() => {
+        if (!isActive) return;
+
+        // Capture previous focus
+        const previousFocus = document.activeElement as HTMLElement;
+
+        // Initial Focus Logic
+        // We use a small timeout to ensure the DOM is fully ready if the component just mounted
+        requestAnimationFrame(() => {
+            const element = containerRef.current;
+            if (element) {
+                if (initialFocusRef?.current) {
+                    initialFocusRef.current.focus();
+                } else {
+                    const focusable = element.querySelectorAll<HTMLElement>(
+                        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+                    );
+                    if (focusable.length > 0) {
+                        focusable[0].focus();
+                    } else {
+                        // If no focusable children, focus the container itself (ensure it has tabindex in markup)
+                        element.focus();
+                    }
+                }
+            }
+        });
+
+        return () => {
+            // Restore focus
+            setTimeout(() => {
+                if (previousFocus && typeof previousFocus.focus === 'function') {
+                    previousFocus.focus();
+                }
+            }, 0);
+        };
+    }, [isActive, initialFocusRef]); // Only run when activation state changes (initialFocusRef usually stable)
+
+    // 2. Key Handler (Trap Logic)
+    useEffect(() => {
+        if (!isActive) return;
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape' && onClose) {
+                e.preventDefault();
+                onClose();
+                return;
+            }
+
+            if (e.key === 'Tab') {
+                const element = containerRef.current;
+                if (!element) return;
+
+                const focusableElements = element.querySelectorAll<HTMLElement>(
+                    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+                );
+
+                if (focusableElements.length === 0) return;
+
+                const firstElement = focusableElements[0];
+                const lastElement = focusableElements[focusableElements.length - 1];
+
+                if (e.shiftKey) {
+                    if (document.activeElement === firstElement) {
+                        e.preventDefault();
+                        lastElement.focus();
+                    }
+                } else {
+                    if (document.activeElement === lastElement) {
+                        e.preventDefault();
+                        firstElement.focus();
+                    }
+                }
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [isActive, onClose]);
+
+    return containerRef;
+};


### PR DESCRIPTION
Implemented a reusable `useFocusTrap` hook that handles Tab cycling, Escape key dismissal, and focus restoration. 
Applied it to `CloudLibrary`, `NoteSelector`, `PatternSelector`, and `LiveKeyboard` Guide.
Also fixed a broken import in `useAudioEngine.ts` that was causing build failures.

---
*PR created automatically by Jules for task [12079309669286918666](https://jules.google.com/task/12079309669286918666) started by @ford442*