### PR TITLE
Add Slice Mode UI to SamplerPanel

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -16,7 +16,7 @@
 - [x] **Phoneme Elasticity:** Connect `rubberband.wasm` to the sequencer steps. If a note is dragged longer, the specific phoneme should time-stretch to match the duration without altering pitch.
 
 ### Domain B: Editor Workflow (The "Cubase" Feel)
-- [ ] **Slice Mode UI:** Add a toggle in `SamplerPanel` to enable "Phoneme Slice Mode", allowing users to play slices via MIDI keyboard.
+- [x] **Slice Mode UI:** Add a toggle in `SamplerPanel` to enable "Phoneme Slice Mode", allowing users to play slices via MIDI keyboard.
 - [ ] **Rubber-Band Selection:** Implement multi-note selection via mouse drag in `Sequencer.tsx`.
 - [ ] **Clipboard Operations:** Standardize `Ctrl+C` / `Ctrl+V` logic to handle both Note Data *and* associated TTS Metadata (which word is attached to the note).
 - [ ] **Per-Step Parameters:** Create a UI to edit "Expression" or "Timbre" for individual sequencer steps (vital for humanizing TTS output).
@@ -33,6 +33,7 @@
 * **Idea:** "Lyric Track" - A global text input that automatically distributes syllables across selected MIDI notes.
 * **Idea:** "Glitch Mode" - A probability knob that randomly retriggers/stutters the start of a TTS sample (granular synthesis).
 * **Idea:** "Choir Stack" - Using Polyphony to detune the TTS voice slightly on 3 channels to create a chorus effect.
+* **Idea:** "Visual Slice Feedback" - Highlight the active phoneme slice in the UI during playback.
 
 ---
 
@@ -41,3 +42,4 @@
 * [2026-02-05] - Implemented Phoneme Elasticity in Sampler Engine.
 * [2026-05-21] - Refactored SingingVoice state management to eliminate type casting hacks and improve multi-bank alignment handling.
 * [2026-05-22] - Implemented TTS Slice Triggering (Phoneme Mode) in Audio Engine.
+* [2026-05-23] - Implemented Slice Mode UI in SamplerPanel, enabling Phoneme Slice Mode triggering via MIDI keys.

--- a/src/__tests__/SamplerPanelSlice.test.tsx
+++ b/src/__tests__/SamplerPanelSlice.test.tsx
@@ -1,0 +1,120 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SamplerPanel } from '../components/SamplerPanel';
+import React from 'react';
+
+// Mock the SupertonicService
+vi.mock('../services/Supertonic', () => ({
+  SupertonicService: {
+    getInstance: () => ({
+      init: vi.fn().mockResolvedValue(undefined),
+      isServiceReady: () => false,
+      generate: vi.fn().mockResolvedValue(new Float32Array(1000))
+    })
+  }
+}));
+
+// Mock AudioContext
+const mockAudioContext = {
+  createBuffer: vi.fn((_channels: number, length: number) => ({
+    getChannelData: () => new Float32Array(length)
+  }))
+} as any;
+
+describe('SamplerPanel Slice Mode', () => {
+  const defaultProps = {
+    params: Array(8).fill({
+      sampleName: 'bank_0',
+      playbackSpeed: 1.0,
+      volume: 1.0,
+      filterCutoff: 20000,
+      filterResonance: 0,
+      drive: 0,
+      delaySend: 0,
+      mode: 'loop', // Default is loop
+      grainSize: 4410,
+      sliceMode: 'off'
+    }),
+    onChange: vi.fn(),
+    onLoadSample: vi.fn(),
+    audioContext: mockAudioContext,
+    activeBankIdx: 0,
+    onBankChange: vi.fn(),
+    ttsPhrases: Array(8).fill("Hello World"),
+    onTtsPhraseChange: vi.fn(),
+    onParamChange: vi.fn() // Important for testing Slice Mode toggle
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does NOT show Slice toggle when mode is LOOP', () => {
+    // @ts-ignore
+    render(<SamplerPanel {...defaultProps} />);
+
+    // Should not find the Slice toggle
+    const sliceButton = screen.queryByLabelText('Toggle Slice Mode');
+    expect(sliceButton).not.toBeInTheDocument();
+  });
+
+  it('does NOT show Slice toggle when mode is WAVETABLE', () => {
+      const wavetableProps = {
+          ...defaultProps,
+          params: [{ ...defaultProps.params[0], mode: 'wavetable' }]
+      };
+      // @ts-ignore
+    render(<SamplerPanel {...wavetableProps} />);
+
+    const sliceButton = screen.queryByLabelText('Toggle Slice Mode');
+    expect(sliceButton).not.toBeInTheDocument();
+  });
+
+  it('SHOWS Slice toggle when mode is STRETCH', () => {
+      const stretchProps = {
+          ...defaultProps,
+          params: [{ ...defaultProps.params[0], mode: 'stretch' }]
+      };
+      // @ts-ignore
+    render(<SamplerPanel {...stretchProps} />);
+
+    const sliceButton = screen.getByLabelText('Toggle Slice Mode');
+    expect(sliceButton).toBeInTheDocument();
+    expect(sliceButton).toHaveTextContent('OFF');
+  });
+
+  it('toggles Slice Mode ON when clicked', () => {
+      const onParamChange = vi.fn();
+      const stretchProps = {
+          ...defaultProps,
+          params: [{ ...defaultProps.params[0], mode: 'stretch', sliceMode: 'off' }],
+          onParamChange
+      };
+      // @ts-ignore
+    render(<SamplerPanel {...stretchProps} />);
+
+    const sliceButton = screen.getByLabelText('Toggle Slice Mode');
+    fireEvent.click(sliceButton);
+
+    expect(onParamChange).toHaveBeenCalledWith(0, 'sliceMode', 'phoneme');
+  });
+
+  it('toggles Slice Mode OFF when clicked again', () => {
+      const onParamChange = vi.fn();
+      const stretchProps = {
+          ...defaultProps,
+          params: [{ ...defaultProps.params[0], mode: 'stretch', sliceMode: 'phoneme' }],
+          onParamChange
+      };
+      // @ts-ignore
+    render(<SamplerPanel {...stretchProps} />);
+
+    const sliceButton = screen.getByLabelText('Toggle Slice Mode');
+    expect(sliceButton).toHaveTextContent('ON (PHONEMES)');
+
+    fireEvent.click(sliceButton);
+
+    expect(onParamChange).toHaveBeenCalledWith(0, 'sliceMode', 'off');
+  });
+});

--- a/src/components/SamplerPanel.tsx
+++ b/src/components/SamplerPanel.tsx
@@ -514,23 +514,46 @@ const SamplerPanelComponent: React.FC<SamplerPanelProps> = ({
                 </div>
                 {/* Grain Size Control - Only visible in stretch mode */}
                 {(currentParams.mode || 'loop') === 'stretch' && (
-                    <div className="flex gap-1 items-center">
-                        <label className="text-[9px] text-gray-500 w-12">Grain:</label>
-                        <input
-                            type="range"
-                            min="441"
-                            max="22050"
-                            step="441"
-                            value={currentParams.grainSize || 4410}
-                            onChange={(e) => handleGrainSizeChange(Number(e.target.value))}
-                            className="flex-1 h-1 bg-gray-700 rounded appearance-none cursor-pointer"
-                            style={{
-                                background: `linear-gradient(to right, #9333ea 0%, #9333ea ${grainSizeToPercent(currentParams.grainSize || 4410)}%, #374151 ${grainSizeToPercent(currentParams.grainSize || 4410)}%, #374151 100%)`
-                            }}
-                            aria-label="Grain Size"
-                            title={`Grain size: ${grainSizeToMs(currentParams.grainSize || 4410)}ms`}
-                        />
-                        <span className="text-[9px] text-gray-500 w-10 text-right">{grainSizeToMs(currentParams.grainSize || 4410)}ms</span>
+                    <div className="flex flex-col gap-1">
+                        <div className="flex gap-1 items-center">
+                            <label className="text-[9px] text-gray-500 w-12">Grain:</label>
+                            <input
+                                type="range"
+                                min="441"
+                                max="22050"
+                                step="441"
+                                value={currentParams.grainSize || 4410}
+                                onChange={(e) => handleGrainSizeChange(Number(e.target.value))}
+                                className="flex-1 h-1 bg-gray-700 rounded appearance-none cursor-pointer"
+                                style={{
+                                    background: `linear-gradient(to right, #9333ea 0%, #9333ea ${grainSizeToPercent(currentParams.grainSize || 4410)}%, #374151 ${grainSizeToPercent(currentParams.grainSize || 4410)}%, #374151 100%)`
+                                }}
+                                aria-label="Grain Size"
+                                title={`Grain size: ${grainSizeToMs(currentParams.grainSize || 4410)}ms`}
+                            />
+                            <span className="text-[9px] text-gray-500 w-10 text-right">{grainSizeToMs(currentParams.grainSize || 4410)}ms</span>
+                        </div>
+                        {/* Slice Mode Toggle */}
+                        <div className="flex gap-1 items-center">
+                            <label className="text-[9px] text-gray-500 w-12">Slice:</label>
+                            <button
+                                onClick={() => {
+                                    const newVal = (currentParams.sliceMode === 'phoneme') ? 'off' : 'phoneme';
+                                    if (onParamChange) onParamChange(activeBankIdx, 'sliceMode', newVal);
+                                    else updateParamRef.current('sliceMode', newVal);
+                                }}
+                                className={`flex-1 h-4 text-[9px] font-bold rounded border transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 ${
+                                    currentParams.sliceMode === 'phoneme'
+                                        ? 'bg-purple-600 border-purple-400 text-white'
+                                        : 'bg-gray-800 border-gray-600 text-gray-400 hover:bg-gray-700'
+                                }`}
+                                aria-label="Toggle Slice Mode"
+                                title="Map MIDI keys to phoneme slices"
+                                aria-pressed={currentParams.sliceMode === 'phoneme'}
+                            >
+                                {currentParams.sliceMode === 'phoneme' ? 'ON (PHONEMES)' : 'OFF'}
+                            </button>
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
- Added a toggle button for `sliceMode` in `SamplerPanel` which is visible only when 'stretch' mode is active.
- The toggle allows switching between 'phoneme' (Slice triggering) and 'off' (normal stretch).
- Added `src/__tests__/SamplerPanelSlice.test.tsx` to verify the toggle visibility and interaction logic.
- Updated `agent_plan.md` to mark the task as complete and added a new Innovation Lab idea.

---
*PR created automatically by Jules for task [14252021954176051382](https://jules.google.com/task/14252021954176051382) started by @ford442*