### PR TITLE
Fix unused React imports in tests

### DIFF
--- a/src/__tests__/SamplerPanelSlice.test.tsx
+++ b/src/__tests__/SamplerPanelSlice.test.tsx
@@ -2,7 +2,6 @@ import '@testing-library/jest-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SamplerPanel } from '../components/SamplerPanel';
-import React from 'react';
 
 // Mock the SupertonicService
 vi.mock('../services/Supertonic', () => ({

--- a/src/components/__tests__/Toast.test.tsx
+++ b/src/components/__tests__/Toast.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, act } from '@testing-library/react';
 import { Toast } from '../Toast';
 import { vi, describe, it, expect } from 'vitest';
-import React from 'react';
 
 describe('Toast', () => {
     it('renders the message', () => {


### PR DESCRIPTION
Removed `import React from 'react';` from `src/__tests__/SamplerPanelSlice.test.tsx` and `src/components/__tests__/Toast.test.tsx` as they are unused in the React 17+ JSX transform environment.
Verified that tests still pass with `npm test`.

---
*PR created automatically by Jules for task [3167757991917015102](https://jules.google.com/task/3167757991917015102) started by @ford442*