### PR TITLE
🎨 Palette: Add loaded sample indicators to Sampler banks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -481,6 +481,7 @@ export const App: React.FC = () => {
     useEffect(() => { activeSamplerBankRef.current = activeSamplerBank; }, [activeSamplerBank]);
 
     const [sampleBuffers, setSampleBuffers] = useState<(AudioBuffer | null)[]>(new Array(8).fill(null));
+    const loadedBanks = useMemo(() => sampleBuffers.map(b => !!b), [sampleBuffers]);
     const [ttsPhrases, setTtsPhrases] = useState<string[]>(Array(8).fill("Hello World"));
 
     const [synthA, setSynthA] = useState<SynthParams>(DEFAULT_SYNTH_PARAMS_A);
@@ -878,7 +879,7 @@ export const App: React.FC = () => {
 
     const synthAChild = useMemo(() => (<div className="absolute top-4 right-6 pointer-events-auto"><WaveformSelector selected={synthA.waveform} onChange={(w) => updateSynthA({ waveform: w })} accentColor="cyan" /></div>), [synthA.waveform, updateSynthA]);
     const synthBChild = useMemo(() => (<div className="absolute top-4 right-6 pointer-events-auto"><WaveformSelector selected={synthB.waveform} onChange={(w) => updateSynthB({ waveform: w })} accentColor="pink" /></div>), [synthB.waveform, updateSynthB]);
-    const samplerChild = useMemo(() => (<div className="absolute top-4 left-[30%] w-[40%] h-auto pointer-events-auto z-10 bg-gray-900/80 rounded-lg border border-purple-500/30 backdrop-blur-sm"><SamplerPanel params={sampler} onChange={(u) => updateSampler(u)} onParamChange={handleSamplerParamChange} onLoadSample={handleLoadSample} audioContext={audioEngine?.context!} audioEngine={audioEngine || undefined} activeBankIdx={activeSamplerBank} onBankChange={setActiveSamplerBank} onOpenEditor={() => setIsVoiceEditorOpen(true)} ttsPhrases={ttsPhrases} onTtsPhraseChange={handleTtsPhraseChange} /></div>), [sampler, updateSampler, handleSamplerParamChange, audioEngine, setIsVoiceEditorOpen, activeSamplerBank, handleLoadSample, ttsPhrases]);
+    const samplerChild = useMemo(() => (<div className="absolute top-4 left-[30%] w-[40%] h-auto pointer-events-auto z-10 bg-gray-900/80 rounded-lg border border-purple-500/30 backdrop-blur-sm"><SamplerPanel params={sampler} onChange={(u) => updateSampler(u)} onParamChange={handleSamplerParamChange} onLoadSample={handleLoadSample} audioContext={audioEngine?.context!} audioEngine={audioEngine || undefined} activeBankIdx={activeSamplerBank} onBankChange={setActiveSamplerBank} onOpenEditor={() => setIsVoiceEditorOpen(true)} ttsPhrases={ttsPhrases} onTtsPhraseChange={handleTtsPhraseChange} loadedBanks={loadedBanks} /></div>), [sampler, updateSampler, handleSamplerParamChange, audioEngine, setIsVoiceEditorOpen, activeSamplerBank, handleLoadSample, ttsPhrases, loadedBanks]);
 
     // --- RENDER PARTS FOR 3D ---
     // Extract parts so they can be passed to either normal view or 3D view

--- a/src/components/SamplerPanel.tsx
+++ b/src/components/SamplerPanel.tsx
@@ -16,6 +16,7 @@ interface SamplerPanelProps {
     onTtsPhraseChange: (phrases: string[]) => void; // Update TTS phrases
     onHarmonize?: (bankIndex: number, chordType: string) => Promise<void>; // New prop
     onParamChange?: (bankIndex: number, key: string, value: any) => void;
+    loadedBanks?: boolean[];         // Visual indicator for loaded samples
 }
 
 // 8 Banks
@@ -28,7 +29,7 @@ const grainSizeToPercent = (size: number) => ((size - 441) / (22050 - 441) * 100
 const SamplerPanelComponent: React.FC<SamplerPanelProps> = ({
     params, onChange, onLoadSample, audioContext, audioEngine, activeBankIdx, onBankChange, onOpenEditor,
     ttsPhrases, onTtsPhraseChange,
-    onHarmonize, onParamChange
+    onHarmonize, onParamChange, loadedBanks
 }) => {
     const fileInputRef = useRef<HTMLInputElement>(null);
     const [isRecording, setIsRecording] = useState(false);
@@ -336,11 +337,11 @@ const SamplerPanelComponent: React.FC<SamplerPanelProps> = ({
                         role="tab"
                         aria-selected={activeBankIdx === i}
                         aria-controls="sampler-bank-panel"
-                        aria-label={`Select Bank ${i + 1}`}
+                        aria-label={`Select Bank ${i + 1}${loadedBanks?.[i] ? ' (Loaded)' : ''}`}
                         tabIndex={activeBankIdx === i ? 0 : -1}
                         onClick={() => onBankChange(i)}
                         onKeyDown={(e) => handleKeyDown(e, i)}
-                        className={`min-w-[24px] py-1 text-[10px] font-bold border rounded transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 ${
+                        className={`relative min-w-[24px] py-1 text-[10px] font-bold border rounded transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 ${
                             flashBankIdx === i ? 'bg-green-600 border-green-400 text-white animate-pulse' :
                             activeBankIdx === i
                                 ? 'bg-purple-600 border-purple-400 text-white shadow-md'
@@ -349,6 +350,9 @@ const SamplerPanelComponent: React.FC<SamplerPanelProps> = ({
                         title={`Select Bank ${i+1}`}
                     >
                         {label}
+                        {loadedBanks?.[i] && (
+                            <div className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 bg-green-500 rounded-full shadow-[0_0_4px_rgba(34,197,94,0.8)] border border-black" />
+                        )}
                     </button>
                 ))}
             </div>
@@ -596,6 +600,10 @@ export const SamplerPanel = memo(SamplerPanelComponent, (prev, next) => {
 
     // 4. Critical props check
     if (prev.audioEngine !== next.audioEngine) return false;
+
+    // 5. Check if loaded banks status changed
+    if (JSON.stringify(prev.loadedBanks) !== JSON.stringify(next.loadedBanks)) return false;
+
     // We assume handler functions are stable or we don't care if they change as long as data is same
 
     return true;

--- a/src/components/__tests__/SamplerPanel.test.tsx
+++ b/src/components/__tests__/SamplerPanel.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { SamplerPanel } from '../SamplerPanel';
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock dependencies
+vi.mock('../../services/Supertonic', () => ({
+    SupertonicService: {
+        getInstance: () => ({
+            init: vi.fn().mockResolvedValue(undefined),
+            isServiceReady: vi.fn().mockReturnValue(true),
+            generate: vi.fn()
+        })
+    }
+}));
+
+const mockAudioContext = {
+    createBuffer: vi.fn(),
+    decodeAudioData: vi.fn(),
+} as unknown as AudioContext;
+
+const defaultBankParams = {
+    sampleName: 'bank_0',
+    playbackSpeed: 1.0,
+    volume: 1.0,
+    filterCutoff: 20000,
+    filterResonance: 0,
+    drive: 0,
+    delaySend: 0,
+    mode: 'loop' as const,
+    grainSize: 4410,
+    timeRatio: 1.0,
+    pitchScale: 1.0,
+    formantShift: 0,
+    vibratoDepth: 0,
+    breathIntensity: 0
+};
+
+describe('SamplerPanel', () => {
+    const defaultProps = {
+        params: Array(8).fill(defaultBankParams),
+        onChange: vi.fn(),
+        onLoadSample: vi.fn(),
+        audioContext: mockAudioContext,
+        audioEngine: undefined,
+        activeBankIdx: 0,
+        onBankChange: vi.fn(),
+        ttsPhrases: Array(8).fill(""),
+        onTtsPhraseChange: vi.fn(),
+    };
+
+    it('renders bank tabs correctly', () => {
+        render(<SamplerPanel {...defaultProps} />);
+        expect(screen.getByRole('tab', { name: 'Select Bank 1' })).toBeDefined();
+    });
+
+    it('shows loaded status when bank is loaded', () => {
+        const loadedBanks = [true, false, false, false, false, false, false, false];
+        render(<SamplerPanel {...defaultProps} loadedBanks={loadedBanks} />);
+
+        // Check for (Loaded) in aria-label
+        const bank1 = screen.getByRole('tab', { name: 'Select Bank 1 (Loaded)' });
+        expect(bank1).toBeDefined();
+
+        const bank2 = screen.getByRole('tab', { name: 'Select Bank 2' });
+        expect(bank2).toBeDefined();
+    });
+});


### PR DESCRIPTION
Added visual and accessible indicators to the SamplerPanel tabs to show which banks have loaded samples. This addresses a UX gap where users couldn't tell which banks were populated without clicking them.

Changes:
- `src/components/SamplerPanel.tsx`: Added `loadedBanks` prop, rendering logic for the green dot indicator, and updated accessibility labels.
- `src/App.tsx`: Derived `loadedBanks` state from `sampleBuffers` and passed it to the component.
- `src/components/__tests__/SamplerPanel.test.tsx`: Added unit tests to verify the new functionality.

Verified with unit tests. E2E verification was attempted but skipped due to environment constraints.

---
*PR created automatically by Jules for task [7236204373837739957](https://jules.google.com/task/7236204373837739957) started by @ford442*