### PR TITLE
🎨 Palette: Add keyboard controls for Song Mode

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -49,3 +49,7 @@
 ## 2025-05-26 - Replacing Alerts with Toasts
 **Learning:** Native `alert()` calls are blocking and disruptive, breaking the user's flow and immersion, especially in a specialized creative app like a DAW. They also fail to respect the application's visual theme.
 **Action:** Replace all `alert()` usage with a non-blocking `Toast` notification system. Use context or prop drilling (for simple hierarchies) to expose a `showToast` function, and ensure the toast component is accessible (`role="alert"`) and auto-dismissing.
+
+## 2025-05-26 - Keyboard Value Control in Sequencer Grids
+**Learning:** Grid-based sequencer inputs often rely on mouse drag for value selection, leaving keyboard users with only binary (toggle) control via Enter/Space. This excludes them from precise musical expression (e.g., selecting specific patterns).
+**Action:** Implement `ArrowUp`/`ArrowDown` handlers on grid cells to increment/decrement values, and `Delete`/`Backspace` to clear them, ensuring functional parity with mouse interactions.

--- a/src/components/SongMode.tsx
+++ b/src/components/SongMode.tsx
@@ -228,7 +228,7 @@ export const SongMode = memo(({
 
     }, [handleGlobalMouseMove, handleGlobalMouseUp, onUpdateStep]);
 
-    // Keyboard Handler: Allows simple toggling via Enter/Space
+    // Keyboard Handler: Allows simple toggling via Enter/Space and value adjustment via Arrows
     const handleCellKeyDown = useCallback((e: React.KeyboardEvent, sIdx: number, track: TrackKey, currentVal: number | null) => {
         if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
@@ -238,6 +238,20 @@ export const SongMode = memo(({
             } else {
                 onUpdateStep(sIdx, track, 0);
             }
+        } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            e.stopPropagation();
+            const nextVal = currentVal === null ? 0 : Math.min(7, currentVal + 1);
+            onUpdateStep(sIdx, track, nextVal);
+        } else if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            e.stopPropagation();
+            const nextVal = currentVal === null ? 0 : Math.max(0, currentVal - 1);
+            onUpdateStep(sIdx, track, nextVal);
+        } else if (e.key === 'Delete' || e.key === 'Backspace') {
+            e.preventDefault();
+            e.stopPropagation();
+            onUpdateStep(sIdx, track, null);
         }
     }, [onUpdateStep]);
 

--- a/src/components/__tests__/SongModeA11y.test.tsx
+++ b/src/components/__tests__/SongModeA11y.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { SongMode } from '../SongMode';
+
+describe('SongMode Accessibility', () => {
+    const mockOnUpdateStep = vi.fn();
+    const defaultStructure = [
+        { partA: 0, partB: null, kick: null, snare: null, closedHat: null, openHat: null, sampler: null },
+        { partA: null, partB: null, kick: null, snare: null, closedHat: null, openHat: null, sampler: null }
+    ];
+
+    const defaultProps = {
+        isVisible: true,
+        songStructure: defaultStructure,
+        currentSongStep: 0,
+        backgroundImage: '',
+        onSetBackgroundImage: vi.fn(),
+        onUpdateStep: mockOnUpdateStep,
+        onToggle: vi.fn(),
+        onAddMeasure: vi.fn(),
+        onRemoveMeasure: vi.fn(),
+        onExportXM: vi.fn(),
+        isSongModeActive: false,
+        onSetIsSongModeActive: vi.fn(),
+        is3D: false
+    };
+
+    beforeEach(() => {
+        mockOnUpdateStep.mockClear();
+    });
+
+    it('handles Enter key to toggle cell value (existing behavior)', () => {
+        render(<SongMode {...defaultProps} />);
+
+        // Target a cell with value 0 (partA, step 0)
+        const activeCell = screen.getByTestId('cell-partA-0');
+        fireEvent.keyDown(activeCell, { key: 'Enter' });
+
+        // Should toggle to null
+        expect(mockOnUpdateStep).toHaveBeenCalledWith(0, 'partA', null);
+
+        // Target an empty cell (partB, step 0)
+        const emptyCell = screen.getByTestId('cell-partB-0');
+        fireEvent.keyDown(emptyCell, { key: 'Enter' });
+
+        // Should toggle to 0
+        expect(mockOnUpdateStep).toHaveBeenCalledWith(0, 'partB', 0);
+    });
+
+    it('handles ArrowUp to increment pattern number', () => {
+        render(<SongMode {...defaultProps} />);
+
+        // Target cell with value 0
+        const activeCell = screen.getByTestId('cell-partA-0');
+        fireEvent.keyDown(activeCell, { key: 'ArrowUp' });
+
+        // Should increment to 1
+        expect(mockOnUpdateStep).toHaveBeenCalledWith(0, 'partA', 1);
+    });
+
+    it('handles ArrowDown to decrement pattern number', () => {
+        // Render with a structure having value 1
+        const structureWithValue = [
+            { ...defaultStructure[0], partA: 1 },
+            defaultStructure[1]
+        ];
+        render(<SongMode {...defaultProps} songStructure={structureWithValue} />);
+
+        const activeCell = screen.getByTestId('cell-partA-0');
+        fireEvent.keyDown(activeCell, { key: 'ArrowDown' });
+
+        // Should decrement to 0
+        expect(mockOnUpdateStep).toHaveBeenCalledWith(0, 'partA', 0);
+    });
+
+    it('handles Delete key to clear cell', () => {
+        render(<SongMode {...defaultProps} />);
+
+        const activeCell = screen.getByTestId('cell-partA-0');
+        fireEvent.keyDown(activeCell, { key: 'Delete' });
+
+        expect(mockOnUpdateStep).toHaveBeenCalledWith(0, 'partA', null);
+    });
+
+    it('handles Backspace key to clear cell', () => {
+        render(<SongMode {...defaultProps} />);
+
+        const activeCell = screen.getByTestId('cell-partA-0');
+        fireEvent.keyDown(activeCell, { key: 'Backspace' });
+
+        expect(mockOnUpdateStep).toHaveBeenCalledWith(0, 'partA', null);
+    });
+
+    it('clamps max value at 7 on ArrowUp', () => {
+        // Test max clamp (7 -> 7)
+        const structureMax = [
+            { ...defaultStructure[0], partA: 7 },
+            defaultStructure[1]
+        ];
+        render(<SongMode {...defaultProps} songStructure={structureMax} />);
+
+        const maxCell = screen.getByTestId('cell-partA-0');
+        fireEvent.keyDown(maxCell, { key: 'ArrowUp' });
+
+        // Should stay at 7
+        expect(mockOnUpdateStep).toHaveBeenCalledWith(0, 'partA', 7);
+    });
+
+    it('clamps min value at 0 on ArrowDown', () => {
+        // Test min clamp (0 -> 0)
+        const structureMin = [
+            { ...defaultStructure[0], partA: 0 },
+            defaultStructure[1]
+        ];
+        render(<SongMode {...defaultProps} songStructure={structureMin} />);
+
+        const minCell = screen.getByTestId('cell-partA-0');
+        fireEvent.keyDown(minCell, { key: 'ArrowDown' });
+
+        // Should stay at 0
+        expect(mockOnUpdateStep).toHaveBeenCalledWith(0, 'partA', 0);
+    });
+
+    it('initializes empty cell to 0 on ArrowUp/Down', () => {
+        render(<SongMode {...defaultProps} />);
+
+        const emptyCell = screen.getByTestId('cell-partB-0'); // Value is null
+
+        fireEvent.keyDown(emptyCell, { key: 'ArrowUp' });
+        expect(mockOnUpdateStep).toHaveBeenCalledWith(0, 'partB', 0);
+
+        mockOnUpdateStep.mockClear();
+        fireEvent.keyDown(emptyCell, { key: 'ArrowDown' });
+        expect(mockOnUpdateStep).toHaveBeenCalledWith(0, 'partB', 0);
+    });
+});


### PR DESCRIPTION
This PR enhances the accessibility of the `SongMode` component by allowing keyboard users to select specific patterns using arrow keys, bringing feature parity with the mouse-drag interaction. Previously, keyboard users could only toggle cells on/off.

**Changes:**
- Modified `handleCellKeyDown` in `SongMode.tsx` to handle `ArrowUp`, `ArrowDown`, `Delete`, and `Backspace`.
- Added a new test file `src/components/__tests__/SongModeA11y.test.tsx` to verify the new interactions.

**Verification:**
- New unit tests passed.
- Existing functionality (toggle) verified via tests.
- Linting checks passed.

---
*PR created automatically by Jules for task [17289742012244954734](https://jules.google.com/task/17289742012244954734) started by @ford442*