### PR TITLE
Fix TypeScript errors in Open303Oscillator and types.ts

### DIFF
--- a/src/engines/Open303Oscillator.ts
+++ b/src/engines/Open303Oscillator.ts
@@ -1,7 +1,7 @@
-import { Open303Params, DEFAULT_303_PARAMS } from './Open303Params';
+import type { Open303Params } from './Open303Params';
+import { DEFAULT_303_PARAMS } from './Open303Params';
 
 export class Open303Oscillator {
-    private audioContext: AudioContext | null = null;
     private workletNode: AudioWorkletNode | null = null;
     private gainNode: GainNode | null = null;
     private outputNode: GainNode | null = null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { AlignmentResult } from './engines/rubberband/PhonemeAligner';
 import type { SingingVoice } from './engines/SingingVoice';
 import type { WebGpuOscillator } from './engines/WebGpuOscillator';
 import type { WasmOscillator } from './engines/WasmOscillator';


### PR DESCRIPTION
This PR fixes three TypeScript errors that were causing the build to fail:
1.  TS1484: `Open303Params` is now imported using `import type` to satisfy `verbatimModuleSyntax`.
2.  TS6133: The unused `audioContext` property in `Open303Oscillator` has been removed.
3.  TS2304: `AlignmentResult` is now imported in `src/types.ts` from `src/engines/rubberband/PhonemeAligner.ts`.

---
*PR created automatically by Jules for task [12786409632630015131](https://jules.google.com/task/12786409632630015131) started by @ford442*