### PR TITLE
fix(Open303Oscillator): add missing audioContext property

### DIFF
--- a/src/engines/Open303Oscillator.ts
+++ b/src/engines/Open303Oscillator.ts
@@ -5,6 +5,7 @@ export class Open303Oscillator {
     private workletNode: AudioWorkletNode | null = null;
     private gainNode: GainNode | null = null;
     private outputNode: GainNode | null = null;
+    private audioContext: AudioContext | null = null;
 
     private params: Open303Params = { ...DEFAULT_303_PARAMS };
     public isReady: boolean = false;


### PR DESCRIPTION
Added the missing `audioContext` property to the `Open303Oscillator` class to resolve TS2339 error.

The `audioContext` was being assigned in the `init` method but was not declared in the class definition. This change adds a private property `audioContext: AudioContext | null = null;`.

Test Plan:
- Verified `npm test src/__tests__/Open303Config.test.ts` passes.
- Verified manual inspection of `src/engines/Open303Oscillator.ts`.

---
*PR created automatically by Jules for task [70023858986369903](https://jules.google.com/task/70023858986369903) started by @ford442*