### PR TITLE
🎨 Palette: Improve WaveformDisplay accessibility and contrast

### DIFF
--- a/src/components/WaveformDisplay.tsx
+++ b/src/components/WaveformDisplay.tsx
@@ -50,7 +50,7 @@ export const WaveformDisplay: React.FC<WaveformDisplayProps> = ({ buffer, alignm
             ctx.fillRect(0, 0, width, height);
 
             if (!buffer) {
-                ctx.fillStyle = '#374151';
+                ctx.fillStyle = '#9ca3af';
                 ctx.font = '10px monospace';
                 ctx.textAlign = 'center';
                 ctx.fillText("NO SAMPLE", width / 2, height / 2);
@@ -64,7 +64,7 @@ export const WaveformDisplay: React.FC<WaveformDisplayProps> = ({ buffer, alignm
             const amp = height / 2;
 
             ctx.beginPath();
-            ctx.strokeStyle = '#4b5563'; // gray-600
+            ctx.strokeStyle = '#6b7280'; // gray-500
             ctx.lineWidth = 1;
 
             for (let i = 0; i < width; i++) {
@@ -147,8 +147,18 @@ export const WaveformDisplay: React.FC<WaveformDisplayProps> = ({ buffer, alignm
 
     }, [buffer, alignment, sliceHighlightRef]);
 
+    const label = !buffer
+        ? "Waveform visualization: No sample loaded"
+        : `Waveform visualization: Sample loaded${alignment ? " with phoneme alignment" : ""}`;
+
     return (
-        <div ref={containerRef} className="w-full h-12 bg-gray-900 rounded border border-gray-700 overflow-hidden mb-1 relative">
+        <div
+            ref={containerRef}
+            className="w-full h-12 bg-gray-900 rounded border border-gray-700 overflow-hidden mb-1 relative"
+            role="img"
+            aria-label={label}
+            title={label}
+        >
             <canvas ref={canvasRef} className="w-full h-full block" />
         </div>
     );

--- a/src/components/__tests__/WaveformDisplay.test.tsx
+++ b/src/components/__tests__/WaveformDisplay.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { WaveformDisplay } from '../WaveformDisplay';
+import type { AlignmentResult } from '../../engines/rubberband/PhonemeAligner';
+
+describe('WaveformDisplay', () => {
+    it('renders with correct accessibility label when no buffer is loaded', () => {
+        const sliceHighlightRef = { current: null };
+        render(<WaveformDisplay buffer={null} alignment={null} sliceHighlightRef={sliceHighlightRef} />);
+
+        const display = screen.getByRole('img');
+        expect(display).toHaveAttribute('aria-label', 'Waveform visualization: No sample loaded');
+        expect(display).toHaveAttribute('title', 'Waveform visualization: No sample loaded');
+    });
+
+    it('renders with correct accessibility label when buffer is loaded', () => {
+        const sliceHighlightRef = { current: null };
+        const mockBuffer = {
+            duration: 1,
+            length: 100,
+            sampleRate: 44100,
+            numberOfChannels: 1,
+            getChannelData: () => new Float32Array(100)
+        } as unknown as AudioBuffer;
+
+        render(<WaveformDisplay buffer={mockBuffer} alignment={null} sliceHighlightRef={sliceHighlightRef} />);
+
+        const display = screen.getByRole('img');
+        expect(display).toHaveAttribute('aria-label', 'Waveform visualization: Sample loaded');
+        expect(display).toHaveAttribute('title', 'Waveform visualization: Sample loaded');
+    });
+
+    it('renders with correct accessibility label when buffer and alignment are loaded', () => {
+        const sliceHighlightRef = { current: null };
+        const mockBuffer = {
+            duration: 1,
+            length: 100,
+            sampleRate: 44100,
+            numberOfChannels: 1,
+            getChannelData: () => new Float32Array(100)
+        } as unknown as AudioBuffer;
+
+        const mockAlignment: AlignmentResult = {
+            phonemes: [{ phoneme: 'AH', start: 0, end: 1, score: 0.9 }]
+        };
+
+        render(<WaveformDisplay buffer={mockBuffer} alignment={mockAlignment} sliceHighlightRef={sliceHighlightRef} />);
+
+        const display = screen.getByRole('img');
+        expect(display).toHaveAttribute('aria-label', 'Waveform visualization: Sample loaded with phoneme alignment');
+        expect(display).toHaveAttribute('title', 'Waveform visualization: Sample loaded with phoneme alignment');
+    });
+});


### PR DESCRIPTION
Palette: UX Improvement

💡 What:
Improved the accessibility and visual clarity of the `WaveformDisplay` component.

🎯 Why:
The previous implementation was a raw canvas with no accessibility attributes, making it invisible to screen readers. Additionally, the "NO SAMPLE" text and waveform lines had low contrast against the dark background, making them hard to see.

📸 Changes:
- `WaveformDisplay` now has `role="img"` and descriptive `aria-label` (e.g., "Waveform visualization: Sample loaded").
- Increased brightness of "NO SAMPLE" text (`gray-700` -> `gray-400`).
- Increased brightness of waveform lines (`gray-600` -> `gray-500`).

♿ Accessibility:
- Screen readers can now announce the state of the waveform (loaded/empty/aligned).
- Improved color contrast meets better visibility standards.

Tests:
- Added `src/components/__tests__/WaveformDisplay.test.tsx` to verify accessibility attributes.
- Confirmed existing tests pass (ignoring pre-existing unrelated failures).


---
*PR created automatically by Jules for task [8896961734977132492](https://jules.google.com/task/8896961734977132492) started by @ford442*