### PR TITLE
Implement Clipboard and Drag-to-Edit for Sequencer

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -19,12 +19,13 @@
 - [x] **Slice Mode UI:** Add a toggle in `SamplerPanel` to enable "Phoneme Slice Mode", allowing users to play slices via MIDI keyboard.
 - [x] **Visual Slice Feedback:** Highlight the active phoneme slice in the UI during playback, visualizing real-time TTS articulation.
 - [x] **Rubber-Band Selection:** Implement multi-note selection via mouse drag in `Sequencer.tsx` (and `App.tsx` main view).
-- [ ] **Clipboard Operations:** Standardize `Ctrl+C` / `Ctrl+V` logic to handle both Note Data *and* associated TTS Metadata (which word is attached to the note).
+- [x] **Clipboard Operations:** Standardize `Ctrl+C` / `Ctrl+V` logic to handle both Note Data *and* associated TTS Metadata (which word is attached to the note).
 - [ ] **Per-Step Parameters:** Create a UI to edit "Expression" or "Timbre" for individual sequencer steps (vital for humanizing TTS output).
 - [ ] **Unify Sequencer Components:** Refactor `App.tsx` to use the standalone `Sequencer` component or move `App.tsx` logic into a reusable view to reduce duplication.
+- [ ] **Cleanup Legacy Code:** Identify and remove unused components like `src/components/Sequencer.tsx` to streamline maintenance.
 
 ### Domain C: Accessibility & Mobile
-- [ ] **Touch Targets:** Audit `Sequencer.tsx` click listeners to ensure mobile drag-to-create works smoothly.
+- [x] **Touch Targets:** Audit `Sequencer.tsx` click listeners to ensure mobile drag-to-create works smoothly.
 - [ ] **A11y Colors:** Verify high-contrast separation between `synth-1` (Chords) and `synth-2` (Lead) notes.
 
 ---
@@ -35,6 +36,7 @@
 * **Idea:** "Lyric Track" - A global text input that automatically distributes syllables across selected MIDI notes.
 * **Idea:** "Glitch Mode" - A probability knob that randomly retriggers/stutters the start of a TTS sample (granular synthesis).
 * **Idea:** "Choir Stack" - Using Polyphony to detune the TTS voice slightly on 3 channels to create a chorus effect.
+* **Idea:** "Gesture Controls" - Implement pinch-to-zoom for the sequencer timeline to handle longer patterns or finer steps.
 
 ---
 
@@ -47,3 +49,4 @@
 * [2026-05-24] - Implemented Rubber-Band Selection (Shift+Drag) in the main sequencer view (`App.tsx`), enabling multi-step selection and bulk deletion.
 * [2026-05-25] - Implemented Hybrid Polyphony using `VoiceManager`, enabling 8-voice polyphony for Synth A and legato monophony for Synth B.
 * [2026-05-26] - Implemented Visual Slice Feedback in SamplerPanel using canvas-based WaveformDisplay and imperative playback highlighting.
+* [2026-05-27] - Implemented Clipboard Operations (Ctrl+C/V) and Drag-to-Edit (Painting) in the main sequencer view (`App.tsx`).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { exportSongToXM } from './utils/xmExport';
 import { getNoteColor } from './utils/noteColors';
 import { noteToMidi, midiToNote } from './utils/musicTheory';
 import { audioBufferToWav, blobToBase64 } from './utils/audioExport';
+import { copySteps, pasteSteps } from './utils/clipboardUtils';
 
 const Studio3D = lazy(() => import('./components/Studio3D').then(module => ({ default: module.Studio3D })));
 
@@ -38,7 +39,7 @@ import {
     DEFAULT_CLOSED_HAT_PARAMS,
     DEFAULT_OPEN_HAT_PARAMS,
 } from './constants'
-import type { Pattern, SynthParams, KickParams, SnareParams, SamplerParams, SamplerBankParams, PartSequence, SavedSongData } from './types'
+import type { Pattern, SynthParams, KickParams, SnareParams, SamplerParams, SamplerBankParams, PartSequence, SavedSongData, Note } from './types'
 
 // --- CONSTANTS ---
 const DEFAULT_SAMPLER_BANK_PARAMS: SamplerBankParams = {
@@ -188,7 +189,7 @@ const getSamplerControls = (params: SamplerBankParams): KnobConfig[] => [
 
 const SvgStep = memo(({
     stepIndex, active, note, refsArray, rowLabel, rowKey, onToggle, onRightMouseDown, onEditLength, length = 1, isSlide,
-    onSelectionStart, onSelectionEnter, isRangeSelected
+    onSelectionStart, onSelectionEnter, isRangeSelected, onDrawEnter, isDrawing
 }: {
     stepIndex: number, active: boolean, note?: string | null, refsArray: React.MutableRefObject<(SVGGElement | null)[]>,
     rowLabel: string, rowKey: TrackKey, onToggle: (k: TrackKey, i: number, e: any) => void,
@@ -196,7 +197,9 @@ const SvgStep = memo(({
     onEditLength: (k: TrackKey, i: number, len: number) => void, length?: number, isSlide?: boolean,
     onSelectionStart?: (k: TrackKey, i: number) => void,
     onSelectionEnter?: (k: TrackKey, i: number) => void,
-    isRangeSelected?: boolean
+    isRangeSelected?: boolean,
+    onDrawEnter?: (k: TrackKey, i: number) => void,
+    isDrawing?: boolean
 }) => {
     const baseWidth = 18;
     const gap = 4;
@@ -241,6 +244,7 @@ const SvgStep = memo(({
     };
 
     const handlePointerEnter = () => {
+        if (isDrawing && onDrawEnter) onDrawEnter(rowKey, stepIndex);
         if (onSelectionEnter) onSelectionEnter(rowKey, stepIndex);
     };
 
@@ -281,9 +285,11 @@ const SequencerRow = memo(forwardRef<SequencerRowHandle, {
     onSelectRow: (k: any) => void, onSelectSlot: (k: TrackKey, slot: number) => void,
     onSelectionStart?: (k: TrackKey, i: number) => void,
     onSelectionEnter?: (k: TrackKey, i: number) => void,
-    selectionRange?: { start: number, end: number } | null
+    selectionRange?: { start: number, end: number } | null,
+    onDrawEnter?: (k: TrackKey, i: number) => void,
+    isDrawing?: boolean
 }>((props, ref) => {
-    const { rowKey, label, rowIndex, steps, isSelected, activeSlot, trackSlots, onToggle, onRightMouseDown, onEditLength, onSelectRow, onSelectSlot, onSelectionStart, onSelectionEnter, selectionRange } = props;
+    const { rowKey, label, rowIndex, steps, isSelected, activeSlot, trackSlots, onToggle, onRightMouseDown, onEditLength, onSelectRow, onSelectSlot, onSelectionStart, onSelectionEnter, selectionRange, onDrawEnter, isDrawing } = props;
     const stepRefs = useRef<(SVGGElement | null)[]>([]);
     const lastStepRef = useRef(-1);
     const lastActiveIndexRef = useRef(-1);
@@ -339,7 +345,7 @@ const SequencerRow = memo(forwardRef<SequencerRowHandle, {
             if (i >= low && i <= high) isRangeSelected = true;
         }
 
-        renderedSteps.push(<SvgStep key={i} stepIndex={i} active={!!stepData} note={stepData ? stepData.note : null} length={length} isSlide={!!stepData?.slide} refsArray={stepRefs} rowLabel={label} rowKey={rowKey} onToggle={onToggle} onRightMouseDown={onRightMouseDown} onEditLength={onEditLength} onSelectionStart={onSelectionStart} onSelectionEnter={onSelectionEnter} isRangeSelected={isRangeSelected} />);
+        renderedSteps.push(<SvgStep key={i} stepIndex={i} active={!!stepData} note={stepData ? stepData.note : null} length={length} isSlide={!!stepData?.slide} refsArray={stepRefs} rowLabel={label} rowKey={rowKey} onToggle={onToggle} onRightMouseDown={onRightMouseDown} onEditLength={onEditLength} onSelectionStart={onSelectionStart} onSelectionEnter={onSelectionEnter} isRangeSelected={isRangeSelected} onDrawEnter={onDrawEnter} isDrawing={isDrawing} />);
         if (stepData && length > 1) { skipCount = length - 1; }
     }
 
@@ -457,6 +463,10 @@ export const App: React.FC = () => {
     // --- SELECTION STATE ---
     const [selection, setSelection] = useState<{ trackKey: TrackKey; startStep: number; endStep: number; } | null>(null);
     const [isSelecting, setIsSelecting] = useState(false);
+    const [clipboard, setClipboard] = useState<(Note | null)[] | null>(null);
+    // Drag-to-Edit State
+    const [isDrawing, setIsDrawing] = useState(false);
+    const [drawMode, setDrawMode] = useState<'add' | 'remove' | null>(null);
 
     const handleSelectionStart = useCallback((trackKey: TrackKey, stepIndex: number) => {
         setSelection({ trackKey, startStep: stepIndex, endStep: stepIndex });
@@ -668,6 +678,43 @@ export const App: React.FC = () => {
     const handleGlobalPanReset = () => { setGlobalPan(0); audioEngine?.setGlobalPan(0); };
     const updateStorageForTrack = useCallback((track: TrackKey, sequence: PartSequence | PartSequence[]) => { setTrackStorage(prev => { const copy = { ...prev }; copy[track] = [...copy[track]]; copy[track][activeTrackSlotsRef.current[track]] = sequence; return copy; }); }, []);
 
+    const handleCopy = useCallback(() => {
+        if (!selection) return;
+        const copied = copySteps(patternRef.current, selection, activeSamplerBankRef.current);
+        if (copied) {
+            setClipboard(copied);
+            showToast("Copied to clipboard!", "success");
+        }
+    }, [selection, showToast]);
+
+    const handlePaste = useCallback(() => {
+        if (!clipboard) return;
+        let targetTrack = selectedTrack;
+        let targetStep = 0;
+
+        // If selection is active, use it as target
+        if (selection) {
+            targetTrack = selection.trackKey;
+            targetStep = selection.startStep;
+        } else {
+            // Default to start of track if no selection, but ask for confirmation or just notify
+             if (!window.confirm(`Paste from clipboard to start of ${targetTrack}?`)) return;
+        }
+
+        const newPattern = pasteSteps(patternRef.current, clipboard, targetTrack, targetStep, activeSamplerBankRef.current);
+        setPattern(newPattern);
+
+        let changedSequence;
+        if (targetTrack === 'sampler') {
+            changedSequence = newPattern.sampler;
+        } else {
+            changedSequence = newPattern[targetTrack];
+        }
+        updateStorageForTrack(targetTrack, changedSequence);
+
+        showToast("Pasted from clipboard!", "success");
+    }, [clipboard, selection, selectedTrack, showToast, updateStorageForTrack]);
+
     const handlePatternChange = useCallback((rowKey: keyof Pattern, i: number, _subIndex?: number | unknown, updates?: { length?: number, slide?: boolean, chord?: string[] }) => {
         // Use Ref to access current state without dependency to avoid re-renders of all rows
         const prev = patternRef.current;
@@ -716,8 +763,19 @@ export const App: React.FC = () => {
     const handleStepToggle = useCallback((rowKey: TrackKey, index: number, e: any) => {
         if (e.altKey) { e.preventDefault(); let step = null; if (rowKey === 'sampler') { step = patternRef.current.sampler[activeSamplerBankRef.current].steps[index]; } else { step = patternRef.current[rowKey].steps[index]; } if (step) { handlePatternChange(rowKey, index, undefined, { slide: !step.slide }); } return; }
         if (e.ctrlKey || e.metaKey) { e.preventDefault(); let step = null; if (rowKey === 'sampler') { step = patternRef.current.sampler[activeSamplerBankRef.current].steps[index]; } else { step = patternRef.current[rowKey].steps[index]; } if (step) { if (step.chord && step.chord.length > 0) { handlePatternChange(rowKey, index, undefined, { chord: [] }); } else { const root = noteToMidi(step.note); const chord = [midiToNote(root + 4), midiToNote(root + 7)]; handlePatternChange(rowKey, index, undefined, { chord }); } } return; }
+
+        // Start Drag Drawing
+        const pattern = patternRef.current;
+        let step = null;
+        if (rowKey === 'sampler') { step = pattern.sampler[activeSamplerBankRef.current].steps[index]; }
+        else { step = pattern[rowKey].steps[index]; }
+        const isActive = !!step;
+
+        setIsDrawing(true);
+        setDrawMode(isActive ? 'remove' : 'add');
+
         handlePatternChange(rowKey, index, e);
-    }, [handlePatternChange]);
+    }, [handlePatternChange, activeSamplerBank]);
 
     const activeKeyboardNotesRef = useRef<Map<string, number>>(new Map());
     const handleKeyboardPlay = useCallback((note: string) => {
@@ -757,13 +815,61 @@ export const App: React.FC = () => {
             }
         }
     }, [isNoteDragging, activeSamplerBank]);
-    const handleGlobalMouseUp = useCallback((e: MouseEvent) => { if (!isNoteDragging || !noteDragRef.current) return; if (!noteDragRef.current.hasMoved) { const { track, step } = noteDragRef.current; setContextMenu({ x: e.clientX, y: e.clientY, track, step }); } else if (noteDragRef.current.pendingSequence) { updateStorageForTrack(noteDragRef.current.track, noteDragRef.current.pendingSequence); } setIsNoteDragging(false); noteDragRef.current = null; document.body.style.cursor = 'default'; }, [isNoteDragging, updateStorageForTrack]);
-    useEffect(() => { if (isNoteDragging) { window.addEventListener('mousemove', handleGlobalMouseMove); window.addEventListener('mouseup', handleGlobalMouseUp); } return () => { window.removeEventListener('mousemove', handleGlobalMouseMove); window.removeEventListener('mouseup', handleGlobalMouseUp); }; }, [isNoteDragging, handleGlobalMouseMove, handleGlobalMouseUp]);
+    const handleGlobalMouseUp = useCallback((e: MouseEvent) => {
+        // Stop Drawing
+        if (isDrawing) { setIsDrawing(false); setDrawMode(null); }
+
+        if (!isNoteDragging || !noteDragRef.current) return;
+        if (!noteDragRef.current.hasMoved) { const { track, step } = noteDragRef.current; setContextMenu({ x: e.clientX, y: e.clientY, track, step }); }
+        else if (noteDragRef.current.pendingSequence) { updateStorageForTrack(noteDragRef.current.track, noteDragRef.current.pendingSequence); }
+        setIsNoteDragging(false); noteDragRef.current = null; document.body.style.cursor = 'default';
+    }, [isNoteDragging, updateStorageForTrack, isDrawing]);
+
+    useEffect(() => {
+        // Add global listener for pointer up to catch drags that end outside
+        window.addEventListener('pointerup', handleGlobalMouseUp as any);
+        if (isNoteDragging) { window.addEventListener('mousemove', handleGlobalMouseMove); window.addEventListener('mouseup', handleGlobalMouseUp); }
+        return () => {
+            window.removeEventListener('pointerup', handleGlobalMouseUp as any);
+            window.removeEventListener('mousemove', handleGlobalMouseMove); window.removeEventListener('mouseup', handleGlobalMouseUp);
+        };
+    }, [isNoteDragging, handleGlobalMouseMove, handleGlobalMouseUp]);
+
+    const handleDrawEnter = useCallback((trackKey: TrackKey, stepIndex: number) => {
+        if (!isDrawing || !drawMode) return;
+
+        const pattern = patternRef.current;
+        let step = null;
+        if (trackKey === 'sampler') {
+            step = pattern.sampler[activeSamplerBankRef.current].steps[stepIndex];
+        } else {
+            step = pattern[trackKey].steps[stepIndex];
+        }
+
+        const isActive = !!step;
+
+        if (drawMode === 'add' && !isActive) {
+            handlePatternChange(trackKey, stepIndex, undefined);
+        } else if (drawMode === 'remove' && isActive) {
+            handlePatternChange(trackKey, stepIndex, undefined);
+        }
+    }, [isDrawing, drawMode, handlePatternChange, activeSamplerBank]);
 
     // Selection Keyboard/Mouse Handler
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+
+            // Clipboard
+            if ((e.ctrlKey || e.metaKey) && e.key === 'c') {
+                e.preventDefault();
+                handleCopy();
+            }
+            if ((e.ctrlKey || e.metaKey) && e.key === 'v') {
+                e.preventDefault();
+                handlePaste();
+            }
+
             if ((e.key === 'Delete' || e.key === 'Backspace') && selection) {
                 const { trackKey, startStep, endStep } = selection;
                 const low = Math.min(startStep, endStep);
@@ -793,7 +899,7 @@ export const App: React.FC = () => {
             window.removeEventListener('keydown', handleKeyDown);
             window.removeEventListener('mouseup', handleSelectionEnd);
         };
-    }, [selection, handleSelectionEnd, updateStorageForTrack]);
+    }, [selection, handleSelectionEnd, updateStorageForTrack, handleCopy, handlePaste]);
 
     const handleNoteSelect = (note: string) => {
         if (!contextMenu) return;
@@ -1073,6 +1179,7 @@ export const App: React.FC = () => {
                                 onToggle={handleStepToggle} onRightMouseDown={handleRightMouseDown} onEditLength={handleEditLength} onSelectRow={handleSelectRow} onSelectSlot={handleTrackSlotClick}
                                 onSelectionStart={handleSelectionStart} onSelectionEnter={handleSelectionEnter}
                                 selectionRange={selection && selection.trackKey === row.key ? { start: selection.startStep, end: selection.endStep } : null}
+                                onDrawEnter={handleDrawEnter} isDrawing={isDrawing}
                             />
                         ))}
                     </g>

--- a/src/__tests__/clipboardUtils.test.ts
+++ b/src/__tests__/clipboardUtils.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { copySteps, pasteSteps } from '../utils/clipboardUtils';
+import type { Pattern } from '../types';
+
+const emptySteps = Array(32).fill(null);
+// Helper to create a fresh pattern
+const createEmptyPattern = (): Pattern => ({
+    partA: { steps: [...emptySteps] },
+    partB: { steps: [...emptySteps] },
+    kick: { steps: [...emptySteps] },
+    snare: { steps: [...emptySteps] },
+    closedHat: { steps: [...emptySteps] },
+    openHat: { steps: [...emptySteps] },
+    sampler: Array.from({ length: 8 }, () => ({ steps: [...emptySteps] }))
+});
+
+describe('clipboardUtils', () => {
+    it('copies steps from partA', () => {
+        const pattern = createEmptyPattern();
+        pattern.partA.steps[0] = { note: 'C4', velocity: 1, length: 1 };
+        pattern.partA.steps[2] = { note: 'D4', velocity: 0.5, length: 2 };
+
+        const selection = { trackKey: 'partA' as const, startStep: 0, endStep: 2 };
+        const copied = copySteps(pattern, selection, 0);
+
+        expect(copied).toHaveLength(3);
+        expect(copied![0]).toEqual({ note: 'C4', velocity: 1, length: 1 });
+        expect(copied![1]).toBeNull();
+        expect(copied![2]).toEqual({ note: 'D4', velocity: 0.5, length: 2 });
+    });
+
+    it('pastes steps into partB', () => {
+        const pattern = createEmptyPattern();
+        const clipboard = [
+             { note: 'C4', velocity: 1, length: 1 },
+             null,
+             { note: 'D4', velocity: 0.5, length: 2 }
+        ];
+
+        const newPattern = pasteSteps(pattern, clipboard, 'partB' as const, 0, 0);
+
+        expect(newPattern.partB.steps[0]).toEqual(clipboard[0]);
+        expect(newPattern.partB.steps[1]).toBeNull();
+        expect(newPattern.partB.steps[2]).toEqual(clipboard[2]);
+        expect(newPattern.partB.steps[3]).toBeNull();
+    });
+
+    it('handles sampler copy/paste correctly', () => {
+        const pattern = createEmptyPattern();
+        pattern.sampler[0].steps[0] = { note: 'C3', velocity: 1, length: 1 };
+
+        const selection = { trackKey: 'sampler' as const, startStep: 0, endStep: 0 };
+        const copied = copySteps(pattern, selection, 0);
+
+        expect(copied).toHaveLength(1);
+        expect(copied![0]).toEqual({ note: 'C3', velocity: 1, length: 1 });
+
+        const newPattern = pasteSteps(pattern, copied!, 'sampler' as const, 1, 0);
+        expect(newPattern.sampler[0].steps[1]).toEqual(copied![0]);
+    });
+
+    it('handles overflow', () => {
+        const pattern = createEmptyPattern();
+        const clipboard = [ { note: 'C4', velocity: 1, length: 1 }, { note: 'D4', velocity: 1, length: 1 } ];
+
+        const newPattern = pasteSteps(pattern, clipboard, 'partA' as const, 31, 0);
+
+        expect(newPattern.partA.steps[31]).toEqual(clipboard[0]);
+        // Step 32 is out of bounds
+    });
+
+    it('deep clones on copy and paste', () => {
+        const pattern = createEmptyPattern();
+        const originalNote = { note: 'C4', velocity: 1, length: 1 };
+        pattern.partA.steps[0] = originalNote;
+
+        const selection = { trackKey: 'partA' as const, startStep: 0, endStep: 0 };
+        const copied = copySteps(pattern, selection, 0);
+
+        // Modify original
+        originalNote.velocity = 0.5;
+
+        // Copied should remain 1
+        expect(copied![0]?.velocity).toBe(1);
+
+        // Paste
+        const newPattern = pasteSteps(pattern, copied!, 'partB' as const, 0, 0);
+
+        // Modify clipboard note
+        copied![0]!.velocity = 0.8;
+
+        // Pasted should remain 1
+        expect(newPattern.partB.steps[0]?.velocity).toBe(1);
+    });
+});

--- a/src/utils/clipboardUtils.ts
+++ b/src/utils/clipboardUtils.ts
@@ -1,0 +1,79 @@
+import type { Pattern, Note, PartSequence } from '../types';
+
+export type TrackKey = keyof Pattern;
+
+export interface SelectionState {
+    trackKey: TrackKey;
+    startStep: number;
+    endStep: number;
+}
+
+/**
+ * Copies a range of steps from the pattern based on the selection.
+ * Returns a deep copy of the selected steps.
+ */
+export function copySteps(pattern: Pattern, selection: SelectionState, activeSamplerBank: number): (Note | null)[] | null {
+    const { trackKey, startStep, endStep } = selection;
+    const low = Math.min(startStep, endStep);
+    const high = Math.max(startStep, endStep);
+
+    let sourceSteps: (Note | null)[];
+
+    if (trackKey === 'sampler') {
+        const bank = pattern.sampler[activeSamplerBank];
+        if (!bank) return null;
+        sourceSteps = bank.steps;
+    } else {
+        // Cast to PartSequence because all other keys are PartSequence
+        const part = pattern[trackKey] as PartSequence;
+        if (!part) return null;
+        sourceSteps = part.steps;
+    }
+
+    // Validate range
+    if (low < 0 || high >= sourceSteps.length) return null;
+
+    // Extract slice and deep clone to avoid reference issues
+    const slice = sourceSteps.slice(low, high + 1);
+    return JSON.parse(JSON.stringify(slice));
+}
+
+/**
+ * Pastes clipboard data into the pattern at the specified target track and step.
+ * Returns a new Pattern object with the changes applied.
+ */
+export function pasteSteps(
+    pattern: Pattern,
+    clipboardData: (Note | null)[],
+    targetTrack: TrackKey,
+    targetStep: number,
+    activeSamplerBank: number
+): Pattern {
+    // Deep clone the entire pattern to ensure immutability
+    const newPattern = JSON.parse(JSON.stringify(pattern)) as Pattern;
+
+    let targetSteps: (Note | null)[];
+
+    if (targetTrack === 'sampler') {
+        // Ensure the bank exists (it should, based on initialization)
+        if (!newPattern.sampler[activeSamplerBank]) {
+             // If for some reason it doesn't exist, we can't paste. Return original.
+             return pattern;
+        }
+        targetSteps = newPattern.sampler[activeSamplerBank].steps;
+    } else {
+        targetSteps = (newPattern[targetTrack] as PartSequence).steps;
+    }
+
+    const maxSteps = targetSteps.length;
+
+    clipboardData.forEach((note, index) => {
+        const currentStep = targetStep + index;
+        if (currentStep < maxSteps) {
+             // Deep clone the note from clipboard to avoid shared references across pastes
+             targetSteps[currentStep] = note ? JSON.parse(JSON.stringify(note)) : null;
+        }
+    });
+
+    return newPattern;
+}


### PR DESCRIPTION
Implemented requested features:
1.  **Clipboard Operations:** Users can now copy selected steps (via Shift+Click/Drag) using `Ctrl+C` and paste them starting at the selection or track start using `Ctrl+V`. Logic is handled in `src/utils/clipboardUtils.ts` to ensure data integrity and deep cloning.
2.  **Touch Targets / Drag-to-Edit:** Users can now "paint" notes by clicking (or touching) a step and dragging across others. The mode (add or remove) is determined by the state of the first clicked step.

Also added unit tests for the clipboard utilities.

---
*PR created automatically by Jules for task [4012359362239337425](https://jules.google.com/task/4012359362239337425) started by @ford442*