### PR TITLE
Fix memory leak in Open303 processor by freeing WASM buffer

### DIFF
--- a/patch_open303.py
+++ b/patch_open303.py
@@ -1,0 +1,34 @@
+import os
+
+filepath = 'src/audio-worklets/open303-processor.ts'
+
+with open(filepath, 'r') as f:
+    content = f.read()
+
+search_str = """                    if (channelL) channelL.fill(0);
+                    if (channelR) channelR.fill(0);
+                }
+            } else {"""
+
+replace_str = """                    if (channelL) channelL.fill(0);
+                    if (channelR) channelR.fill(0);
+                }
+
+                // Free the allocated buffer to prevent memory leak
+                if (exports._free) {
+                    exports._free(ptr);
+                }
+            } else {"""
+
+if search_str in content:
+    new_content = content.replace(search_str, replace_str)
+    with open(filepath, 'w') as f:
+        f.write(new_content)
+    print("Successfully patched open303-processor.ts")
+else:
+    print("Could not find search string in open303-processor.ts")
+    # Print the area where we expect it to help debugging
+    start_idx = content.find("if (offset >= 0")
+    if start_idx != -1:
+        print("Context around failure:")
+        print(content[start_idx:start_idx+500])

--- a/src/audio-worklets/open303-processor.ts
+++ b/src/audio-worklets/open303-processor.ts
@@ -374,6 +374,11 @@ class Open303Processor extends AudioWorkletProcessor {
                     if (channelL) channelL.fill(0);
                     if (channelR) channelR.fill(0);
                 }
+
+                // Free the allocated buffer to prevent memory leak
+                if (exports._free) {
+                    exports._free(ptr);
+                }
             } else {
                 // No process function - output silence
                 if (channelL) channelL.fill(0);


### PR DESCRIPTION
- Added explicit `exports._free(ptr)` call in `src/audio-worklets/open303-processor.ts`.
- This resolves a critical issue where the WASM `jc303_process` function (which allocates a new float array on every call) would exhaust the heap, causing the oscillator to stop producing audio.
- The `_free` call is conditionally executed (`if (exports._free)`) to ensure robustness against future WASM build changes.
- Verified with unit tests (`Open303Config.test.ts`) and code inspection.

---
*PR created automatically by Jules for task [3601355926162584355](https://jules.google.com/task/3601355926162584355) started by @ford442*