### PR TITLE
Per-Step Parameters (Expression, Probability, Microtiming)

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -20,9 +20,10 @@
 - [x] **Visual Slice Feedback:** Highlight the active phoneme slice in the UI during playback, visualizing real-time TTS articulation.
 - [x] **Rubber-Band Selection:** Implement multi-note selection via mouse drag in `Sequencer.tsx` (and `App.tsx` main view).
 - [x] **Clipboard Operations:** Standardize `Ctrl+C` / `Ctrl+V` logic to handle both Note Data *and* associated TTS Metadata (which word is attached to the note).
-- [ ] **Per-Step Parameters:** Create a UI to edit "Expression" or "Timbre" for individual sequencer steps (vital for humanizing TTS output).
+- [x] **Per-Step Parameters:** Create a UI to edit "Expression" or "Timbre" for individual sequencer steps (vital for humanizing TTS output).
 - [ ] **Unify Sequencer Components:** Refactor `App.tsx` to use the standalone `Sequencer` component or move `App.tsx` logic into a reusable view to reduce duplication.
 - [ ] **Cleanup Legacy Code:** Identify and remove unused components like `src/components/Sequencer.tsx` to streamline maintenance.
+- [ ] **Refactor NoteSelector Focus Management:** Address fragility in `NoteSelector` focus trapping and test coverage to ensure robust accessibility with dynamic content.
 
 ### Domain C: Accessibility & Mobile
 - [x] **Touch Targets:** Audit `Sequencer.tsx` click listeners to ensure mobile drag-to-create works smoothly.
@@ -37,6 +38,7 @@
 * **Idea:** "Glitch Mode" - A probability knob that randomly retriggers/stutters the start of a TTS sample (granular synthesis).
 * **Idea:** "Choir Stack" - Using Polyphony to detune the TTS voice slightly on 3 channels to create a chorus effect.
 * **Idea:** "Gesture Controls" - Implement pinch-to-zoom for the sequencer timeline to handle longer patterns or finer steps.
+* **Idea:** "Formant Automation" - Draw curves for formant shift over time (not just per step) for continuous vowel morphing.
 
 ---
 
@@ -50,3 +52,4 @@
 * [2026-05-25] - Implemented Hybrid Polyphony using `VoiceManager`, enabling 8-voice polyphony for Synth A and legato monophony for Synth B.
 * [2026-05-26] - Implemented Visual Slice Feedback in SamplerPanel using canvas-based WaveformDisplay and imperative playback highlighting.
 * [2026-05-27] - Implemented Clipboard Operations (Ctrl+C/V) and Drag-to-Edit (Painting) in the main sequencer view (`App.tsx`).
+* [2026-05-28] - Implemented Per-Step Parameters (Timbre, Probability, Microtiming) in Audio Engine and NoteSelector UI.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -604,25 +604,48 @@ export const App: React.FC = () => {
         const triggerSynth = (trackKey: 'partA' | 'partB', params: SynthParams) => {
             const stepData = p[trackKey].steps[step];
             if (stepData) {
+                // Probability Check
+                if (stepData.probability !== undefined && Math.random() > stepData.probability) return;
+
                 const currentBaseFreq = noteToFrequency(stepData.note) * Math.pow(2, params.pitch / 12);
                 let slideFrom = null;
                 if (stepData.slide && lastFreqRef.current[trackKey] > 0) { slideFrom = lastFreqRef.current[trackKey]; }
                 const notes = stepData.chord ? [stepData.note, ...stepData.chord] : stepData.note;
+
+                const noteParams = { timbre: stepData.timbre, microtiming: stepData.microtiming };
+
                 // @ts-ignore
-                audioEngine.playSynth(params, notes, time, stepData.length, stepTime, slideFrom, trackKey);
+                audioEngine.playSynth(params, notes, time, stepData.length, stepTime, slideFrom, trackKey, noteParams);
                 lastFreqRef.current[trackKey] = currentBaseFreq;
             }
         };
 
         triggerSynth('partA', synthARef.current);
         triggerSynth('partB', synthBRef.current);
-        if (p.kick.steps[step]) audioEngine.playDrum('kick', kickRef.current, time)
-        if (p.snare.steps[step]) audioEngine.playDrum('snare', snareRef.current, time)
-        if (p.openHat.steps[step]) audioEngine.playDrum('openHat', openHatRef.current, time)
-        else if (p.closedHat.steps[step]) audioEngine.playDrum('closedHat', closedHatRef.current, time)
+
+        // Drums (Basic probability check)
+        const playDrumIfActive = (trackKey: 'kick' | 'snare' | 'closedHat' | 'openHat', sound: any, params: any) => {
+            const stepData = p[trackKey].steps[step];
+            if (stepData) {
+                 if (stepData.probability !== undefined && Math.random() > stepData.probability) return;
+                 // Drums don't support timbre/microtiming yet in this simplified call, but we could add it
+                 // For now just probability
+                 audioEngine.playDrum(sound, params, time);
+            }
+        };
+
+        playDrumIfActive('kick', 'kick', kickRef.current);
+        playDrumIfActive('snare', 'snare', snareRef.current);
+        playDrumIfActive('openHat', 'openHat', openHatRef.current);
+        if (!p.openHat.steps[step]) playDrumIfActive('closedHat', 'closedHat', closedHatRef.current); // Only closed if open not playing
+
         p.sampler.forEach((seq, bankIdx) => {
             const stepData = seq.steps[step];
-            if (stepData) { audioEngine.playSampler(samplerRef.current[bankIdx], stepData.note, time, stepData.length, stepTime); }
+            if (stepData) {
+                if (stepData.probability !== undefined && Math.random() > stepData.probability) return;
+                const noteParams = { timbre: stepData.timbre, microtiming: stepData.microtiming };
+                audioEngine.playSampler(samplerRef.current[bankIdx], stepData.note, time, stepData.length, stepTime, noteParams);
+            }
         });
 
         // Visual Slice Feedback for Active Bank
@@ -942,6 +965,33 @@ export const App: React.FC = () => {
         setPattern(copy);
         updateStorageForTrack(trackKey, changedSequence);
     };
+
+    const handleNotePropertyChange = (key: 'timbre' | 'probability' | 'microtiming', value: number) => {
+        if (!contextMenu) return;
+        const prev = patternRef.current;
+        const copy = JSON.parse(JSON.stringify(prev)) as Pattern;
+        const trackKey = contextMenu.track;
+        const stepIndex = contextMenu.step;
+        const isSampler = trackKey === 'sampler';
+
+        let stepsArray;
+        if (isSampler) {
+            stepsArray = copy.sampler[activeSamplerBank].steps;
+        } else {
+            stepsArray = (copy[trackKey] as any).steps;
+        }
+
+        const stepData = stepsArray[stepIndex];
+        if (stepData) {
+            stepData[key] = value;
+        }
+
+        let changedSequence;
+        if (isSampler) { changedSequence = copy.sampler; } else { changedSequence = copy[trackKey]; }
+        setPattern(copy);
+        updateStorageForTrack(trackKey, changedSequence);
+    };
+
     const handleClearPattern = () => { if (window.confirm("Clear current pattern?")) { const emptyPattern = { partA: { steps: Array(32).fill(null) }, partB: { steps: Array(32).fill(null) }, kick: { steps: Array(32).fill(null) }, snare: { steps: Array(32).fill(null) }, closedHat: { steps: Array(32).fill(null) }, openHat: { steps: Array(32).fill(null) }, sampler: Array.from({ length: 8 }, () => ({ steps: Array(32).fill(null) })), } as any as Pattern; setPattern(emptyPattern); setTrackStorage(prevStorage => { const storageCopy = { ...prevStorage }; (Object.keys(storageCopy) as TrackKey[]).forEach(key => { storageCopy[key] = [...storageCopy[key]]; storageCopy[key][activeTrackSlots[key]] = emptyPattern[key]; }); return storageCopy; }); } };
     const handleTrackSlotClick = useCallback((track: TrackKey, slotIndex: number) => { const currentTrackPattern = track === 'sampler' ? patternRef.current.sampler : patternRef.current[track]; const storedPattern = trackStorageRef.current[track][slotIndex]; if (storedPattern) { setPattern(prev => ({ ...prev, [track]: storedPattern })); setActiveTrackSlots(prev => ({ ...prev, [track]: slotIndex })); } else { setTrackStorage(prev => { const copy = { ...prev }; copy[track] = [...prev[track]]; copy[track][slotIndex] = currentTrackPattern; return copy; }); setActiveTrackSlots(prev => ({ ...prev, [track]: slotIndex })); } }, []);
     const handleSelectRow = useCallback((k: any) => setSelectedTrack(k as TrackKey), []);
@@ -1271,7 +1321,23 @@ export const App: React.FC = () => {
             <SongMode isVisible={isSongModeOpen} songStructure={songStructure} currentSongStep={currentSongMeasure} backgroundImage={backgroundImage} onSetBackgroundImage={setBackgroundImage} onToggle={handleSongModeToggle} onUpdateStep={handleSongStructureUpdate} onAddMeasure={handleAddMeasure} onRemoveMeasure={handleRemoveMeasure} onExportXM={handleExportXM} isSongModeActive={isSongModeActive} onSetIsSongModeActive={setIsSongModeActive} />
 
             <main className="flex-1 relative bg-gradient-to-b from-[#0a0e14] via-[#111827] to-[#050709] shadow-inner flex flex-col justify-start pt-10 pb-6 z-10">
-                {contextMenu && (<NoteSelector x={contextMenu.x} y={contextMenu.y} trackType={(contextMenu.track.startsWith('part') || contextMenu.track === 'sampler') ? 'synth' : 'drum'} currentNote={contextMenu.track === 'sampler' ? pattern.sampler[activeSamplerBank]?.steps[contextMenu.step]?.note ?? '' : pattern?.[contextMenu.track]?.steps?.[contextMenu.step]?.note ?? ''} currentLength={contextMenu.track === 'sampler' ? pattern.sampler[activeSamplerBank]?.steps[contextMenu.step]?.length ?? 1 : pattern?.[contextMenu.track]?.steps?.[contextMenu.step]?.length ?? 1} onSelect={handleNoteSelect} onLengthChange={handleNoteLengthChange} onClose={() => setContextMenu(null)} getNoteColor={getNoteColor} />)}
+                {contextMenu && (
+                    <NoteSelector
+                        x={contextMenu.x}
+                        y={contextMenu.y}
+                        trackType={(contextMenu.track.startsWith('part') || contextMenu.track === 'sampler') ? 'synth' : 'drum'}
+                        currentNote={contextMenu.track === 'sampler' ? pattern.sampler[activeSamplerBank]?.steps[contextMenu.step]?.note ?? '' : pattern?.[contextMenu.track]?.steps?.[contextMenu.step]?.note ?? ''}
+                        currentLength={contextMenu.track === 'sampler' ? pattern.sampler[activeSamplerBank]?.steps[contextMenu.step]?.length ?? 1 : pattern?.[contextMenu.track]?.steps?.[contextMenu.step]?.length ?? 1}
+                        currentTimbre={contextMenu.track === 'sampler' ? pattern.sampler[activeSamplerBank]?.steps[contextMenu.step]?.timbre ?? 0 : pattern?.[contextMenu.track]?.steps?.[contextMenu.step]?.timbre ?? 0}
+                        currentProbability={contextMenu.track === 'sampler' ? pattern.sampler[activeSamplerBank]?.steps[contextMenu.step]?.probability ?? 1 : pattern?.[contextMenu.track]?.steps?.[contextMenu.step]?.probability ?? 1}
+                        currentMicrotiming={contextMenu.track === 'sampler' ? pattern.sampler[activeSamplerBank]?.steps[contextMenu.step]?.microtiming ?? 0 : pattern?.[contextMenu.track]?.steps?.[contextMenu.step]?.microtiming ?? 0}
+                        onSelect={handleNoteSelect}
+                        onLengthChange={handleNoteLengthChange}
+                        onPropertyChange={handleNotePropertyChange}
+                        onClose={() => setContextMenu(null)}
+                        getNoteColor={getNoteColor}
+                    />
+                )}
                 <div className="w-full max-w-[1000px] mx-auto h-[480px]">
                     {sequencerNode}
                 </div>

--- a/src/components/NoteSelector.tsx
+++ b/src/components/NoteSelector.tsx
@@ -12,10 +12,16 @@ interface NoteSelectorProps {
     onLengthChange: (length: number) => void; // NEW: Handle length changes
     onClose: () => void;
     getNoteColor: (note: string) => string;
+    // NEW: Per-step parameters
+    currentTimbre?: number;
+    currentProbability?: number;
+    currentMicrotiming?: number;
+    onPropertyChange?: (key: 'timbre' | 'probability' | 'microtiming', value: number) => void;
 }
 
 export const NoteSelector: React.FC<NoteSelectorProps> = ({
-    x, y, trackType, currentNote, currentLength, onSelect, onLengthChange, onClose, getNoteColor
+    x, y, trackType, currentNote, currentLength, onSelect, onLengthChange, onClose, getNoteColor,
+    currentTimbre = 0, currentProbability = 1, currentMicrotiming = 0, onPropertyChange
 }) => {
     // Determine octave range based on track type
     const octaves = trackType === 'synth' ? [2, 3, 4] : [2];
@@ -65,6 +71,64 @@ export const NoteSelector: React.FC<NoteSelectorProps> = ({
                         aria-valuetext={`${currentLength} Steps`}
                     />
                 </div>
+
+                {onPropertyChange && (
+                    <>
+                        {/* Timbre Control */}
+                        <div className="flex flex-col gap-1">
+                            <div className="flex justify-between text-[10px] text-slate-400 font-bold uppercase">
+                                <label htmlFor="note-timbre">Expression</label>
+                                <span className="text-pink-400">{Math.round((currentTimbre + 0.0001) * 100)}%</span>
+                            </div>
+                            <input
+                                id="note-timbre"
+                                type="range"
+                                min="0"
+                                max="1"
+                                step="0.01"
+                                value={currentTimbre}
+                                onChange={(e) => onPropertyChange('timbre', parseFloat(e.target.value))}
+                                className="w-full h-2 bg-slate-700 rounded-lg appearance-none cursor-pointer accent-pink-500"
+                            />
+                        </div>
+
+                        {/* Probability Control */}
+                        <div className="flex flex-col gap-1">
+                            <div className="flex justify-between text-[10px] text-slate-400 font-bold uppercase">
+                                <label htmlFor="note-prob">Probability</label>
+                                <span className="text-yellow-400">{Math.round((currentProbability + 0.0001) * 100)}%</span>
+                            </div>
+                            <input
+                                id="note-prob"
+                                type="range"
+                                min="0"
+                                max="1"
+                                step="0.01"
+                                value={currentProbability}
+                                onChange={(e) => onPropertyChange('probability', parseFloat(e.target.value))}
+                                className="w-full h-2 bg-slate-700 rounded-lg appearance-none cursor-pointer accent-yellow-500"
+                            />
+                        </div>
+
+                        {/* Microtiming Control */}
+                        <div className="flex flex-col gap-1">
+                            <div className="flex justify-between text-[10px] text-slate-400 font-bold uppercase">
+                                <label htmlFor="note-micro">Microtiming</label>
+                                <span className="text-purple-400">{currentMicrotiming > 0 ? '+' : ''}{currentMicrotiming.toFixed(2)}</span>
+                            </div>
+                            <input
+                                id="note-micro"
+                                type="range"
+                                min="-0.5"
+                                max="0.5"
+                                step="0.01"
+                                value={currentMicrotiming}
+                                onChange={(e) => onPropertyChange('microtiming', parseFloat(e.target.value))}
+                                className="w-full h-2 bg-slate-700 rounded-lg appearance-none cursor-pointer accent-purple-500"
+                            />
+                        </div>
+                    </>
+                )}
 
                 <div className="flex gap-2">
                     {octaves.map(octave => (

--- a/src/engines/SingingVoice.ts
+++ b/src/engines/SingingVoice.ts
@@ -234,10 +234,11 @@ export class SingingVoice {
     /**
      * Set the pitch scale ratio.
      * @param ratio Pitch multiplier (e.g., 2.0 = one octave up, 0.5 = one octave down)
+     * @param time Optional time to apply the change (default: now)
      */
-    setPitch(ratio: number): void {
+    setPitch(ratio: number, time?: number): void {
         if (this.useWorklet && this.workletNode) {
-            this.workletNode.parameters.get('pitchScale')!.setValueAtTime(ratio, this.audioContext.currentTime);
+            this.workletNode.parameters.get('pitchScale')!.setValueAtTime(ratio, time || this.audioContext.currentTime);
         }
         // ScriptProcessorNode fallback doesn't support pitch shifting
     }
@@ -246,8 +247,9 @@ export class SingingVoice {
      * Set pitch from MIDI note number relative to base note.
      * @param targetMidiNote Target MIDI note for pitch shifting
      * @param baseMidiNote Base MIDI note (default: C4 = 60)
+     * @param time Optional time to apply the change (default: now)
      */
-    setPitchFromMidi(targetMidiNote: number, baseMidiNote: number = 60): void {
+    setPitchFromMidi(targetMidiNote: number, baseMidiNote: number = 60, time?: number): void {
         const targetFreq = midiToFreq(targetMidiNote);
         const baseFreq = midiToFreq(baseMidiNote);
         
@@ -255,7 +257,7 @@ export class SingingVoice {
         let pitchRatio = targetFreq / baseFreq;
         pitchRatio = Math.max(PITCH_RATIO_LIMITS.MIN, Math.min(PITCH_RATIO_LIMITS.MAX, pitchRatio));
         
-        this.setPitch(pitchRatio);
+        this.setPitch(pitchRatio, time);
     }
     
     /**
@@ -384,10 +386,11 @@ export class SingingVoice {
     /**
      * Set the time stretch ratio.
      * @param timeRatio Time multiplier (e.g., 2.0 = twice as long, 0.5 = half as long)
+     * @param time Optional time to apply the change (default: now)
      */
-    setTimeRatio(timeRatio: number): void {
+    setTimeRatio(timeRatio: number, time?: number): void {
         if (this.useWorklet && this.workletNode) {
-            this.workletNode.parameters.get('timeRatio')!.setValueAtTime(timeRatio, this.audioContext.currentTime);
+            this.workletNode.parameters.get('timeRatio')!.setValueAtTime(timeRatio, time || this.audioContext.currentTime);
         }
         // ScriptProcessorNode fallback doesn't support time stretching
     }
@@ -592,30 +595,33 @@ export class SingingVoice {
     /**
      * Set formant shift in semitones.
      * @param semitones Formant shift in semitones (e.g., -12 to 12)
+     * @param time Optional time to apply the change (default: now)
      */
-    setFormantShift(semitones: number): void {
+    setFormantShift(semitones: number, time?: number): void {
         if (this.workletNode) {
-            this.workletNode.parameters.get('formantScale')?.setValueAtTime(semitones / 12, this.audioContext.currentTime);
+            this.workletNode.parameters.get('formantScale')?.setValueAtTime(semitones / 12, time || this.audioContext.currentTime);
         }
     }
 
     /**
      * Set vibrato depth percentage.
      * @param percent Vibrato depth (0-100)
+     * @param time Optional time to apply the change (default: now)
      */
-    setVibratoDepth(percent: number): void {
+    setVibratoDepth(percent: number, time?: number): void {
         if (this.workletNode) {
-            this.workletNode.parameters.get('vibratoDepth')?.setValueAtTime(percent / 100, this.audioContext.currentTime);
+            this.workletNode.parameters.get('vibratoDepth')?.setValueAtTime(percent / 100, time || this.audioContext.currentTime);
         }
     }
 
     /**
      * Set breath intensity.
      * @param intensity Breath intensity (0-1)
+     * @param time Optional time to apply the change (default: now)
      */
-    setBreathIntensity(intensity: number): void {
+    setBreathIntensity(intensity: number, time?: number): void {
         if (this.workletNode) {
-            this.workletNode.parameters.get('breathIntensity')?.setValueAtTime(intensity, this.audioContext.currentTime);
+            this.workletNode.parameters.get('breathIntensity')?.setValueAtTime(intensity, time || this.audioContext.currentTime);
         }
     }
 }

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -226,13 +226,26 @@ export const useAudioEngine = (pyodide: any, forceScriptProcessor: boolean = fal
 
             // Define Playback Functions
 
-            const playSynth = (params: SynthParams, note: string | string[], time: number, durationSteps: number = 1, stepTime: number = 0.2, slideFromFreq?: number, track?: 'partA' | 'partB') => {
+            const playSynth = (params: SynthParams, note: string | string[], time: number, durationSteps: number = 1, stepTime: number = 0.2, slideFromFreq?: number, track?: 'partA' | 'partB', noteParams?: { timbre?: number, microtiming?: number }) => {
                  if (!masterGainRef.current) return;
+
+                 // Apply Microtiming
+                 const actualTime = time + (noteParams?.microtiming ? noteParams.microtiming * stepTime : 0);
+
+                 // Apply Timbre Modulation (Filter Cutoff)
+                 let effectiveParams = params;
+                 if (noteParams?.timbre !== undefined) {
+                     effectiveParams = { ...params };
+                     // Modulate cutoff: 0.5 is neutral. 0 = -50%, 1 = +50%
+                     // Or just scale: cutoff * (0.5 + timbre)
+                     const mod = 0.5 + noteParams.timbre; // 0.5 to 1.5
+                     effectiveParams.filterCutoff = Math.min(20000, params.filterCutoff * mod);
+                 }
 
                  // Open303 Routing (Specific check for 303 waveforms)
                  if (params.waveform === '303-saw' || params.waveform === '303-sqr') {
                      if (open303EngineRef.current) {
-                         apply303Params(open303EngineRef.current, params, params.waveform === '303-sqr' ? 'sqr' : 'saw');
+                         apply303Params(open303EngineRef.current, effectiveParams, params.waveform === '303-sqr' ? 'sqr' : 'saw');
 
                          // Note: 303 Engine is monophonic by nature in this implementation or handles its own logic.
                          // But noteToMidi expects string. If chord (array), pick first note?
@@ -242,7 +255,7 @@ export const useAudioEngine = (pyodide: any, forceScriptProcessor: boolean = fal
                          const midi = noteToMidi(noteStr);
 
                          const now = context.currentTime;
-                         const startDelay = Math.max(0, time - now);
+                         const startDelay = Math.max(0, actualTime - now);
                          const duration = durationSteps * stepTime;
 
                          setTimeout(() => {
@@ -263,10 +276,10 @@ export const useAudioEngine = (pyodide: any, forceScriptProcessor: boolean = fal
                  const duration = durationSteps * stepTime;
 
                  if (track === 'partB' && voiceManagerBRef.current) {
-                     voiceManagerBRef.current.playNote(params, note, time, duration, slideFromFreq);
+                     voiceManagerBRef.current.playNote(effectiveParams, note, actualTime, duration, slideFromFreq);
                  } else if (voiceManagerARef.current) {
                      // Default to Synth A (Poly)
-                     voiceManagerARef.current.playNote(params, note, time, duration, slideFromFreq);
+                     voiceManagerARef.current.playNote(effectiveParams, note, actualTime, duration, slideFromFreq);
                  }
             };
 
@@ -373,15 +386,27 @@ export const useAudioEngine = (pyodide: any, forceScriptProcessor: boolean = fal
                 return vocalAlignmentsRef.current.get(bankName) || null;
             };
 
-            const playSampler = (params: SamplerBankParams, note: string, time: number, durationSteps: number = 1, stepTime: number = 0.2) => {
+            const playSampler = (params: SamplerBankParams, note: string, time: number, durationSteps: number = 1, stepTime: number = 0.2, noteParams?: { timbre?: number, microtiming?: number }) => {
                 const buffer = loadedSampleBuffersRef.current.get(params.sampleName);
                 if (!buffer || !masterGainRef.current) return;
+
+                // Apply Microtiming
+                const actualTime = time + (noteParams?.microtiming ? noteParams.microtiming * stepTime : 0);
 
                 if (params.mode === 'stretch' && singingVoiceRef.current) {
                     // PHONEME ELASTICITY & SINGING VOICE MODE
                     const voice = singingVoiceRef.current;
                     const targetDuration = durationSteps * stepTime;
                     const originalDuration = buffer.duration;
+
+                    // Apply Timbre Modulation (Formant Shift)
+                    if (noteParams?.timbre !== undefined) {
+                        const baseShift = params.formantShift || 0;
+                        const mod = (noteParams.timbre * 12) - 6; // +/- 6 semitones
+                        voice.setFormantShift(baseShift + mod, actualTime);
+                    } else if (params.formantShift !== undefined) {
+                         voice.setFormantShift(params.formantShift, actualTime);
+                    }
 
                     // CHECK FOR SLICE TRIGGER MODE
                     if (params.sliceMode === 'phoneme') {
@@ -400,12 +425,12 @@ export const useAudioEngine = (pyodide: any, forceScriptProcessor: boolean = fal
 
                     // 1. Calculate Time Ratio
                     const timeRatio = targetDuration / originalDuration;
-                    voice.setTimeRatio(timeRatio);
+                    voice.setTimeRatio(timeRatio, actualTime);
 
                     // 2. Pitch Shift
                     // Assuming base note C4 (60) for the sample
                     const targetMidi = noteToMidi(note);
-                    voice.setPitchFromMidi(targetMidi, 60);
+                    voice.setPitchFromMidi(targetMidi, 60, actualTime);
 
                     // 3. Phoneme Awareness
                     const alignment = vocalAlignmentsRef.current.get(params.sampleName);
@@ -447,7 +472,7 @@ export const useAudioEngine = (pyodide: any, forceScriptProcessor: boolean = fal
                 shaper.connect(gain);
                 gain.connect(masterGainRef.current);
 
-                source.start(time);
+                source.start(actualTime);
             };
 
             const noteOnSampler = (params: SamplerBankParams, _note: string, time?: number): number | null => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,9 @@ export interface Note {
   length?: number; // Duration in steps (default 1)
   slide?: boolean; // Triggers portamento from previous note
   chord?: string[]; // Additional notes to play simultaneously
+  timbre?: number; // 0-1, tonal character (filter/formant)
+  probability?: number; // 0-1, chance of triggering
+  microtiming?: number; // -0.5 to 0.5 steps, rhythmic offset
 }
 
 export interface PartSequence {


### PR DESCRIPTION
Implemented "Per-Step Parameters" to humanize TTS and Synth sequencing.
Users can now adjust:
- **Expression (Timbre):** Modulates Formant Shift for voices or Filter Cutoff for synths.
- **Probability:** Adds chance-based triggering (0-100%).
- **Microtiming:** Offsets note start time (-0.5 to +0.5 steps) for groove/humanization.

Changes include updates to `AudioEngine`, `SingingVoice` scheduling logic, and `NoteSelector` UI.

---
*PR created automatically by Jules for task [16114887948273898741](https://jules.google.com/task/16114887948273898741) started by @ford442*