### PR TITLE
Implement Lyric Input and Auto-Phoneme Mapping

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -14,7 +14,7 @@
 - [x] **TTS Slice Triggering:** Implement a logic where a MIDI Note NoteOn event can trigger a specific *slice* or *word* from the TTS buffer (e.g., Note C3 = "Hello", Note D3 = "World").
 - [x] **Hybrid Polyphony:** Finalize `VoiceManager` to handle 8-voice polyphony for `synth-1` while keeping `synth-2` strictly monophonic (legato priority).
 - [x] **Phoneme Elasticity:** Connect `rubberband.wasm` to the sequencer steps. If a note is dragged longer, the specific phoneme should time-stretch to match the duration without altering pitch.
-- [ ] **Lyric Input:** Add a global text input component to distribute syllables across selected MIDI notes in the active sampler bank (Auto-Phoneme Mapping).
+- [x] **Lyric Input:** Add a global text input component to distribute syllables across selected MIDI notes in the active sampler bank (Auto-Phoneme Mapping).
 - [ ] **Formant Automation:** Implement automation lanes or per-step drawing for formant shift to allow continuous vowel morphing.
 
 ### Domain B: Editor Workflow (The "Cubase" Feel)
@@ -36,6 +36,7 @@
 ## 🧠 Innovation Lab (The "Dream" Log)
 *These are concepts to be fleshed out by the agent during "Architect Mode".*
 
+* **Idea:** "One Note per Word" - Advanced mapping in Lyric Input to distribute whole words to steps instead of phonemes.
 * **Idea:** "Glitch Mode" - A probability knob that randomly retriggers/stutters the start of a TTS sample (granular synthesis).
 * **Idea:** "Choir Stack" - Using Polyphony to detune the TTS voice slightly on 3 channels to create a chorus effect.
 * **Idea:** "Gesture Controls" - Implement pinch-to-zoom for the sequencer timeline to handle longer patterns or finer steps.
@@ -57,3 +58,4 @@
 * [2026-05-29] - Implemented Phoneme-Aware Time Stretching DSP in RubberBandProcessor, enabling dynamic vowel stretching during playback.
 * [2026-05-30] - Refactored `App.tsx` to use `MainSequencer` component, unifying sequencer logic and improving maintainability.
 * [2026-05-31] - Removed legacy `Sequencer` component and `src/components/sequencer/` directory. Refactored `NoteSelector` focus management tests for stability.
+* [2026-06-01] - Implemented Lyric Input (LyricMapper), allowing text entry to auto-generate TTS and map phonemes to selected sequencer steps.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ import { WaveformSelector } from './components/WaveformSelector';
 import { NoteSelector } from './components/NoteSelector';
 import { LiveKeyboard } from './components/LiveKeyboard';
 import { ShortcutsHelp } from './components/ShortcutsHelp';
+import { LyricMapper } from './components/LyricMapper';
+import { SupertonicService } from './services/Supertonic';
 
 import { VoiceEditor } from './components/VoiceEditor';
 import { SamplerPanel } from './components/SamplerPanel';
@@ -194,8 +196,10 @@ export const App: React.FC = () => {
     const { pyodide, isPyodideReady, pyodideStatus } = usePyodideEngine()
     const [isVoiceEditorOpen, setIsVoiceEditorOpen] = useState(false);
     const [isCloudLibraryOpen, setIsCloudLibraryOpen] = useState(false);
+    const [isLyricMapperOpen, setIsLyricMapperOpen] = useState(false);
     const [isShortcutsOpen, setIsShortcutsOpen] = useState(false);
     const [showGamepadDebug, setShowGamepadDebug] = useState(false);
+    const [isGenerating, setIsGenerating] = useState(false);
     const [hasStarted, setHasStarted] = useState(false);
     const [forceScriptProcessorFallback, setForceScriptProcessorFallback] = useState(() => {
         // Read persisted preference from localStorage
@@ -860,6 +864,78 @@ export const App: React.FC = () => {
         }
     }, [audioEngine, activeSamplerBank]);
 
+    const handleGenerateTTS = useCallback(async (text: string) => {
+        if (!audioEngine) return;
+        setIsGenerating(true);
+        try {
+            const rawData = await SupertonicService.getInstance().generate(text);
+            const buffer = audioEngine.context.createBuffer(1, rawData.length, 44100);
+            buffer.getChannelData(0).set(rawData);
+
+            // Reuse handleLoadSample to update state and engine
+            const bankName = `bank_${activeSamplerBankRef.current}`;
+            handleLoadSample(bankName, buffer);
+            showToast(`Generated: ${text.substring(0, 15)}...`, "success");
+        } catch (e) {
+            console.error(e);
+            showToast("TTS Generation Failed", "error");
+            throw e;
+        } finally {
+            setIsGenerating(false);
+        }
+    }, [audioEngine, handleLoadSample, showToast]);
+
+    const handleLyricApply = useCallback(async (text: string, mapToSelection: boolean) => {
+        try {
+            await handleGenerateTTS(text);
+
+            // Update phrases state
+            const newPhrases = [...ttsPhrases];
+            newPhrases[activeSamplerBankRef.current] = text;
+            setTtsPhrases(newPhrases);
+
+            if (mapToSelection && selection && selection.trackKey === 'sampler') {
+                const { startStep, endStep } = selection;
+                const low = Math.min(startStep, endStep);
+                const high = Math.max(startStep, endStep);
+
+                const prev = patternRef.current;
+                const copy = JSON.parse(JSON.stringify(prev)) as Pattern;
+                const bankIdx = activeSamplerBankRef.current;
+                const bank = copy.sampler[bankIdx];
+
+                let noteIndex = 0;
+                for (let i = low; i <= high; i++) {
+                    if (!bank.steps[i]) {
+                         bank.steps[i] = { note: 'C4', velocity: 1, length: 1 };
+                    }
+                    if (bank.steps[i]) {
+                         const midi = 60 + noteIndex;
+                         bank.steps[i]!.note = midiToNote(midi);
+                         noteIndex++;
+                    }
+                }
+
+                setPattern(copy);
+                updateStorageForTrack('sampler', copy.sampler);
+
+                // Update Sampler Params to enable slice mode
+                setSampler(prevParams => {
+                    const next = [...prevParams];
+                    if (next[bankIdx]) {
+                        next[bankIdx] = { ...next[bankIdx], sliceMode: 'phoneme' };
+                    }
+                    samplerRef.current = next;
+                    return next;
+                });
+
+                showToast("Lyrics Mapped!", "success");
+            }
+        } catch (e) {
+            // Error handled in handleGenerateTTS
+        }
+    }, [handleGenerateTTS, ttsPhrases, selection, setPattern, setSampler, updateStorageForTrack, showToast]);
+
     const onSynthAParamChange = useCallback((id: string, v: number) => handleSynthChange(true, id, v), [handleSynthChange]);
     const onSynthBParamChange = useCallback((id: string, v: number) => handleSynthChange(false, id, v), [handleSynthChange]);
 
@@ -873,7 +949,7 @@ export const App: React.FC = () => {
 
     const synthAChild = useMemo(() => (<div className="absolute top-4 right-6 pointer-events-auto"><WaveformSelector selected={synthA.waveform} onChange={(w) => updateSynthA({ waveform: w })} accentColor="cyan" /></div>), [synthA.waveform, updateSynthA]);
     const synthBChild = useMemo(() => (<div className="absolute top-4 right-6 pointer-events-auto"><WaveformSelector selected={synthB.waveform} onChange={(w) => updateSynthB({ waveform: w })} accentColor="pink" /></div>), [synthB.waveform, updateSynthB]);
-    const samplerChild = useMemo(() => (<div className="absolute top-2 left-[25%] w-[50%] max-h-[280px] h-auto pointer-events-auto z-10 bg-gray-900/90 rounded-lg border border-purple-500/30 backdrop-blur-sm overflow-hidden"><SamplerPanel params={sampler} onChange={(u) => updateSampler(u)} onParamChange={handleSamplerParamChange} onLoadSample={handleLoadSample} audioContext={audioEngine?.context!} audioEngine={audioEngine || undefined} activeBankIdx={activeSamplerBank} onBankChange={setActiveSamplerBank} onOpenEditor={() => setIsVoiceEditorOpen(true)} ttsPhrases={ttsPhrases} onTtsPhraseChange={handleTtsPhraseChange} loadedBanks={loadedBanks} sampleBuffer={sampleBuffers[activeSamplerBank]} sliceHighlightRef={sliceHighlightRef} /></div>), [sampler, updateSampler, handleSamplerParamChange, audioEngine, setIsVoiceEditorOpen, activeSamplerBank, handleLoadSample, ttsPhrases, loadedBanks, sampleBuffers]);
+    const samplerChild = useMemo(() => (<div className="absolute top-2 left-[25%] w-[50%] max-h-[280px] h-auto pointer-events-auto z-10 bg-gray-900/90 rounded-lg border border-purple-500/30 backdrop-blur-sm overflow-hidden"><SamplerPanel params={sampler} onChange={(u) => updateSampler(u)} onParamChange={handleSamplerParamChange} onLoadSample={handleLoadSample} audioContext={audioEngine?.context!} audioEngine={audioEngine || undefined} activeBankIdx={activeSamplerBank} onBankChange={setActiveSamplerBank} onOpenEditor={() => setIsVoiceEditorOpen(true)} ttsPhrases={ttsPhrases} onTtsPhraseChange={handleTtsPhraseChange} onGenerateTTS={handleGenerateTTS} loadedBanks={loadedBanks} sampleBuffer={sampleBuffers[activeSamplerBank]} sliceHighlightRef={sliceHighlightRef} /></div>), [sampler, updateSampler, handleSamplerParamChange, audioEngine, setIsVoiceEditorOpen, activeSamplerBank, handleLoadSample, ttsPhrases, handleGenerateTTS, loadedBanks, sampleBuffers]);
 
     // --- RENDER PARTS FOR 3D ---
     // Extract parts so they can be passed to either normal view or 3D view
@@ -946,6 +1022,7 @@ export const App: React.FC = () => {
                 </div>
                 <button onClick={handlePanic} aria-label="Panic Stop All Notes" className="w-8 h-8 rounded-full bg-red-900/50 text-red-500 flex items-center justify-center font-bold text-xs mr-2">!</button>
                 <button onClick={() => setIsRecording(!isRecording)} aria-pressed={isRecording} aria-label="Toggle Recording" className={`w-12 py-1 rounded font-orbitron text-sm font-bold tracking-wide mr-2 ${isRecording ? 'bg-red-600 text-white animate-pulse' : 'bg-gray-800 text-red-700'}`}>REC</button>
+                <button onClick={() => setIsLyricMapperOpen(!isLyricMapperOpen)} aria-pressed={isLyricMapperOpen} aria-label="Open Lyric Mapper" className={`w-20 py-1 rounded font-orbitron text-sm font-bold tracking-wide mr-2 ${isLyricMapperOpen ? 'bg-cyan-900/40 text-cyan-300' : 'bg-gray-800 text-gray-400'}`}>LYRICS</button>
                 <button onClick={() => setIsSongModeOpen(!isSongModeOpen)} aria-pressed={isSongModeOpen} aria-label="Toggle Song Mode" className={`w-24 py-1 rounded font-orbitron text-sm font-bold tracking-wide mr-2 ${isSongModeOpen ? 'bg-purple-900/40 text-purple-300' : 'bg-gray-800 text-gray-400'}`}>SONG</button>
                 <button onClick={handlePlayToggle} aria-pressed={isPlaying} aria-label={isPlaying ? "Stop Playback" : "Start Playback"} className={`w-24 py-1 rounded font-orbitron text-sm font-bold tracking-wide ${isPlaying ? 'bg-red-900/20 text-red-400' : 'bg-green-900/20 text-green-400'}`}>{isPlaying ? 'STOP' : 'PLAY'}</button>
 
@@ -1119,6 +1196,7 @@ export const App: React.FC = () => {
             {backgroundImage && <div className="absolute inset-0 bg-black/60 pointer-events-none z-0"></div>}
             {!hasStarted && <StartOverlay onStart={handleStart} isReady={isPyodideReady} />}
             <CloudLibrary isOpen={isCloudLibraryOpen} onClose={() => setIsCloudLibraryOpen(false)} onLoadData={loadCloudData} onShowToast={showToast} getSongData={getSongData} getBankData={getBankData} getPatternData={getPatternData} />
+            <LyricMapper isOpen={isLyricMapperOpen} onClose={() => setIsLyricMapperOpen(false)} onApply={handleLyricApply} initialText={ttsPhrases[activeSamplerBank] || ""} isGenerating={isGenerating} hasSelection={!!selection && selection.trackKey === 'sampler'} />
             {isVoiceEditorOpen && (<VoiceEditor onClose={() => setIsVoiceEditorOpen(false)} />)}
             {isShortcutsOpen && <ShortcutsHelp onClose={() => setIsShortcutsOpen(false)} />}
             {showGamepadDebug && (<GamepadDebugger onClose={() => setShowGamepadDebug(false)} />)}

--- a/src/components/LyricMapper.tsx
+++ b/src/components/LyricMapper.tsx
@@ -1,0 +1,84 @@
+import React, { useState, useEffect } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
+
+interface LyricMapperProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onApply: (text: string, mapToSelection: boolean) => void;
+    initialText: string;
+    isGenerating: boolean;
+    hasSelection: boolean;
+}
+
+export const LyricMapper: React.FC<LyricMapperProps> = ({
+    isOpen,
+    onClose,
+    onApply,
+    initialText,
+    isGenerating,
+    hasSelection
+}) => {
+    const [text, setText] = useState(initialText);
+    const containerRef = useFocusTrap<HTMLDivElement>(isOpen, onClose);
+
+    useEffect(() => {
+        if (isOpen) {
+            setText(initialText);
+        }
+    }, [isOpen, initialText]);
+
+    if (!isOpen) return null;
+
+    return (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm">
+            <div
+                ref={containerRef}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="lyric-mapper-title"
+                className="w-full max-w-md bg-gray-900 border border-gray-700 rounded-xl p-6 shadow-2xl flex flex-col gap-4"
+            >
+                <div className="flex justify-between items-center border-b border-gray-800 pb-2">
+                    <h2 id="lyric-mapper-title" className="text-xl font-bold font-orbitron text-cyan-400">LYRIC MAPPER</h2>
+                    <button
+                        onClick={onClose}
+                        className="text-gray-400 hover:text-white"
+                        aria-label="Close"
+                    >
+                        ✕
+                    </button>
+                </div>
+
+                <p className="text-sm text-gray-400">
+                    Enter lyrics below. "Map to Selection" will assign consecutive phonemes (slices) to your selected notes.
+                </p>
+
+                <textarea
+                    value={text}
+                    onChange={(e) => setText(e.target.value)}
+                    className="w-full h-32 bg-gray-800 border border-gray-700 rounded p-2 text-white font-mono text-sm focus:border-cyan-500 outline-none resize-none"
+                    placeholder="Enter lyrics here..."
+                    aria-label="Lyrics Input"
+                />
+
+                <div className="flex justify-end gap-2 pt-2">
+                    <button
+                        onClick={() => onApply(text, false)}
+                        disabled={isGenerating}
+                        className="px-4 py-2 bg-gray-800 text-cyan-400 border border-gray-700 rounded hover:bg-gray-700 disabled:opacity-50 text-xs font-bold font-orbitron"
+                    >
+                        {isGenerating ? 'GENERATING...' : 'GENERATE ONLY'}
+                    </button>
+                    <button
+                        onClick={() => onApply(text, true)}
+                        disabled={isGenerating || !hasSelection}
+                        className="px-4 py-2 bg-cyan-900 text-cyan-100 border border-cyan-700 rounded hover:bg-cyan-800 disabled:opacity-50 disabled:cursor-not-allowed text-xs font-bold font-orbitron"
+                        title={!hasSelection ? "Select notes in the sequencer first" : "Generate audio and map phonemes to selection"}
+                    >
+                        GENERATE & MAP
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/components/SamplerPanel.tsx
+++ b/src/components/SamplerPanel.tsx
@@ -15,6 +15,7 @@ interface SamplerPanelProps {
     onOpenEditor?: () => void;
     ttsPhrases: string[];            // Array of 8 TTS phrases
     onTtsPhraseChange: (phrases: string[]) => void; // Update TTS phrases
+    onGenerateTTS?: (text: string) => Promise<void>; // Delegate generation to parent
     onHarmonize?: (bankIndex: number, chordType: string) => Promise<void>; // New prop
     onParamChange?: (bankIndex: number, key: string, value: any) => void;
     loadedBanks?: boolean[];         // Visual indicator for loaded samples
@@ -31,7 +32,7 @@ const grainSizeToPercent = (size: number) => ((size - 441) / (22050 - 441) * 100
 
 const SamplerPanelComponent: React.FC<SamplerPanelProps> = ({
     params, onChange, onLoadSample, audioContext, audioEngine, activeBankIdx, onBankChange, onOpenEditor,
-    ttsPhrases, onTtsPhraseChange,
+    ttsPhrases, onTtsPhraseChange, onGenerateTTS,
     onHarmonize, onParamChange, loadedBanks, sampleBuffer, sliceHighlightRef
 }) => {
     const fileInputRef = useRef<HTMLInputElement>(null);
@@ -241,6 +242,7 @@ const SamplerPanelComponent: React.FC<SamplerPanelProps> = ({
     };
 
     const handleTTS = async () => {
+        if (!onGenerateTTS) return;
         if (!audioContext || !SupertonicService.getInstance().isServiceReady()) {
             setStatus("Engine not ready");
             return;
@@ -249,11 +251,7 @@ const SamplerPanelComponent: React.FC<SamplerPanelProps> = ({
         setIsGenerating(true);
         setStatus("Generating...");
         try {
-            const rawData = await SupertonicService.getInstance().generate(currentTtsText);
-            const buffer = audioContext.createBuffer(1, rawData.length, 44100);
-            buffer.getChannelData(0).set(rawData);
-
-            loadBufferToBank(buffer);
+            await onGenerateTTS(currentTtsText);
             setStatus(`Gen: Bank ${activeBankIdx + 1}`);
         } catch (e) {
             console.error(e);
@@ -689,6 +687,9 @@ export const SamplerPanel = memo(SamplerPanelComponent, (prev, next) => {
 
     // 7. Check sliceHighlightRef (should be stable, but just in case)
     if (prev.sliceHighlightRef !== next.sliceHighlightRef) return false;
+
+    // 8. Check onGenerateTTS
+    if (prev.onGenerateTTS !== next.onGenerateTTS) return false;
 
     return true;
 });

--- a/src/components/__tests__/LyricMapper.test.tsx
+++ b/src/components/__tests__/LyricMapper.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LyricMapper } from '../LyricMapper';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock requestAnimationFrame for useFocusTrap
+beforeEach(() => {
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+        cb(0);
+        return 0;
+    });
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('LyricMapper', () => {
+    const defaultProps = {
+        isOpen: true,
+        onClose: vi.fn(),
+        onApply: vi.fn(),
+        initialText: 'Hello World',
+        isGenerating: false,
+        hasSelection: true,
+    };
+
+    it('renders when open', () => {
+        render(<LyricMapper {...defaultProps} />);
+        expect(screen.getByRole('dialog', { name: 'LYRIC MAPPER' })).toBeDefined();
+        expect(screen.getByRole('textbox', { name: 'Lyrics Input' })).toBeDefined();
+    });
+
+    it('does not render when closed', () => {
+        render(<LyricMapper {...defaultProps} isOpen={false} />);
+        expect(screen.queryByRole('dialog')).toBeNull();
+    });
+
+    it('updates text input', () => {
+        render(<LyricMapper {...defaultProps} />);
+        const textarea = screen.getByRole('textbox', { name: 'Lyrics Input' }) as HTMLTextAreaElement;
+
+        expect(textarea.value).toBe('Hello World');
+
+        fireEvent.change(textarea, { target: { value: 'New Lyrics' } });
+        expect(textarea.value).toBe('New Lyrics');
+    });
+
+    it('calls onApply with false when "Generate Only" is clicked', () => {
+        const onApply = vi.fn();
+        render(<LyricMapper {...defaultProps} onApply={onApply} />);
+
+        fireEvent.click(screen.getByText('GENERATE ONLY'));
+        expect(onApply).toHaveBeenCalledWith('Hello World', false);
+    });
+
+    it('calls onApply with true when "Generate & Map" is clicked', () => {
+        const onApply = vi.fn();
+        render(<LyricMapper {...defaultProps} onApply={onApply} />);
+
+        fireEvent.click(screen.getByText('GENERATE & MAP'));
+        expect(onApply).toHaveBeenCalledWith('Hello World', true);
+    });
+
+    it('disables "Generate & Map" if no selection', () => {
+        render(<LyricMapper {...defaultProps} hasSelection={false} />);
+        const mapBtn = screen.getByText('GENERATE & MAP') as HTMLButtonElement;
+        expect(mapBtn.disabled).toBe(true);
+    });
+
+    it('disables buttons when generating', () => {
+        render(<LyricMapper {...defaultProps} isGenerating={true} />);
+        const genBtn = screen.getByText('GENERATING...') as HTMLButtonElement;
+        const mapBtn = screen.getByText('GENERATE & MAP') as HTMLButtonElement;
+
+        expect(genBtn.disabled).toBe(true);
+        expect(mapBtn.disabled).toBe(true);
+    });
+});


### PR DESCRIPTION
Implemented the Lyric Input feature, allowing users to input text which is then converted to speech (TTS) and mapped to selected sequencer steps in the sampler track. The mapping assigns consecutive MIDI notes (starting from C3/60) to the steps, which triggers consecutive phoneme slices in the `sliceMode: 'phoneme'` playback mode.

---
*PR created automatically by Jules for task [7290766995397640196](https://jules.google.com/task/7290766995397640196) started by @ford442*