### PR TITLE
🎨 Palette: Improve SamplerPanel accessibility and units

### DIFF
--- a/src/components/SamplerPanel.tsx
+++ b/src/components/SamplerPanel.tsx
@@ -635,6 +635,8 @@ const SamplerPanelComponent: React.FC<SamplerPanelProps> = ({
                                         background: `linear-gradient(to right, #9333ea 0%, #9333ea ${grainSizeToPercent(currentParams.grainSize || 4410)}%, #374151 ${grainSizeToPercent(currentParams.grainSize || 4410)}%, #374151 100%)`
                                     }}
                                     aria-label="Grain Size"
+                                    aria-valuetext={grainSizeToMs(currentParams.grainSize || 4410) + 'ms'}
+                                    title="Grain Size"
                                 />
                                 <span className="text-[9px] text-gray-500 w-8 text-right">{grainSizeToMs(currentParams.grainSize || 4410)}ms</span>
                             </div>
@@ -668,9 +670,9 @@ const SamplerPanelComponent: React.FC<SamplerPanelProps> = ({
                     <div className="flex-1 min-w-[140px] bg-gray-800/30 p-2 rounded">
                         <div className="text-[9px] text-gray-500 font-bold mb-1 border-b border-gray-700 pb-0.5">BASIC</div>
                         <div className="grid grid-cols-2 gap-2">
-                            <Knob label="Speed" value={currentParams.playbackSpeed || 1} onChange={handleSpeedChange} min={0.1} max={4.0} color="purple" />
+                            <Knob label="Speed" value={currentParams.playbackSpeed || 1} onChange={handleSpeedChange} min={0.1} max={4.0} color="purple" unit="x" />
                             <Knob label="Vol" value={currentParams.volume} onChange={handleVolumeChange} min={0} max={2.0} color="purple" />
-                            <Knob label="Filter" value={currentParams.filterCutoff} onChange={handleFilterChange} min={100} max={20000} color="purple" logarithmic />
+                            <Knob label="Filter" value={currentParams.filterCutoff} onChange={handleFilterChange} min={100} max={20000} color="purple" logarithmic unit="Hz" />
                             <Knob label="Drive" value={currentParams.drive} onChange={handleDriveChange} min={0} max={1} color="red" />
                         </div>
                     </div>
@@ -679,10 +681,10 @@ const SamplerPanelComponent: React.FC<SamplerPanelProps> = ({
                     <div className="flex-[2] min-w-[200px] bg-indigo-900/50 p-2 rounded">
                         <div className="text-[9px] text-indigo-300 font-bold mb-1 border-b border-indigo-800 pb-0.5">ENGINE</div>
                         <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2">
-                            <Knob label="Time" value={currentParams.timeRatio ?? 1} onChange={handleTimeRatioChange} min={0.5} max={2.0} step={0.01} color="indigo" />
-                            <Knob label="Pitch" value={currentParams.pitchScale ?? 1} onChange={handlePitchScaleChange} min={0.5} max={2.0} step={0.01} color="indigo" />
+                            <Knob label="Time" value={currentParams.timeRatio ?? 1} onChange={handleTimeRatioChange} min={0.5} max={2.0} step={0.01} color="indigo" unit="x" />
+                            <Knob label="Pitch" value={currentParams.pitchScale ?? 1} onChange={handlePitchScaleChange} min={0.5} max={2.0} step={0.01} color="indigo" unit="x" />
                             <Knob label="Formant" value={currentParams.formantShift ?? 0} onChange={handleFormantShiftChange} min={-12} max={12} step={0.1} color="indigo" />
-                            <Knob label="Vibrato" value={currentParams.vibratoDepth ?? 0} onChange={handleVibratoDepthChange} min={0} max={100} color="indigo" />
+                            <Knob label="Vibrato" value={currentParams.vibratoDepth ?? 0} onChange={handleVibratoDepthChange} min={0} max={100} color="indigo" unit="%" />
                             <Knob label="Breath" value={currentParams.breathIntensity ?? 0} onChange={handleBreathIntensityChange} min={0} max={1.0} step={0.01} color="indigo" />
                             <Knob label="Choir" value={currentParams.choir ?? 0} onChange={handleChoirChange} min={0} max={1.0} step={0.01} color="indigo" />
                         </div>

--- a/src/components/__tests__/SamplerPanel.test.tsx
+++ b/src/components/__tests__/SamplerPanel.test.tsx
@@ -65,4 +65,16 @@ describe('SamplerPanel', () => {
         const bank2 = screen.getByRole('tab', { name: 'Select Bank 2' });
         expect(bank2).toBeDefined();
     });
+
+    it('provides accessible value text for Grain Size slider in stretch mode', () => {
+        const stretchParams = { ...defaultBankParams, mode: 'stretch' as const, grainSize: 4410 };
+        const params = Array(8).fill(defaultBankParams);
+        params[0] = stretchParams;
+
+        render(<SamplerPanel {...defaultProps} params={params} activeBankIdx={0} />);
+
+        const slider = screen.getByLabelText('Grain Size');
+        expect(slider).toBeInTheDocument();
+        expect(slider).toHaveAttribute('aria-valuetext', '100ms');
+    });
 });


### PR DESCRIPTION
This PR improves the accessibility and usability of the `SamplerPanel` component.
- The **Grain Size** slider (visible in Stretch mode) now has an accessible `aria-valuetext` attribute, so screen readers announce "100ms" instead of "4410". A `title` tooltip was also added.
- The **Knobs** for Filter, Time, Pitch, Speed, and Vibrato now display their units (Hz, x, %) for better clarity.
- A new test case in `SamplerPanel.test.tsx` ensures the accessibility improvements are verified.

---
*PR created automatically by Jules for task [9747640678783911428](https://jules.google.com/task/9747640678783911428) started by @ford442*