### PR TITLE
Feat: Reverse Step Playback for Sampler

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -18,6 +18,7 @@
 - [x] **Formant Automation:** Implement automation lanes or per-step drawing for formant shift to allow continuous vowel morphing.
 - [x] **Choir Stack:** Implemented 3-voice polyphony for TTS samples (Center, Left+Detune, Right-Detune) to create a rich chorus effect using Rubber Band.
 - [x] **Glitch Mode:** Implemented a probability-based stutter effect ("Glitch") for the sampler, featuring rapid retriggering and randomized timing for both "Stretch" and "Loop" modes.
+- [x] **Reverse Step Playback:** Implemented per-step reverse playback for sampler engine, allowing creative vocal textures via `RubberBandProcessor` reverse streaming.
 
 ### Domain B: Editor Workflow (The "Cubase" Feel)
 - [x] **Slice Mode UI:** Add a toggle in `SamplerPanel` to enable "Phoneme Slice Mode", allowing users to play slices via MIDI keyboard.
@@ -32,6 +33,10 @@
 ### Domain C: Accessibility & Mobile
 - [x] **Touch Targets:** Audit `Sequencer.tsx` click listeners to ensure mobile drag-to-create works smoothly.
 - [ ] **A11y Colors:** Verify high-contrast separation between `synth-1` (Chords) and `synth-2` (Lead) notes.
+- [ ] **Mobile Zoom/Pan:** Implement pinch-to-zoom for the sequencer timeline to handle longer patterns or finer steps.
+
+### Domain D: Generative Tools
+- [ ] **Melodic Euclidean Rhythms:** Generate rhythms based on Euclidean algorithms but map them to a scale.
 
 ---
 
@@ -39,9 +44,8 @@
 *These are concepts to be fleshed out by the agent during "Architect Mode".*
 
 * **Idea:** "One Note per Word" - Advanced mapping in Lyric Input to distribute whole words to steps instead of phonemes.
-* **Idea:** "Reverse Step" - Add a per-step probability to play the sample slice in reverse (requires buffer reversal logic).
-* **Idea:** "Gesture Controls" - Implement pinch-to-zoom for the sequencer timeline to handle longer patterns or finer steps.
-* **Idea:** "Melodic Euclidean Rhythms" - Generate rhythms based on Euclidean algorithms but map them to a scale.
+* **Idea:** "Harmonic Quantization" - Force notes to scale/key during input or playback.
+* **Idea:** "Sample Scrubbing" - Interactive scrubbing of samples in the editor for precise start/end point selection.
 
 ---
 
@@ -62,3 +66,4 @@
 * [2026-06-01] - Implemented Lyric Input (LyricMapper), allowing text entry to auto-generate TTS and map phonemes to selected sequencer steps.
 * [2026-06-02] - Implemented Formant Automation (Automation View), allowing per-step drawing of formant shift and other parameters for the active voice.
 * [2026-06-03] - Implemented Choir Stack (3-voice Polyphony) for TTS, adding detuning and stereo width controls to the Sampler Engine.
+* [2026-06-04] - Implemented Reverse Step Playback (Sampler Engine), enabling per-step reverse playback for creative vocal textures.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -453,7 +453,7 @@ export const App: React.FC = () => {
             const stepData = seq.steps[step];
             if (stepData) {
                 if (stepData.probability !== undefined && Math.random() > stepData.probability) return;
-                const noteParams = { timbre: stepData.timbre, microtiming: stepData.microtiming };
+                const noteParams = { timbre: stepData.timbre, microtiming: stepData.microtiming, reverse: stepData.reverse };
                 audioEngine.playSampler(samplerRef.current[bankIdx], stepData.note, time, stepData.length, stepTime, noteParams);
             }
         });
@@ -848,7 +848,7 @@ export const App: React.FC = () => {
         updateStorageForTrack(trackKey, changedSequence);
     };
 
-    const handleNotePropertyChange = (key: 'timbre' | 'probability' | 'microtiming', value: number) => {
+    const handleNotePropertyChange = (key: 'timbre' | 'probability' | 'microtiming' | 'reverse', value: number | boolean) => {
         if (!contextMenu) return;
         const prev = patternRef.current;
         const copy = JSON.parse(JSON.stringify(prev)) as Pattern;
@@ -865,7 +865,11 @@ export const App: React.FC = () => {
 
         const stepData = stepsArray[stepIndex];
         if (stepData) {
-            stepData[key] = value;
+            if (key === 'reverse') {
+                if (typeof value === 'boolean') stepData.reverse = value;
+            } else {
+                if (typeof value === 'number') stepData[key] = value;
+            }
         }
 
         let changedSequence;
@@ -1222,6 +1226,7 @@ export const App: React.FC = () => {
                             currentTimbre={contextMenu.track === 'sampler' ? pattern.sampler[activeSamplerBank]?.steps[contextMenu.step]?.timbre ?? 0 : pattern?.[contextMenu.track]?.steps?.[contextMenu.step]?.timbre ?? 0}
                             currentProbability={contextMenu.track === 'sampler' ? pattern.sampler[activeSamplerBank]?.steps[contextMenu.step]?.probability ?? 1 : pattern?.[contextMenu.track]?.steps?.[contextMenu.step]?.probability ?? 1}
                             currentMicrotiming={contextMenu.track === 'sampler' ? pattern.sampler[activeSamplerBank]?.steps[contextMenu.step]?.microtiming ?? 0 : pattern?.[contextMenu.track]?.steps?.[contextMenu.step]?.microtiming ?? 0}
+                            currentReverse={contextMenu.track === 'sampler' ? pattern.sampler[activeSamplerBank]?.steps[contextMenu.step]?.reverse ?? false : false}
                             onSelect={handleNoteSelect}
                             onLengthChange={handleNoteLengthChange}
                             onPropertyChange={handleNotePropertyChange}

--- a/src/audio-worklets/rubberband-processor.ts
+++ b/src/audio-worklets/rubberband-processor.ts
@@ -38,7 +38,9 @@ class RubberBandProcessor extends AudioWorkletProcessor {
 
   // Playback State (for Phoneme Elasticity)
   private isPlaying = false;
+  private isReverse = false;
   private currentSamplePtr = 0;
+  private startSamplePtr = 0;
   private endSamplePtr = 0;
 
   // Phoneme Data
@@ -159,9 +161,18 @@ class RubberBandProcessor extends AudioWorkletProcessor {
 
         if (startSample >= endSample) return;
 
+        this.isReverse = !!data.reverse;
+
         // Initialize streaming state
-        this.currentSamplePtr = startSample;
+        this.startSamplePtr = startSample;
         this.endSamplePtr = endSample;
+
+        if (this.isReverse) {
+            this.currentSamplePtr = endSample - 1;
+        } else {
+            this.currentSamplePtr = startSample;
+        }
+
         this.isPlaying = true;
         break;
 
@@ -224,28 +235,52 @@ class RubberBandProcessor extends AudioWorkletProcessor {
         // STREAMING INPUT LOGIC
         // If playing a note, stream from fullSampleBuffer
         if (this.isPlaying && this.fullSampleBuffer) {
-            const samplesRemaining = this.endSamplePtr - this.currentSamplePtr;
-
-            // Only feed if more input is required to generate output
-            // This prevents internal buffer bloat and keeps playback synced
             const samplesRequired = this.rubberBand.getSamplesRequired();
 
-            if (samplesRemaining > 0 && samplesRequired > 0) {
-                // Feed only what is needed, or remaining samples
-                const samplesToFeed = Math.min(samplesRemaining, samplesRequired);
+            if (this.isReverse) {
+                // REVERSE STREAMING
+                const samplesRemaining = this.currentSamplePtr - this.startSamplePtr + 1;
 
-                this.ensureHeapSize(samplesToFeed);
+                if (samplesRemaining > 0 && samplesRequired > 0) {
+                    const samplesToFeed = Math.min(samplesRemaining, samplesRequired);
+                    this.ensureHeapSize(samplesToFeed);
 
-                // Copy directly to WASM heap
-                const slice = this.fullSampleBuffer.subarray(
-                    this.currentSamplePtr,
-                    this.currentSamplePtr + samplesToFeed
-                );
-                this.rubberBand.module.HEAPF32.set(slice, this.inputHeapPtr >> 2);
+                    // Manually copy in reverse order
+                    const heap = this.rubberBand.module.HEAPF32;
+                    const ptr = this.inputHeapPtr >> 2;
+                    const buf = this.fullSampleBuffer;
+                    let readPtr = this.currentSamplePtr;
 
-                this.rubberBand.process(this.inputHeapPtr, samplesToFeed, false);
+                    for (let i = 0; i < samplesToFeed; i++) {
+                        heap[ptr + i] = buf[readPtr--];
+                    }
 
-                this.currentSamplePtr += samplesToFeed;
+                    this.rubberBand.process(this.inputHeapPtr, samplesToFeed, false);
+                    this.currentSamplePtr = readPtr;
+                }
+            } else {
+                // FORWARD STREAMING
+                const samplesRemaining = this.endSamplePtr - this.currentSamplePtr;
+
+                // Only feed if more input is required to generate output
+                // This prevents internal buffer bloat and keeps playback synced
+                if (samplesRemaining > 0 && samplesRequired > 0) {
+                    // Feed only what is needed, or remaining samples
+                    const samplesToFeed = Math.min(samplesRemaining, samplesRequired);
+
+                    this.ensureHeapSize(samplesToFeed);
+
+                    // Copy directly to WASM heap
+                    const slice = this.fullSampleBuffer.subarray(
+                        this.currentSamplePtr,
+                        this.currentSamplePtr + samplesToFeed
+                    );
+                    this.rubberBand.module.HEAPF32.set(slice, this.inputHeapPtr >> 2);
+
+                    this.rubberBand.process(this.inputHeapPtr, samplesToFeed, false);
+
+                    this.currentSamplePtr += samplesToFeed;
+                }
             }
         }
         // Fallback: Streaming from RingBuffer (Real-time input mode)
@@ -282,9 +317,13 @@ class RubberBandProcessor extends AudioWorkletProcessor {
 
             outputChannel.set(outputView);
             this.expressiveProcessor.process(outputChannel, outputChannel);
-        } else if (this.isPlaying && this.currentSamplePtr >= this.endSamplePtr) {
-             // If we finished feeding input and there is no output left, we are done
-             this.isPlaying = false;
+        } else if (this.isPlaying) {
+             // Check for completion
+             if (this.isReverse) {
+                 if (this.currentSamplePtr < this.startSamplePtr) this.isPlaying = false;
+             } else {
+                 if (this.currentSamplePtr >= this.endSamplePtr) this.isPlaying = false;
+             }
         }
 
     } catch (e) {

--- a/src/components/NoteSelector.tsx
+++ b/src/components/NoteSelector.tsx
@@ -16,12 +16,13 @@ interface NoteSelectorProps {
     currentTimbre?: number;
     currentProbability?: number;
     currentMicrotiming?: number;
-    onPropertyChange?: (key: 'timbre' | 'probability' | 'microtiming', value: number) => void;
+    currentReverse?: boolean;
+    onPropertyChange?: (key: 'timbre' | 'probability' | 'microtiming' | 'reverse', value: number | boolean) => void;
 }
 
 export const NoteSelector: React.FC<NoteSelectorProps> = ({
     x, y, trackType, currentNote, currentLength, onSelect, onLengthChange, onClose, getNoteColor,
-    currentTimbre = 0, currentProbability = 1, currentMicrotiming = 0, onPropertyChange
+    currentTimbre = 0, currentProbability = 1, currentMicrotiming = 0, currentReverse = false, onPropertyChange
 }) => {
     // Determine octave range based on track type
     const octaves = trackType === 'synth' ? [2, 3, 4] : [2];
@@ -126,6 +127,21 @@ export const NoteSelector: React.FC<NoteSelectorProps> = ({
                                 onChange={(e) => onPropertyChange('microtiming', parseFloat(e.target.value))}
                                 className="w-full h-2 bg-slate-700 rounded-lg appearance-none cursor-pointer accent-purple-500"
                             />
+                        </div>
+
+                        {/* Reverse Control */}
+                        <div className="flex justify-between items-center text-[10px] text-slate-400 font-bold uppercase py-1">
+                            <label htmlFor="note-reverse">Reverse Sample</label>
+                            <button
+                                id="note-reverse"
+                                onClick={() => onPropertyChange('reverse', !currentReverse)}
+                                className={`w-8 h-4 rounded-full transition-colors flex items-center px-0.5 ${currentReverse ? 'bg-cyan-600 justify-end' : 'bg-slate-700 justify-start'}`}
+                                aria-checked={currentReverse}
+                                role="switch"
+                                title="Play slice in reverse"
+                            >
+                                <div className="w-3 h-3 rounded-full bg-white shadow-sm" />
+                            </button>
                         </div>
                     </>
                 )}

--- a/src/engines/SingingVoice.ts
+++ b/src/engines/SingingVoice.ts
@@ -354,8 +354,9 @@ export class SingingVoice {
      * @param startSample Optional start sample index
      * @param endSample Optional end sample index
      * @param pitch Optional pitch override (default 1.0)
+     * @param reverse Optional reverse playback (default false)
      */
-    play(startSample?: number, endSample?: number, pitch: number = 1.0): void {
+    play(startSample?: number, endSample?: number, pitch: number = 1.0, reverse: boolean = false): void {
         if (!this.workletNode) {
             throw new Error('SingingVoice not initialized. Call initWorklet() first.');
         }
@@ -365,7 +366,8 @@ export class SingingVoice {
             data: {
                 pitch,
                 startSample,
-                endSample
+                endSample,
+                reverse
             }
         });
     }

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -425,7 +425,7 @@ export const useAudioEngine = (pyodide: any, forceScriptProcessor: boolean = fal
                 return vocalAlignmentsRef.current.get(bankName) || null;
             };
 
-            const playSampler = (params: SamplerBankParams, note: string, time: number, durationSteps: number = 1, stepTime: number = 0.2, noteParams?: { timbre?: number, microtiming?: number }) => {
+            const playSampler = (params: SamplerBankParams, note: string, time: number, durationSteps: number = 1, stepTime: number = 0.2, noteParams?: { timbre?: number, microtiming?: number, reverse?: boolean }) => {
                 const buffer = loadedSampleBuffersRef.current.get(params.sampleName);
                 if (!buffer || !masterGainRef.current) return;
 
@@ -494,7 +494,7 @@ export const useAudioEngine = (pyodide: any, forceScriptProcessor: boolean = fal
                         }
 
                         // 4. Play (Buffer assumed loaded)
-                        voice.play(undefined, undefined, 1.0);
+                        voice.play(undefined, undefined, 1.0, noteParams?.reverse);
                     };
 
                     // Load buffer ONCE for the voice(s)

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,7 @@ export interface Note {
   timbre?: number; // 0-1, tonal character (filter/formant)
   probability?: number; // 0-1, chance of triggering
   microtiming?: number; // -0.5 to 0.5 steps, rhythmic offset
+  reverse?: boolean; // Play sample in reverse (Sampler only)
 }
 
 export interface PartSequence {
@@ -122,7 +123,7 @@ export interface AudioEngine {
     open303Engine?: Open303Oscillator | null;
     playSynth: (params: SynthParams, note: string | string[], time: number, durationSteps?: number, stepTime?: number, slideFromFreq?: number, track?: 'partA' | 'partB', noteParams?: { timbre?: number, microtiming?: number }) => void;
     playDrum: (sound: DrumSound, params: KickParams | SnareParams | HatParams, time: number) => void;
-    playSampler: (params: SamplerBankParams, note: string, time: number, durationSteps?: number, stepTime?: number, noteParams?: { timbre?: number, microtiming?: number }) => void;
+    playSampler: (params: SamplerBankParams, note: string, time: number, durationSteps?: number, stepTime?: number, noteParams?: { timbre?: number, microtiming?: number, reverse?: boolean }) => void;
     noteOnSampler?: (params: SamplerBankParams, note: string, time?: number) => number | null;
     noteOffSampler?: (id: number) => void;
     noteOnSynth?: (params: SynthParams, note: string, time?: number, track?: 'partA' | 'partB') => Promise<number | null> | number | null;


### PR DESCRIPTION
Implemented per-step reverse playback for the Sampler engine. This allows users to toggle a "Reverse" flag for individual steps in the sequencer via the Note Selector context menu. The audio engine (RubberBandProcessor) handles this by streaming the sample buffer in reverse order to the time-stretcher, enabling reverse playback while maintaining time-stretching capabilities.

Key changes:
- `Note` type now includes `reverse?: boolean`.
- `RubberBandProcessor` supports `isReverse` state and reverse buffer copying.
- `NoteSelector` UI includes a toggle for the reverse property.
- `App` handles `reverse` property updates and passes them to the audio engine.

---
*PR created automatically by Jules for task [10810560075034411609](https://jules.google.com/task/10810560075034411609) started by @ford442*