### PR TITLE
🎨 Palette: Add keyboard support to automation sliders

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -53,3 +53,7 @@
 ## 2025-05-26 - Keyboard Value Control in Sequencer Grids
 **Learning:** Grid-based sequencer inputs often rely on mouse drag for value selection, leaving keyboard users with only binary (toggle) control via Enter/Space. This excludes them from precise musical expression (e.g., selecting specific patterns).
 **Action:** Implement `ArrowUp`/`ArrowDown` handlers on grid cells to increment/decrement values, and `Delete`/`Backspace` to clear them, ensuring functional parity with mouse interactions.
+
+## 2025-05-27 - SVG Slider Interaction
+**Learning:** Custom SVG elements with `role="slider"` and `tabIndex="0"` are focusable but do not automatically handle keyboard interactions like native inputs. Developers must manually implement `onKeyDown` handlers for Arrow keys, Home, and End to ensure accessibility.
+**Action:** Always implement a `handleKeyDown` function for custom SVG sliders that supports standard ARIA slider keys (ArrowUp/Down, PageUp/Down, Home, End).

--- a/src/components/MainSequencer.tsx
+++ b/src/components/MainSequencer.tsx
@@ -44,7 +44,7 @@ const getPatternColor = (slotIndex: number): string => {
 
 // --- COMPONENTS ---
 
-const AutomationStep = memo(({
+export const AutomationStep = memo(({
     stepIndex, value, rowKey, rowLabel, onChange, refsArray
 }: {
     stepIndex: number, value: number, rowKey: TrackKey, rowLabel: string,
@@ -60,6 +60,39 @@ const AutomationStep = memo(({
     // Calculate bar height based on value (0-1)
     const barHeight = Math.max(2, value * height);
     const y = height - barHeight;
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        let newValue = value;
+        let handled = false;
+        const smallStep = 0.05;
+        const largeStep = 0.2;
+
+        if (e.key === 'ArrowUp' || e.key === 'ArrowRight') {
+            newValue = Math.min(1, value + smallStep);
+            handled = true;
+        } else if (e.key === 'ArrowDown' || e.key === 'ArrowLeft') {
+            newValue = Math.max(0, value - smallStep);
+            handled = true;
+        } else if (e.key === 'PageUp') {
+            newValue = Math.min(1, value + largeStep);
+            handled = true;
+        } else if (e.key === 'PageDown') {
+            newValue = Math.max(0, value - largeStep);
+            handled = true;
+        } else if (e.key === 'Home') {
+            newValue = 0;
+            handled = true;
+        } else if (e.key === 'End') {
+            newValue = 1;
+            handled = true;
+        }
+
+        if (handled) {
+            e.preventDefault();
+            e.stopPropagation();
+            onChange(rowKey, stepIndex, newValue);
+        }
+    };
 
     const handlePointerDown = (e: React.PointerEvent) => {
         e.preventDefault();
@@ -103,9 +136,11 @@ const AutomationStep = memo(({
             role="slider"
             aria-label={`${rowLabel} automation step ${stepIndex + 1}`}
             aria-valuenow={Math.round(value * 100)}
+            aria-valuetext={`${Math.round(value * 100)}%`}
             tabIndex={0}
             cursor="ns-resize"
             onPointerDown={handlePointerDown}
+            onKeyDown={handleKeyDown}
         >
             {/* Background container for click area */}
             <rect x={0} y={0} width={baseWidth} height={height} rx={2} fill="#111" fillOpacity={0.8} />

--- a/src/components/__tests__/AutomationStepA11y.test.tsx
+++ b/src/components/__tests__/AutomationStepA11y.test.tsx
@@ -1,0 +1,74 @@
+import React, { useRef } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { AutomationStep } from '../MainSequencer';
+import type { TrackKey } from '../../types';
+
+// Define props for TestWrapper based on AutomationStep props
+interface AutomationStepProps {
+    stepIndex: number;
+    value: number;
+    rowKey: TrackKey;
+    rowLabel: string;
+    onChange: (k: TrackKey, i: number, val: number) => void;
+}
+
+// Wrapper component to provide refs and SVG context
+const TestWrapper = (props: AutomationStepProps) => {
+    const refsArray = useRef<(SVGGElement | null)[]>([]);
+    return (
+        <svg>
+            <AutomationStep {...props} refsArray={refsArray} />
+        </svg>
+    );
+};
+
+describe('AutomationStep Accessibility', () => {
+    const defaultProps = {
+        stepIndex: 0,
+        value: 0.5,
+        rowKey: 'partA' as TrackKey,
+        rowLabel: 'Lead',
+        onChange: vi.fn(),
+    };
+
+    it('renders with correct accessibility attributes', () => {
+        render(<TestWrapper {...defaultProps} />);
+        const slider = screen.getByRole('slider');
+
+        expect(slider).toHaveAttribute('aria-label', 'Lead automation step 1');
+        expect(slider).toHaveAttribute('aria-valuenow', '50');
+        expect(slider).toHaveAttribute('aria-valuetext', '50%');
+        expect(slider).toHaveAttribute('tabindex', '0');
+    });
+
+    it('responds to keyboard interactions', () => {
+        render(<TestWrapper {...defaultProps} />);
+        const slider = screen.getByRole('slider');
+        slider.focus();
+
+        // Arrow Up -> Increment (Small Step)
+        fireEvent.keyDown(slider, { key: 'ArrowUp' });
+        expect(defaultProps.onChange).toHaveBeenCalledWith('partA', 0, expect.closeTo(0.55, 1));
+
+        // Arrow Down -> Decrement (Small Step)
+        fireEvent.keyDown(slider, { key: 'ArrowDown' });
+        expect(defaultProps.onChange).toHaveBeenCalledWith('partA', 0, expect.closeTo(0.45, 1));
+
+        // Page Up -> Large Increment
+        fireEvent.keyDown(slider, { key: 'PageUp' });
+        expect(defaultProps.onChange).toHaveBeenCalledWith('partA', 0, expect.closeTo(0.7, 1));
+
+        // Page Down -> Large Decrement
+        fireEvent.keyDown(slider, { key: 'PageDown' });
+        expect(defaultProps.onChange).toHaveBeenCalledWith('partA', 0, expect.closeTo(0.3, 1));
+
+        // Home -> Min
+        fireEvent.keyDown(slider, { key: 'Home' });
+        expect(defaultProps.onChange).toHaveBeenCalledWith('partA', 0, 0);
+
+        // End -> Max
+        fireEvent.keyDown(slider, { key: 'End' });
+        expect(defaultProps.onChange).toHaveBeenCalledWith('partA', 0, 1);
+    });
+});


### PR DESCRIPTION
💡 What: Added keyboard support to the automation sliders in the Main Sequencer.
🎯 Why: Previously, these sliders were mouse-only (drag), making them inaccessible to keyboard users and screen readers despite having `role="slider"`.
♿ Accessibility:
- Added ArrowUp/Right (+0.05) and ArrowDown/Left (-0.05) support.
- Added PageUp (+0.2) and PageDown (-0.2) support.
- Added Home (Min) and End (Max) support.
- Added `aria-valuetext` to announce the value as a percentage.


---
*PR created automatically by Jules for task [17993440356158749771](https://jules.google.com/task/17993440356158749771) started by @ford442*