### PR TITLE
Add aria-busy to AI Song Modal import button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -23,3 +23,7 @@
 ## 2024-05-18 - Missing Focus Visible States on Custom Switches
 **Learning:** Custom UI controls that mimic native inputs (like pill-shaped switches for Reverse or Melodic Mode) frequently omit `focus-visible` styles, rendering them completely invisible to keyboard users when tabbing through the interface. Furthermore, developers frequently mistakenly use `aria-pressed` with `role="button"` instead of the correct `role="switch"` with `aria-checked` for these pill-shaped components.
 **Action:** Always verify that interactive custom switches not only have appropriate ARIA roles (`role="switch"`, `aria-checked`) but explicitly define `focus:outline-none focus-visible:ring-*` classes.
+
+## 2024-04-10 - Standardization of aria-busy on Async Import Buttons
+**Learning:** Discovered an inconsistency where some background task buttons (like the AI Song Import button) lacked the `aria-busy` attribute, while others (like RbsImportModal and SamplerPanel) correctly used it to inform screen readers of processing states.
+**Action:** Applied `aria-busy={isImporting}` to the AI Song Import button to standardise asynchronous feedback mechanisms for accessibility across all modal interfaces.

--- a/src/components/AISongModal.tsx
+++ b/src/components/AISongModal.tsx
@@ -1347,6 +1347,7 @@ export function AISongModal({ isOpen, onClose, onImport, onShowToast, audioEngin
               <button
                 onClick={handleImport}
                 disabled={!parsedData || isImporting}
+                aria-busy={isImporting}
                 className={`px-3 sm:px-4 py-2 text-xs font-medium rounded transition-all flex items-center gap-2 disabled:cursor-not-allowed ${
                   parsedData && !isImporting
                     ? 'bg-emerald-600 hover:bg-emerald-500 text-white shadow-[0_0_20px_rgba(16,185,129,0.3)] hover:shadow-[0_0_30px_rgba(16,185,129,0.5)]'


### PR DESCRIPTION
The "Import Song" button within `AISongModal.tsx` handles asynchronous song parsing and importing. While it visually indicated its loading state and disabled itself appropriately, it lacked the semantic `aria-busy` attribute. This change standardises the UX across the repository by explicitly exposing the busy state to assistive technologies, making the application more accessible.

I also added an entry to `.Jules/palette.md` noting the standardization of `aria-busy` for background import processes.

---
*PR created automatically by Jules for task [15545524829121002300](https://jules.google.com/task/15545524829121002300) started by @ford442*