### PR TITLE
🎨 Palette: Add missing tabpanel roles to tabbed interfaces

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-04-13 - Add aria-busy to processing buttons
 **Learning:** Buttons that represent an asynchronous or intensive background process (such as rendering/mixdown or AI processing) should be explicitly marked with `aria-busy` to let screen reader users know that the system is doing work.
 **Action:** When a button handles "Rendering..." or similar delayed states, ensure `aria-busy={isRendering}` or equivalent is added alongside `disabled={isRendering}`.
+
+## 2025-04-13 - Add role="tabpanel" to custom tabbed interfaces
+**Learning:** When implementing custom tabbed interfaces using `role="tablist"` and `role="tab"`, the corresponding content container must have `role="tabpanel"`, a unique `id` that matches the `aria-controls` attribute of the active tab, and an `aria-labelledby` attribute pointing to the active tab's `id`. This ensures screen reader users understand the relationship between the tabs and the content.
+**Action:** Always verify that every `role="tablist"` has an associated `role="tabpanel"` wrapping the displayed content.

--- a/src/components/SamplerPanel.tsx
+++ b/src/components/SamplerPanel.tsx
@@ -640,7 +640,12 @@ const SamplerPanelComponent: React.FC<SamplerPanelProps> = ({
             </div>
 
             {/* --- SCROLLABLE CONTENT --- */}
-            <div className="flex-1 overflow-y-auto p-2 space-y-2 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-gray-700">
+            <div
+                id="sampler-bank-panel"
+                role="tabpanel"
+                aria-labelledby={`sampler-bank-tab-${activeBankIdx}`}
+                className="flex-1 overflow-y-auto p-2 space-y-2 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-gray-700"
+            >
 
                 {/* 1. Waveform Visualization */}
                 <WaveformDisplay


### PR DESCRIPTION
💡 **What:** Added `role="tabpanel"`, `id="sampler-bank-panel"`, and `aria-labelledby` attributes to the scrollable content container in the `SamplerPanel` component.
🎯 **Why:** To fix an accessibility violation where a custom tabbed interface (`role="tablist"`) lacked the corresponding `role="tabpanel"` for its content. This change ensures screen reader users understand the relationship between the active bank tab and the displayed content.
♿ **Accessibility:** Completes the ARIA tablist pattern for the `SamplerPanel` interface.

Also recorded this learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [5210245565283228395](https://jules.google.com/task/5210245565283228395) started by @ford442*