### PR TITLE
🎨 Palette: Keyboard Accessibility for Custom Radio Groups

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-04-13 - Add role="tabpanel" to custom tabbed interfaces
 **Learning:** When implementing custom tabbed interfaces using `role="tablist"` and `role="tab"`, the corresponding content container must have `role="tabpanel"`, a unique `id` that matches the `aria-controls` attribute of the active tab, and an `aria-labelledby` attribute pointing to the active tab's `id`. This ensures screen reader users understand the relationship between the tabs and the content.
 **Action:** Always verify that every `role="tablist"` has an associated `role="tabpanel"` wrapping the displayed content.
+
+## 2025-04-17 - Add keyboard navigation to custom ARIA radio groups
+**Learning:** When implementing custom radio button groups using `role="radiogroup"` and `role="radio"`, it is not enough to just add the ARIA attributes and a click handler. Screen reader users expect standard radio group keyboard behavior: the arrow keys should move focus and instantly select the adjacent radio button in the group. Additionally, the roving `tabIndex` pattern must be used where only the currently selected radio has `tabIndex={0}` and the others have `tabIndex={-1}`.
+**Action:** When building or modifying custom radio groups (like the Retrigger selector in NoteSelector or Voice Count in Harmonizer), always add an `onKeyDown` handler to support `ArrowRight`/`ArrowDown` (next) and `ArrowLeft`/`ArrowUp` (previous) navigation, prevent the default scrolling behavior, update the selected state, and programmatically move focus to the new element.


### PR DESCRIPTION
💡 **What**: Added proper keyboard navigation support for custom radio groups in `HarmonizerPopover.tsx` (Voice Count and Harmony Type) and `NoteSelector.tsx` (Retrigger).

🎯 **Why**: Previously, assistive technology users could not navigate between these radio buttons using standard arrow key patterns, which violates standard ARIA `role="radiogroup"` behavior and makes the controls inaccessible to keyboard users.

📸 **Before/After**: Visually identical, but the `tabIndex` now updates automatically (`0` for the active radio, `-1` for inactive), and pressing Left/Up or Right/Down arrows while focused will automatically cycle selection and focus.

♿ **Accessibility**: 
- Added `onKeyDown` handlers for `ArrowUp`, `ArrowDown`, `ArrowLeft`, and `ArrowRight` to properly change selection and programmatically move focus.
- Converted `tabIndex` to use the roving pattern (`0` for active, `-1` for inactive).
- Replaced `aria-pressed` with `aria-checked` on radios, as that is the standard state for `role="radio"`.
- Added missing `id` attributes to buttons for robust focusing via `document.getElementById()`.
- Updated `role="group"` to `role="radiogroup"` in `NoteSelector.tsx` to match the child `role="radio"`.

---
*PR created automatically by Jules for task [18200434778025539060](https://jules.google.com/task/18200434778025539060) started by @ford442*