### PR TITLE
🎨 Palette: Fix orphaned aria-describedby references in modals

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-04-17 - Add keyboard navigation to custom ARIA radio groups
 **Learning:** When implementing custom radio button groups using `role="radiogroup"` and `role="radio"`, it is not enough to just add the ARIA attributes and a click handler. Screen reader users expect standard radio group keyboard behavior: the arrow keys should move focus and instantly select the adjacent radio button in the group. Additionally, the roving `tabIndex` pattern must be used where only the currently selected radio has `tabIndex={0}` and the others have `tabIndex={-1}`.
 **Action:** When building or modifying custom radio groups (like the Retrigger selector in NoteSelector or Voice Count in Harmonizer), always add an `onKeyDown` handler to support `ArrowRight`/`ArrowDown` (next) and `ArrowLeft`/`ArrowUp` (previous) navigation, prevent the default scrolling behavior, update the selected state, and programmatically move focus to the new element.
+
+## 2025-04-18 - Fix orphaned aria-describedby references
+**Learning:** When using `aria-describedby` on a modal dialog (or any element), the `id` it points to must actually exist in the DOM. If the ID is missing (orphaned), screen readers will silently fail to read the crucial contextual information intended for the user (e.g., loading states, instructions).
+**Action:** Always verify that the string provided to `aria-describedby` perfectly matches an `id` attribute on the element containing the descriptive text.

--- a/src/components/AISongModal.tsx
+++ b/src/components/AISongModal.tsx
@@ -664,7 +664,7 @@ export function AISongModal({ isOpen, onClose, onImport, onShowToast, audioEngin
       <div 
         role="dialog"
         aria-modal="true"
-        aria-labelledby="ai-song-modal-title"
+        aria-labelledby="ai-song-modal-title" aria-describedby="ai-song-modal-desc"
         className="relative z-10 bg-[#0f1115] border border-emerald-500/30 rounded-xl shadow-[0_0_60px_rgba(16,185,129,0.2)] w-full max-w-3xl max-h-[95vh] sm:max-h-[90vh] flex flex-col animate-in fade-in zoom-in-95 duration-200"
         onDragEnter={handleDragEnter}
         onDragLeave={handleDragLeave}
@@ -679,7 +679,7 @@ export function AISongModal({ isOpen, onClose, onImport, onShowToast, audioEngin
             </div>
             <div>
               <h2 id="ai-song-modal-title" className="text-base sm:text-lg font-bold text-white">Import AI Song</h2>
-              <p className="text-[10px] sm:text-xs text-gray-400 hidden sm:block">Import songs from Claude, Gemini, Jules, Copilot, etc.</p>
+              <p id="ai-song-modal-desc" className="text-[10px] sm:text-xs text-gray-400 hidden sm:block">Import songs from Claude, Gemini, Jules, Copilot, etc.</p>
             </div>
           </div>
           <Tooltip text="Close (Esc)" position="bottom">

--- a/src/components/CloudLibrary.tsx
+++ b/src/components/CloudLibrary.tsx
@@ -198,12 +198,13 @@ export const CloudLibrary: React.FC<CloudLibraryProps> = ({
                 className="w-full max-w-2xl z-10 bg-[#0f1215] border border-cyan-900/50 rounded-xl shadow-[0_0_50px_rgba(6,182,212,0.2)] overflow-hidden flex flex-col max-h-[80vh]"
                 role="dialog"
                 aria-modal="true"
-                aria-labelledby="cloud-library-title"
+                aria-labelledby="cloud-library-title" aria-describedby="cloud-library-desc"
                 tabIndex={-1}
             >
 
                 {/* Header Tabs */}
                 <h2 id="cloud-library-title" className="sr-only">Cloud Library</h2>
+                <p id="cloud-library-desc" className="sr-only">Browse, upload, and download songs, patterns, and sample banks from the cloud.</p>
                 <div
                     className="flex border-b border-gray-800 bg-gray-900/50"
                     role="tablist"

--- a/src/components/GamepadDebugger.tsx
+++ b/src/components/GamepadDebugger.tsx
@@ -27,7 +27,7 @@ export const GamepadDebugger: React.FC<{ onClose: () => void }> = ({ onClose }) 
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm p-4 overflow-y-auto" onClick={onClose}>
       <div aria-hidden="true" className="absolute inset-0 z-0"></div>
-      <div className="bg-slate-900 border border-slate-700 rounded-xl shadow-2xl w-full max-w-5xl p-6 relative" role="dialog" aria-modal="true" aria-labelledby="gamepad-debugger-title" ref={modalRef} onClick={e => e.stopPropagation()}>
+      <div className="bg-slate-900 border border-slate-700 rounded-xl shadow-2xl w-full max-w-5xl p-6 relative" role="dialog" aria-modal="true" aria-labelledby="gamepad-debugger-title" aria-describedby="gamepad-debugger-desc" ref={modalRef} onClick={e => e.stopPropagation()}>
         <button
           onClick={onClose}
           className="absolute top-4 right-4 text-slate-400 hover:text-white"
@@ -44,15 +44,18 @@ export const GamepadDebugger: React.FC<{ onClose: () => void }> = ({ onClose }) 
         </h2>
 
         {gamepads.length === 0 ? (
-           <div className="text-center py-12 text-slate-500 border-2 border-dashed border-slate-800 rounded-lg">
+           <div id="gamepad-debugger-desc" className="text-center py-12 text-slate-500 border-2 border-dashed border-slate-800 rounded-lg">
              No Gamepads Detected. Press a button to wake them up.
            </div>
         ) : (
-          <div className="grid grid-cols-1 gap-6">
+          <>
+            <div id="gamepad-debugger-desc" className="sr-only">Displays real-time state of connected gamepads including buttons and axes.</div>
+            <div className="grid grid-cols-1 gap-6">
             {gamepads.map((gp) => (
               <GamepadCard key={gp.index} gamepad={gp} />
             ))}
-          </div>
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -72,7 +72,7 @@ export const LoadingOverlay: React.FC<LoadingOverlayProps> = ({ isVisible, onCom
           >
             HYPHON
           </h1>
-          <p className="text-gray-400 font-mono text-sm tracking-wide">INITIALIZING AUDIO ENGINE</p>
+          <p id="loading-desc" className="text-gray-400 font-mono text-sm tracking-wide">INITIALIZING AUDIO ENGINE</p>
         </div>
 
         {/* Progress Bar Container */}

--- a/src/components/RbsImportModal.tsx
+++ b/src/components/RbsImportModal.tsx
@@ -390,7 +390,7 @@ export function RbsImportModal({ isOpen, onClose, onImport, onShowToast }: RbsIm
         onClick={onClose}
         aria-hidden="true"
       />
-      <div role="dialog" aria-modal="true" aria-labelledby="rbs-import-title" className="relative z-10 bg-[#0f1115] border border-amber-500/30 rounded-xl shadow-[0_0_60px_rgba(245,158,11,0.2)] w-full max-w-4xl max-h-[90vh] flex flex-col">
+      <div role="dialog" aria-modal="true" aria-labelledby="rbs-import-title" aria-describedby="rbs-import-desc" className="relative z-10 bg-[#0f1115] border border-amber-500/30 rounded-xl shadow-[0_0_60px_rgba(245,158,11,0.2)] w-full max-w-4xl max-h-[90vh] flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-gray-800">
           <div className="flex items-center gap-3">
@@ -399,7 +399,7 @@ export function RbsImportModal({ isOpen, onClose, onImport, onShowToast }: RbsIm
             </div>
             <div>
               <h2 id="rbs-import-title" className="text-lg font-bold text-white">Import ReBirth RB-338 File</h2>
-              <p className="text-xs text-gray-400">Import .rbs pattern files from ReBirth RB-338</p>
+              <p id="rbs-import-desc" className="text-xs text-gray-400">Import .rbs pattern files from ReBirth RB-338</p>
             </div>
           </div>
           <button

--- a/src/components/ShortcutsHelp.tsx
+++ b/src/components/ShortcutsHelp.tsx
@@ -59,7 +59,7 @@ export const ShortcutsHelp: React.FC<ShortcutsHelpProps> = ({ onClose }) => {
                 className="w-full max-w-2xl z-10 bg-[#0f1215] border border-cyan-900/50 rounded-xl shadow-[0_0_50px_rgba(6,182,212,0.2)] overflow-hidden flex flex-col max-h-[80vh]"
                 role="dialog"
                 aria-modal="true"
-                aria-labelledby="shortcuts-title"
+                aria-labelledby="shortcuts-title" aria-describedby="shortcuts-desc"
                 tabIndex={-1}
             >
                 {/* Header */}
@@ -78,7 +78,7 @@ export const ShortcutsHelp: React.FC<ShortcutsHelpProps> = ({ onClose }) => {
                 </div>
 
                 {/* Content */}
-                <div className="p-6 overflow-y-auto custom-scrollbar">
+                <div id="shortcuts-desc" className="p-6 overflow-y-auto custom-scrollbar" aria-label="List of available keyboard shortcuts grouped by section">
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                         {sections.map((section) => (
                             <div key={section.title} className="bg-gray-800/20 rounded-lg p-4 border border-gray-800">


### PR DESCRIPTION
🎨 Palette: Fix orphaned aria-describedby references in modals

- Fix orphaned `aria-describedby` in `LoadingOverlay.tsx`
- Add valid target IDs for `aria-describedby` attributes in `AISongModal.tsx`, `GamepadDebugger.tsx`, `ShortcutsHelp.tsx`, `CloudLibrary.tsx`, and `RbsImportModal.tsx`
- Resolved JSX fragment syntax error in `GamepadDebugger.tsx`
- Added missing `id` tags to elements containing description text for these modals
- Updated `palette.md` with learning about orphaned aria-describedby references

---
*PR created automatically by Jules for task [7216807180838325070](https://jules.google.com/task/7216807180838325070) started by @ford442*