### PR TITLE
🎨 Palette: Replace checkboxes with accessible ARIA switches

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-04-18 - Fix orphaned aria-describedby references
 **Learning:** When using `aria-describedby` on a modal dialog (or any element), the `id` it points to must actually exist in the DOM. If the ID is missing (orphaned), screen readers will silently fail to read the crucial contextual information intended for the user (e.g., loading states, instructions).
 **Action:** Always verify that the string provided to `aria-describedby` perfectly matches an `id` attribute on the element containing the descriptive text.
+
+## 2025-04-19 - Replace native checkboxes with ARIA switches for toggle actions
+**Learning:** Native `<input type="checkbox">` elements, when used for immediate state toggles (like "Lock to Seq" or import configuration options), can feel clunky and lack the visual affordance of a modern switch. More importantly, when visually hidden or improperly styled, they can lose native keyboard focus indicators, impairing accessibility.
+**Action:** Always implement custom UI toggle switches using `<button type="button" role="switch" aria-checked={state}>` accompanied by explicit Tailwind `focus-visible` classes (e.g., `focus-visible:ring-2`) and clear `aria-labelledby` linking to their labels. This provides both a polished look and robust screen reader/keyboard support.

--- a/src/components/RbsImportModal.tsx
+++ b/src/components/RbsImportModal.tsx
@@ -744,37 +744,91 @@ export function RbsImportModal({ isOpen, onClose, onImport, onShowToast }: RbsIm
                 {showOptions && (
                   <div id="import-options-panel" className="p-4 space-y-4 bg-gray-900/30">
                     {/* Expand Steps */}
-                    <label className="flex items-center justify-between">
-                      <span className="text-sm text-gray-400">Expand 16 → 32 steps</span>
-                      <input
-                        type="checkbox"
-                        checked={importOptions.expandTo32Steps}
-                        onChange={(e) => updateOption('expandTo32Steps', e.target.checked)}
-                        className="w-4 h-4 rounded border-gray-600 bg-gray-800 text-amber-500 focus:ring-amber-500/50"
-                      />
-                    </label>
+                    <div
+                      className="flex items-center justify-between cursor-pointer"
+                      onClick={() => updateOption('expandTo32Steps', !importOptions.expandTo32Steps)}
+                    >
+                      <span id="expand-label" className="text-sm text-gray-400 select-none">Expand 16 → 32 steps</span>
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-checked={importOptions.expandTo32Steps}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          updateOption('expandTo32Steps', !importOptions.expandTo32Steps);
+                        }}
+                        aria-labelledby="expand-label"
+                        className={`relative inline-flex h-4 w-8 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 focus-visible:ring-offset-gray-900 ${
+                          importOptions.expandTo32Steps ? 'bg-amber-600' : 'bg-gray-800'
+                        }`}
+                      >
+                        <span className="sr-only">Expand 16 to 32 steps</span>
+                        <span
+                          aria-hidden="true"
+                          className={`pointer-events-none inline-block h-3 w-3 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                            importOptions.expandTo32Steps ? 'translate-x-4' : 'translate-x-0'
+                          }`}
+                        />
+                      </button>
+                    </div>
 
                     {/* Import Swing */}
-                    <label className="flex items-center justify-between">
-                      <span className="text-sm text-gray-400">Import swing settings</span>
-                      <input
-                        type="checkbox"
-                        checked={importOptions.importSwing}
-                        onChange={(e) => updateOption('importSwing', e.target.checked)}
-                        className="w-4 h-4 rounded border-gray-600 bg-gray-800 text-amber-500 focus:ring-amber-500/50"
-                      />
-                    </label>
+                    <div
+                      className="flex items-center justify-between cursor-pointer"
+                      onClick={() => updateOption('importSwing', !importOptions.importSwing)}
+                    >
+                      <span id="swing-label" className="text-sm text-gray-400 select-none">Import swing settings</span>
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-checked={importOptions.importSwing}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          updateOption('importSwing', !importOptions.importSwing);
+                        }}
+                        aria-labelledby="swing-label"
+                        className={`relative inline-flex h-4 w-8 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 focus-visible:ring-offset-gray-900 ${
+                          importOptions.importSwing ? 'bg-amber-600' : 'bg-gray-800'
+                        }`}
+                      >
+                        <span className="sr-only">Import swing settings</span>
+                        <span
+                          aria-hidden="true"
+                          className={`pointer-events-none inline-block h-3 w-3 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                            importOptions.importSwing ? 'translate-x-4' : 'translate-x-0'
+                          }`}
+                        />
+                      </button>
+                    </div>
 
                     {/* Convert PCF */}
-                    <label className="flex items-center justify-between">
-                      <span className="text-sm text-gray-400">Convert PCF to automation</span>
-                      <input
-                        type="checkbox"
-                        checked={importOptions.convertPcfToAutomation}
-                        onChange={(e) => updateOption('convertPcfToAutomation', e.target.checked)}
-                        className="w-4 h-4 rounded border-gray-600 bg-gray-800 text-amber-500 focus:ring-amber-500/50"
-                      />
-                    </label>
+                    <div
+                      className="flex items-center justify-between cursor-pointer"
+                      onClick={() => updateOption('convertPcfToAutomation', !importOptions.convertPcfToAutomation)}
+                    >
+                      <span id="pcf-label" className="text-sm text-gray-400 select-none">Convert PCF to automation</span>
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-checked={importOptions.convertPcfToAutomation}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          updateOption('convertPcfToAutomation', !importOptions.convertPcfToAutomation);
+                        }}
+                        aria-labelledby="pcf-label"
+                        className={`relative inline-flex h-4 w-8 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 focus-visible:ring-offset-gray-900 ${
+                          importOptions.convertPcfToAutomation ? 'bg-amber-600' : 'bg-gray-800'
+                        }`}
+                      >
+                        <span className="sr-only">Convert PCF to automation</span>
+                        <span
+                          aria-hidden="true"
+                          className={`pointer-events-none inline-block h-3 w-3 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                            importOptions.convertPcfToAutomation ? 'translate-x-4' : 'translate-x-0'
+                          }`}
+                        />
+                      </button>
+                    </div>
 
                     {/* Drum Kit */}
                     <div className="flex items-center justify-between">

--- a/src/components/SamplerPitchControls.tsx
+++ b/src/components/SamplerPitchControls.tsx
@@ -264,17 +264,35 @@ export const SamplerPitchControls: React.FC<SamplerPitchControlsProps> = ({
           </div>
 
           {/* Auto Follow Checkbox */}
-          <div className="flex items-center gap-2 mt-1">
-            <input
+          <div
+            className="flex items-center gap-2 mt-1 cursor-pointer"
+            onClick={() => onChange('autoFollow', !values.autoFollow)}
+          >
+            <button
+              type="button"
+              role="switch"
+              aria-checked={values.autoFollow}
               id={autoFollowId}
-              type="checkbox"
-              checked={values.autoFollow}
-              onChange={(e) => onChange('autoFollow', e.target.checked)}
-              className="w-3 h-3 rounded border-gray-600 text-purple-600 focus:ring-purple-500 bg-gray-800 cursor-pointer"
-            />
-            <label htmlFor={autoFollowId} className="text-[10px] text-gray-300 cursor-pointer hover:text-white transition-colors leading-none select-none">
+              onClick={(e) => {
+                e.stopPropagation();
+                onChange('autoFollow', !values.autoFollow);
+              }}
+              className={`relative inline-flex h-3 w-6 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-1 focus-visible:ring-offset-gray-900 ${
+                values.autoFollow ? 'bg-purple-600' : 'bg-gray-800'
+              }`}
+              aria-labelledby={`${autoFollowId}-label`}
+            >
+              <span className="sr-only">Lock to Sequence</span>
+              <span
+                aria-hidden="true"
+                className={`pointer-events-none inline-block h-2 w-2 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                  values.autoFollow ? 'translate-x-3' : 'translate-x-0'
+                }`}
+              />
+            </button>
+            <span id={`${autoFollowId}-label`} className="text-[10px] text-gray-300 hover:text-white transition-colors leading-none select-none">
               Lock to Seq
-            </label>
+            </span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Replaced native checkboxes used as immediate toggles with accessible ARIA switches (`<button role="switch">`). Added focus rings and appropriate `aria-labelledby` attributes to improve keyboard navigation and screen reader support while preventing click propagation issues on wrapper components.

---
*PR created automatically by Jules for task [9786792541957035941](https://jules.google.com/task/9786792541957035941) started by @ford442*