### PR TITLE
🎨 Palette: Add aria-label and title to icon-only action buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,6 @@
 ## 2025-04-19 - Replace native checkboxes with ARIA switches for toggle actions
 **Learning:** Native `<input type="checkbox">` elements, when used for immediate state toggles (like "Lock to Seq" or import configuration options), can feel clunky and lack the visual affordance of a modern switch. More importantly, when visually hidden or improperly styled, they can lose native keyboard focus indicators, impairing accessibility.
 **Action:** Always implement custom UI toggle switches using `<button type="button" role="switch" aria-checked={state}>` accompanied by explicit Tailwind `focus-visible` classes (e.g., `focus-visible:ring-2`) and clear `aria-labelledby` linking to their labels. This provides both a polished look and robust screen reader/keyboard support.
+## $(date +%Y-%m-%d) - Added Title and ARIA labels to Sampler/Harmonizer action buttons
+**Learning:** Icon-only buttons or text-heavy components inside complex modal structures (like Voice Editor and Sampler Panel) often rely on visual context but fail to provide screen-reader accessibility or tooltips for hover interactions, degrading usability.
+**Action:** Always add `aria-label` alongside a matching `title` attribute for icon-only action buttons and quick-presets to ensure both visual hover affordances and screen reader context are available, preventing empty accessibility tree nodes.

--- a/src/components/SamplerVoicePanel.tsx
+++ b/src/components/SamplerVoicePanel.tsx
@@ -405,15 +405,17 @@ const HarmonizerPopover: React.FC<{
                         <span className="text-[8px] font-mono text-gray-500 uppercase tracking-wider">Quick Presets</span>
                         <div className="flex gap-1.5 mt-2">
                             {[
-                                { key: 'subtle', label: 'DBL' },
-                                { key: 'classic', label: '3RD' },
-                                { key: 'choir', label: 'CHR' },
-                                { key: 'power', label: '5TH' }
-                            ].map(({ key, label }) => (
+                                { key: 'subtle', label: 'DBL', desc: 'Double (Subtle)' },
+                                { key: 'classic', label: '3RD', desc: '3rd Harmony (Classic)' },
+                                { key: 'choir', label: 'CHR', desc: 'Choir (Thick)' },
+                                { key: 'power', label: '5TH', desc: '5th Harmony (Power)' }
+                            ].map(({ key, label, desc }) => (
                                 <button
                                     key={key}
                                     onClick={() => setLocalConfig(HARMONIZE_PRESETS[key as keyof typeof HARMONIZE_PRESETS]())}
                                     className="flex-1 py-1.5 rounded-md text-[8px] font-bold bg-gradient-to-b from-zinc-800 to-zinc-900 text-zinc-400 border border-zinc-700 hover:text-zinc-200 transition-all shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]"
+                                    title={desc}
+                                    aria-label={`Apply ${desc} Preset`}
                                 >
                                     {label}
                                 </button>
@@ -424,6 +426,8 @@ const HarmonizerPopover: React.FC<{
                     {/* Apply Button - Animated hardware style */}
                     <button
                         onClick={handleApply}
+                        aria-label="Apply Harmonizer Settings"
+                        title="Apply Harmonizer Settings"
                         className="w-full py-2.5 rounded-lg text-xs font-bold font-orbitron tracking-wider transition-all text-black relative overflow-hidden group"
                         style={{
                             background: `linear-gradient(135deg, ${color} 0%, ${color}dd 50%, ${color} 100%)`,

--- a/src/components/VoiceEditor.tsx
+++ b/src/components/VoiceEditor.tsx
@@ -106,15 +106,15 @@ export const VoiceEditor: React.FC<VoiceEditorProps> = ({ onClose }) => {
 
                 {/* Controls */}
                 <div className="grid grid-cols-4 gap-2 mb-6 font-mono">
-                    <button onClick={() => handleOp('mirrorX')} className={`${btnClass} bg-gray-800 hover:bg-gray-700 text-gray-300`} title="Mirror the voice pattern horizontally">Mirror X</button>
-                    <button onClick={() => handleOp('mirrorY')} className={`${btnClass} bg-gray-800 hover:bg-gray-700 text-gray-300`} title="Mirror the voice pattern vertically">Mirror Y</button>
-                    <button onClick={() => handleOp('invertSign')} className={`${btnClass} bg-gray-800 hover:bg-gray-700 text-gray-300`} title="Invert the phase of the voice pattern">Invert</button>
-                    <button onClick={() => handleOp('randomShift')} className={`${btnClass} bg-gray-800 hover:bg-gray-700 text-gray-300`} title="Randomly shift voice characteristics">Rand Shift</button>
+                    <button onClick={() => handleOp('mirrorX')} className={`${btnClass} bg-gray-800 hover:bg-gray-700 text-gray-300`} aria-label="Mirror the voice pattern horizontally" title="Mirror the voice pattern horizontally">Mirror X</button>
+                    <button onClick={() => handleOp('mirrorY')} className={`${btnClass} bg-gray-800 hover:bg-gray-700 text-gray-300`} aria-label="Mirror the voice pattern vertically" title="Mirror the voice pattern vertically">Mirror Y</button>
+                    <button onClick={() => handleOp('invertSign')} className={`${btnClass} bg-gray-800 hover:bg-gray-700 text-gray-300`} aria-label="Invert the phase of the voice pattern" title="Invert the phase of the voice pattern">Invert</button>
+                    <button onClick={() => handleOp('randomShift')} className={`${btnClass} bg-gray-800 hover:bg-gray-700 text-gray-300`} aria-label="Randomly shift voice characteristics" title="Randomly shift voice characteristics">Rand Shift</button>
 
-                    <button onClick={() => handleOp('dspSharpen')} className={`${btnClass} bg-purple-900/30 hover:bg-purple-900/50 text-purple-300 border border-purple-900/50`} title="Enhance contrast in voice features">Sharpen</button>
-                    <button onClick={() => handleOp('dspTremolo')} className={`${btnClass} bg-purple-900/30 hover:bg-purple-900/50 text-purple-300 border border-purple-900/50`} title="Apply amplitude modulation">Tremolo</button>
-                    <button onClick={() => handleOp('dspEcho')} className={`${btnClass} bg-purple-900/30 hover:bg-purple-900/50 text-purple-300 border border-purple-900/50`} title="Add delay/echo effect">Echo</button>
-                    <button onClick={() => handleOp('reset')} className={`${btnClass} bg-red-900/30 hover:bg-red-900/50 text-red-300 border border-red-900/50`} title="Reset to original voice style">Reset</button>
+                    <button onClick={() => handleOp('dspSharpen')} className={`${btnClass} bg-purple-900/30 hover:bg-purple-900/50 text-purple-300 border border-purple-900/50`} aria-label="Enhance contrast in voice features" title="Enhance contrast in voice features">Sharpen</button>
+                    <button onClick={() => handleOp('dspTremolo')} className={`${btnClass} bg-purple-900/30 hover:bg-purple-900/50 text-purple-300 border border-purple-900/50`} aria-label="Apply amplitude modulation" title="Apply amplitude modulation">Tremolo</button>
+                    <button onClick={() => handleOp('dspEcho')} className={`${btnClass} bg-purple-900/30 hover:bg-purple-900/50 text-purple-300 border border-purple-900/50`} aria-label="Add delay/echo effect" title="Add delay/echo effect">Echo</button>
+                    <button onClick={() => handleOp('reset')} className={`${btnClass} bg-red-900/30 hover:bg-red-900/50 text-red-300 border border-red-900/50`} aria-label="Reset to original voice style" title="Reset to original voice style">Reset</button>
                 </div>
 
                 <div className="flex justify-between items-center">

--- a/src/components/sampler/HarmonizerPopover.tsx
+++ b/src/components/sampler/HarmonizerPopover.tsx
@@ -229,15 +229,17 @@ export const HarmonizerPopover: React.FC<HarmonizerPopoverProps> = ({ isOpen, on
                         <span className="text-[8px] font-mono text-gray-500 uppercase tracking-wider">Quick Presets</span>
                         <div className="flex gap-1.5 mt-2">
                             {[
-                                { key: 'subtle', label: 'DBL' },
-                                { key: 'classic', label: '3RD' },
-                                { key: 'choir', label: 'CHR' },
-                                { key: 'power', label: '5TH' }
-                            ].map(({ key, label }) => (
+                                { key: 'subtle', label: 'DBL', desc: 'Double (Subtle)' },
+                                { key: 'classic', label: '3RD', desc: '3rd Harmony (Classic)' },
+                                { key: 'choir', label: 'CHR', desc: 'Choir (Thick)' },
+                                { key: 'power', label: '5TH', desc: '5th Harmony (Power)' }
+                            ].map(({ key, label, desc }) => (
                                 <button
                                     key={key}
                                     onClick={() => setLocalConfig(HARMONIZE_PRESETS[key as keyof typeof HARMONIZE_PRESETS]())}
                                     className="flex-1 py-1.5 rounded-md text-[8px] font-bold bg-gradient-to-b from-zinc-800 to-zinc-900 text-zinc-400 border border-zinc-700 hover:text-zinc-200 transition-all shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]"
+                                    title={desc}
+                                    aria-label={`Apply ${desc} Preset`}
                                 >
                                     {label}
                                 </button>
@@ -248,6 +250,8 @@ export const HarmonizerPopover: React.FC<HarmonizerPopoverProps> = ({ isOpen, on
                     {/* Apply Button - Animated hardware style */}
                     <button
                         onClick={handleApply}
+                        aria-label="Apply Harmonizer Settings"
+                        title="Apply Harmonizer Settings"
                         className="w-full py-2.5 rounded-lg text-xs font-bold font-orbitron tracking-wider transition-all text-black relative overflow-hidden group"
                         style={{
                             background: `linear-gradient(135deg, ${color} 0%, ${color}dd 50%, ${color} 100%)`,


### PR DESCRIPTION
💡 What: Added missing `aria-label` and `title` attributes to icon-only buttons and key action buttons in `HarmonizerPopover`, `SamplerVoicePanel`, and `VoiceEditor`.

🎯 Why: Icon-only buttons or minimal-text components often rely on visual context but fail to provide screen-reader accessibility or tooltips for hover interactions, degrading usability. Adding these attributes ensures visual affordance and full accessibility.

📸 Before/After: Pre-commit visual verification complete and verified. (No visible layout changes, tooltips now active on hover).

♿ Accessibility: Ensures correct DOM nodes for screen readers and tooltips for cursor navigation.

---
*PR created automatically by Jules for task [3890394722362010204](https://jules.google.com/task/3890394722362010204) started by @ford442*