### PR TITLE
🎨 Palette: Add loading spinners and tooltips to Start Overlay and Synth Part buttons

### DIFF
--- a/src/components/StartOverlay.tsx
+++ b/src/components/StartOverlay.tsx
@@ -21,12 +21,19 @@ export const StartOverlay: React.FC<StartOverlayProps> = ({ onStart, isReady }) 
                     onClick={onStart} 
                     disabled={!isReady} 
                     aria-busy={!isReady} 
-                    className={`w-full py-4 rounded-xl font-orbitron text-xl font-bold tracking-widest transition-all duration-300 ${
+                    title={isReady ? 'Start Application' : 'Please wait, loading system resources...'}
+                    className={`w-full py-4 rounded-xl font-orbitron text-xl font-bold tracking-widest transition-all duration-300 flex items-center justify-center gap-3 ${
                         isReady 
                             ? 'bg-cyan-600 hover:bg-cyan-500 text-white shadow-[0_0_20px_rgba(6,182,212,0.6)] hover:shadow-[0_0_30px_rgba(6,182,212,0.8)] border border-cyan-400 cursor-pointer transform hover:scale-[1.02]' 
                             : 'bg-gray-700 text-gray-500 cursor-wait border border-gray-600'
                     }`}
                 >
+                    {!isReady && (
+                        <svg className="animate-spin h-6 w-6 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                        </svg>
+                    )}
                     {isReady ? 'INITIALIZE SYSTEM' : 'LOADING RESOURCES...'}
                 </button>
             </div>

--- a/src/components/SynthPart.tsx
+++ b/src/components/SynthPart.tsx
@@ -39,12 +39,19 @@ export const SynthPart: React.FC<SynthPartProps> = ({ title, accentColor, params
           onClick={isFrozen ? onUnfreeze : onMixdown}
           disabled={isRendering}
           aria-busy={isRendering}
-          className={`px-3 py-1 text-xs font-bold rounded-md transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 ${accentClasses[accentColor].ring} ${
+          title={isRendering ? 'Rendering audio to track, please wait...' : isFrozen ? 'Unfreeze to edit track parameters (uses more CPU)' : 'Mixdown to freeze track (saves CPU)'}
+          className={`px-3 py-1 text-xs font-bold rounded-md transition-colors duration-200 flex items-center gap-1.5 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 ${accentClasses[accentColor].ring} ${
             isRendering ? 'bg-gray-600 text-gray-400 cursor-wait' :
             isFrozen ? 'bg-yellow-500 hover:bg-yellow-600 text-gray-900' :
             'bg-indigo-500 hover:bg-indigo-600 text-white'
           }`}
         >
+          {isRendering && (
+            <svg className="animate-spin h-3.5 w-3.5 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            </svg>
+          )}
           {isRendering ? 'Rendering...' : isFrozen ? 'Unfreeze' : 'Mixdown'}
         </button>
       </div>


### PR DESCRIPTION
💡 **What**: Added SVG loading spinners and native `title` tooltips to the asynchronous buttons in the `StartOverlay` and `SynthPart` components.
🎯 **Why**: When the application initializes or renders audio, the operations can take substantial time (e.g., Pyodide downloading). Without spinners or explanatory tooltips, the buttons appear frozen despite having an `aria-busy` attribute, leaving users uncertain if the app crashed.
📸 **Before/After**: The "LOADING RESOURCES..." and "Rendering..." buttons now visually spin and explain their disabled state on hover.
♿ **Accessibility**: Enhanced screen reader feedback through descriptive `title` attributes that mirror the `aria-busy` semantics.

---
*PR created automatically by Jules for task [3242839541049616891](https://jules.google.com/task/3242839541049616891) started by @ford442*