### PR TITLE
feat(audio): Implement Master Bus Compressor (Glue Compressor)

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -99,10 +99,12 @@
 * [x] **Idea:** "Advanced Slice Tuning" - Allow users to fine-tune slice sensitivity and adjust the threshold parameters for Auto-Slice. (Implemented in `SamplerPanel` and `WaveformDisplay`!)
 
 * [x] **Idea:** "Per-Step Delay Send" - Allow sequence steps to override the global delay send amount. (Implemented!)
-* **Idea:** "Master Bus Compressor" - Add a `DynamicsCompressorNode` to the master output for gluing the mix together.
+* [x] **Idea:** "Master Bus Compressor" - Add a `DynamicsCompressorNode` to the master output for gluing the mix together. (Implemented via a fixed "Glue Compressor" block before the Master Gain!)
+* **Idea:** "Sidechain Compression" - Allow routing the kick drum to the master compressor's sidechain input or a dedicated sidechain bus to dynamically duck the bass/synths.
 ---
 
 ## 📜 Changelog
+* [2026-06-27] - Implemented Master Bus Compressor: Inserted a default `DynamicsCompressorNode` configured as a gentle "Glue Compressor" (Threshold: -15dB, Ratio: 4:1, Attack: 30ms, Release: 250ms) into the master audio chain (`masterSaturation` -> `masterCompressor` -> `masterGain` -> `masterPanner`). Updated `useAudioEngine.ts` to reflect the new master bus input point and updated `PlaybackRefs`.
 * [Date] - Implemented Custom Waveform LFO: Added `DrawableLFO` component to allow users to draw custom LFO shapes for formant modulation. Integrated with `FormantShifter.ts` to convert the drawn array into a `PeriodicWave` using a Discrete Fourier Transform (DFT), passing `formantLfoShape` from the `SamplerPanel` through `SingingVoice` and `useAudioEngine`. Added new ideas: "LFO Rate Sync to Tempo" and "Microtonal Scale Mapping".
 * [2026-06-27] - Implemented Vocal Formant Envelope: Added Formant Envelope parameters to `SamplerBankParams` and `Note` interfaces, allowing users to modulate formant detune amounts via an attack/decay envelope on `ConstantSourceNode` and `GainNode`. Added global and per-step controls to `SamplerPanel` and `NoteSelector`.
 * [2026-06-27] - Verified Gesture Controls: Confirmed pinch-to-zoom is fully implemented in `MainSequencer.tsx` and marked as complete.

--- a/src/hooks/audioEngine/audioPlayback.ts
+++ b/src/hooks/audioEngine/audioPlayback.ts
@@ -63,6 +63,7 @@ interface ActiveSamplerNote {
 export interface PlaybackRefs {
     masterGainRef: MutableRefObject<GainNode | null>;
     masterSaturationRef: MutableRefObject<WaveShaperNode | null>;
+    masterCompressorRef: MutableRefObject<DynamicsCompressorNode | null>;
     reverbNodesRef: MutableRefObject<Record<string, ConvolverNode>>;
     reverbTypeRef: MutableRefObject<'room' | 'plate' | 'hall'>;
     delayNodeRef: MutableRefObject<DelayNode | null>;

--- a/src/hooks/audioEngine/initialization.ts
+++ b/src/hooks/audioEngine/initialization.ts
@@ -8,29 +8,39 @@ export function initializeMasterOutput(
     masterGainRef: MutableRefObject<GainNode | null>,
     masterPannerRef: MutableRefObject<StereoPannerNode | null>,
     masterSaturationRef: MutableRefObject<WaveShaperNode | null>,
-): GainNode {
-    const masterGain = context.createGain();
-    masterGain.gain.setValueAtTime(0.8, 0);
-    masterGainRef.current = masterGain;
-
+    masterCompressorRef: MutableRefObject<DynamicsCompressorNode | null>,
+): WaveShaperNode {
     const masterSaturation = context.createWaveShaper();
     masterSaturation.curve = makeDistortionCurve(0);
     masterSaturation.oversample = '4x';
     masterSaturationRef.current = masterSaturation;
 
-    masterGain.connect(masterSaturation);
+    const masterCompressor = context.createDynamicsCompressor();
+    masterCompressor.threshold.setValueAtTime(-15, context.currentTime);
+    masterCompressor.knee.setValueAtTime(30, context.currentTime);
+    masterCompressor.ratio.setValueAtTime(4, context.currentTime);
+    masterCompressor.attack.setValueAtTime(0.03, context.currentTime);
+    masterCompressor.release.setValueAtTime(0.25, context.currentTime);
+    masterCompressorRef.current = masterCompressor;
+
+    const masterGain = context.createGain();
+    masterGain.gain.setValueAtTime(0.8, 0);
+    masterGainRef.current = masterGain;
+
+    masterSaturation.connect(masterCompressor);
+    masterCompressor.connect(masterGain);
 
     if (context.createStereoPanner) {
         const masterPanner = context.createStereoPanner();
         masterPanner.pan.setValueAtTime(0, 0);
         masterPannerRef.current = masterPanner;
-        masterSaturation.connect(masterPanner);
+        masterGain.connect(masterPanner);
         masterPanner.connect(context.destination);
     } else {
-        masterSaturation.connect(context.destination);
+        masterGain.connect(context.destination);
     }
 
-    return masterGain;
+    return masterSaturation;
 }
 
 export async function loadWavBuffer(context: AudioContext, url: string): Promise<AudioBuffer | null> {

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -88,6 +88,7 @@ export const useAudioEngine = (pyodide: unknown) => {
     // Master Volume & Pan
     const masterGainRef = useRef<GainNode | null>(null);
     const masterSaturationRef = useRef<WaveShaperNode | null>(null);
+    const masterCompressorRef = useRef<DynamicsCompressorNode | null>(null);
     const reverbNodesRef = useRef<Record<string, ConvolverNode>>({});
     const reverbNodeRef = useRef<ConvolverNode | null>(null); // Keep for backwards compatibility if needed temporarily
     const reverbTypeRef = useRef<'room' | 'plate' | 'hall'>('plate');
@@ -113,6 +114,7 @@ export const useAudioEngine = (pyodide: unknown) => {
     const playbackRefs = useMemo<PlaybackRefs>(() => ({
         masterGainRef,
         masterSaturationRef,
+        masterCompressorRef,
         reverbNodesRef,
         reverbTypeRef,
         delayNodeRef,
@@ -155,21 +157,21 @@ export const useAudioEngine = (pyodide: unknown) => {
                 console.log("AudioContext resumed");
             }
 
-            const masterGain = initializeMasterOutput(context, masterGainRef, masterPannerRef, masterSaturationRef);
+            const masterBusInput = initializeMasterOutput(context, masterGainRef, masterPannerRef, masterSaturationRef, masterCompressorRef);
 
             // Initialize Reverb Node
             // Initialize Reverb Nodes (Room, Plate, Hall)
             const roomNode = context.createConvolver();
             roomNode.buffer = createReverbImpulseResponse(context, 0.5, 1.0);
-            roomNode.connect(masterGain);
+            roomNode.connect(masterBusInput);
 
             const plateNode = context.createConvolver();
             plateNode.buffer = createReverbImpulseResponse(context, 1.5, 2.0);
-            plateNode.connect(masterGain);
+            plateNode.connect(masterBusInput);
 
             const hallNode = context.createConvolver();
             hallNode.buffer = createReverbImpulseResponse(context, 3.5, 3.0);
-            hallNode.connect(masterGain);
+            hallNode.connect(masterBusInput);
 
             reverbNodesRef.current = { room: roomNode, plate: plateNode, hall: hallNode };
             reverbNodeRef.current = plateNode; // Fallback
@@ -181,7 +183,7 @@ export const useAudioEngine = (pyodide: unknown) => {
             delayFeedback.gain.value = 0.4;
             delayNode.connect(delayFeedback);
             delayFeedback.connect(delayNode);
-            delayNode.connect(masterGain);
+            delayNode.connect(masterBusInput);
             delayNodeRef.current = delayNode;
             delayFeedbackRef.current = delayFeedback;
 
@@ -206,7 +208,7 @@ export const useAudioEngine = (pyodide: unknown) => {
                 });
                 
                 if (open303Ready) {
-                    open303Manager.connect(masterGain);
+                    open303Manager.connect(masterBusInput);
                     open303ManagerRef.current = open303Manager;
                     console.log('[useAudioEngine] Open303Manager Ready');
                     try { engineTelemetry.registerResolution('jc303','open303','ready'); } catch (e) { /* noop */ }
@@ -242,10 +244,10 @@ export const useAudioEngine = (pyodide: unknown) => {
             }
 
             // Initialize Voice Managers
-            voiceManagerARef.current = new VoiceManager(context, masterGainRef.current!, 8, false, sawBuf || undefined, sqrBuf || undefined, delayNodeRef.current || undefined);
-            voiceManagerBRef.current = new VoiceManager(context, masterGainRef.current!, 1, true, sawBuf || undefined, sqrBuf || undefined, delayNodeRef.current || undefined);
+            voiceManagerARef.current = new VoiceManager(context, masterSaturationRef.current!, 8, false, sawBuf || undefined, sqrBuf || undefined, delayNodeRef.current || undefined);
+            voiceManagerBRef.current = new VoiceManager(context, masterSaturationRef.current!, 1, true, sawBuf || undefined, sqrBuf || undefined, delayNodeRef.current || undefined);
 
-            await initializeSustainProcessor(context, sustainProcessorUrl, sustainNodeRef, masterGainRef);
+            await initializeSustainProcessor(context, sustainProcessorUrl, sustainNodeRef, masterSaturationRef);
 
             // --- Singing Voice Manager Init ---
             try {
@@ -272,7 +274,7 @@ export const useAudioEngine = (pyodide: unknown) => {
 
                 initializeChoirBuses(
                     context,
-                    masterGainRef,
+                    masterSaturationRef,
                     choirLeftGainRef,
                     choirRightGainRef,
                     choirLeftPannerRef,
@@ -280,7 +282,7 @@ export const useAudioEngine = (pyodide: unknown) => {
                 );
 
                 manager.getAllVoices().forEach(voice => {
-                    voice.connectOutput(masterGainRef.current!);
+                    voice.connectOutput(masterSaturationRef.current!);
                 });
 
                 if (pyodideRef.current) {
@@ -349,7 +351,7 @@ export const useAudioEngine = (pyodide: unknown) => {
                 const legacyBuffer = loadedSampleBuffersRef.current.get(params.sampleName);
                 const buffer = multisampleBank?.baseBuffer || legacyBuffer;
                 
-                if (!buffer || !masterGainRef.current) return;
+                if (!buffer || !masterSaturationRef.current) return;
 
                 // Apply Microtiming
                 const actualTime = time + (noteParams?.microtiming ? noteParams.microtiming * stepTime : 0);
@@ -380,7 +382,7 @@ export const useAudioEngine = (pyodide: unknown) => {
 
                             // Ensure voice connected to correct output
                             voice.disconnectOutput();
-                            let finalDest = destination || masterGainRef.current!;
+                            let finalDest = destination || masterSaturationRef.current!;
 
                             // Apply Drive/Distortion if present
                             const driveAmount = noteParams?.drive !== undefined ? noteParams.drive : params.drive;
@@ -672,11 +674,11 @@ export const useAudioEngine = (pyodide: unknown) => {
                         shaper.curve = null;
                     }
 
-                    let finalDestination: AudioNode = masterGainRef.current!;
+                    let finalDestination: AudioNode = masterSaturationRef.current!;
                     if (params.pan !== undefined && params.pan !== 0) {
                         const panner = context.createStereoPanner();
                         panner.pan.value = params.pan;
-                        panner.connect(masterGainRef.current!);
+                        panner.connect(masterSaturationRef.current!);
                         finalDestination = panner;
                     }
 
@@ -781,7 +783,7 @@ export const useAudioEngine = (pyodide: unknown) => {
                 const legacyBuffer = loadedSampleBuffersRef.current.get(params.sampleName);
                 const buffer = multisampleBank?.baseBuffer || legacyBuffer;
                 
-                if (!buffer || !masterGainRef.current) return null;
+                if (!buffer || !masterSaturationRef.current) return null;
 
                 const rootNote = params.rootNote ?? 60;
                 const coarseTune = params.coarseTune ?? params.coarse ?? 0;
@@ -810,7 +812,7 @@ export const useAudioEngine = (pyodide: unknown) => {
                 gain.gain.value = params.volume;
 
                 source.connect(gain);
-                gain.connect(masterGainRef.current);
+                gain.connect(masterSaturationRef.current);
                 source.start(now);
 
                 const id = nextSamplerNoteId.current++;
@@ -840,7 +842,7 @@ export const useAudioEngine = (pyodide: unknown) => {
             const playBufferedPart = (buffer: AudioBuffer, time: number) => {
                 const src = context.createBufferSource();
                 src.buffer = buffer;
-                src.connect(masterGainRef.current!);
+                src.connect(masterSaturationRef.current!);
                 src.start(time);
             };
             const { playAmbiance, stopAmbiance, setAmbianceVolume } = createAmbianceControls(context, playbackRefs);

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -247,7 +247,7 @@ export const useAudioEngine = (pyodide: unknown) => {
             voiceManagerARef.current = new VoiceManager(context, masterSaturationRef.current!, 8, false, sawBuf || undefined, sqrBuf || undefined, delayNodeRef.current || undefined);
             voiceManagerBRef.current = new VoiceManager(context, masterSaturationRef.current!, 1, true, sawBuf || undefined, sqrBuf || undefined, delayNodeRef.current || undefined);
 
-            await initializeSustainProcessor(context, sustainProcessorUrl, sustainNodeRef, masterSaturationRef);
+            await initializeSustainProcessor(context, sustainProcessorUrl, sustainNodeRef, masterGainRef);
 
             // --- Singing Voice Manager Init ---
             try {
@@ -274,7 +274,7 @@ export const useAudioEngine = (pyodide: unknown) => {
 
                 initializeChoirBuses(
                     context,
-                    masterSaturationRef,
+                    masterGainRef,
                     choirLeftGainRef,
                     choirRightGainRef,
                     choirLeftPannerRef,

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -247,7 +247,7 @@ export const useAudioEngine = (pyodide: unknown) => {
             voiceManagerARef.current = new VoiceManager(context, masterSaturationRef.current!, 8, false, sawBuf || undefined, sqrBuf || undefined, delayNodeRef.current || undefined);
             voiceManagerBRef.current = new VoiceManager(context, masterSaturationRef.current!, 1, true, sawBuf || undefined, sqrBuf || undefined, delayNodeRef.current || undefined);
 
-            await initializeSustainProcessor(context, sustainProcessorUrl, sustainNodeRef, masterGainRef);
+            await initializeSustainProcessor(context, sustainProcessorUrl, sustainNodeRef, masterSaturationRef);
 
             // --- Singing Voice Manager Init ---
             try {
@@ -274,7 +274,7 @@ export const useAudioEngine = (pyodide: unknown) => {
 
                 initializeChoirBuses(
                     context,
-                    masterGainRef,
+                    masterSaturationRef,
                     choirLeftGainRef,
                     choirRightGainRef,
                     choirLeftPannerRef,


### PR DESCRIPTION
Implemented the Master Bus Compressor idea from the Innovation Lab.
The new signal flow is: `masterSaturation` -> `masterCompressor` -> `masterGain` -> `masterPanner` -> `destination`.
Added a new `DynamicsCompressorNode` inside `initializeMasterOutput` with gentle glue compressor settings.
Updated the `PlaybackRefs` interface and `useAudioEngine.ts` to hold the `masterCompressorRef` and correctly point all track output connections to `masterSaturationRef.current` (the start of the master bus) instead of `masterGainRef.current`.

---
*PR created automatically by Jules for task [18160029074863583986](https://jules.google.com/task/18160029074863583986) started by @ford442*