### PR TITLE
feat: Sidechain Compression via Deterministic Ducking

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -100,13 +100,14 @@
 
 * [x] **Idea:** "Per-Step Delay Send" - Allow sequence steps to override the global delay send amount. (Implemented!)
 * [x] **Idea:** "Master Bus Compressor" - Add a `DynamicsCompressorNode` to the master output for gluing the mix together. (Implemented via a fixed "Glue Compressor" block before the Master Gain!)
-* **Idea:** "Sidechain Compression" - Allow routing the kick drum to the master compressor's sidechain input or a dedicated sidechain bus to dynamically duck the bass/synths.
+* [x] **Idea:** "Sidechain Compression" - Allow routing the kick drum to a dedicated sidechain bus to dynamically duck the bass/synths. (Implemented via scheduled GainNode automation on kick hits!)
 ---
 
 * **Idea:** "Granular Envelope Follower" - Allow mapping the amplitude envelope of the voice sample to control granular parameters like grain size or freeze amount.
 ---
 
 ## 📜 Changelog
+* [2026-06-29] - Implemented Sidechain Compression: Added `sidechainBus` between the master saturation and master compressor to duck Synths/Basses when the kick drum triggers. Implemented `triggerSidechainDuck` in `audioPlayback.ts` to use deterministic native browser parameter scheduling (`linearRampToValueAtTime` / `exponentialRampToValueAtTime`) on the new sidechain gain node to avoid CPU overhead and achieve a classic EDM pump. Fulfills the "Sidechain Compression" Innovation Lab idea.
 * [2026-06-28] - Implemented LFO Rate Sync to Tempo: Added toggles and subdivision dropdowns to `SamplerPanel` and `NoteSelector` for `freezeLfoRate` and `formantLfoRate`. Updated `useAudioEngine.ts` to calculate real-time Hz values from BPM and note subdivisions when sync mode is enabled. Fulfills the "LFO Rate Sync to Tempo" Innovation Lab idea. Added new idea: "Granular Envelope Follower".
 * [2026-06-27] - Implemented Master Bus Compressor: Inserted a default `DynamicsCompressorNode` configured as a gentle "Glue Compressor" (Threshold: -15dB, Ratio: 4:1, Attack: 30ms, Release: 250ms) into the master audio chain (`masterSaturation` -> `masterCompressor` -> `masterGain` -> `masterPanner`). Updated `useAudioEngine.ts` to reflect the new master bus input point and updated `PlaybackRefs`.
 * [Date] - Implemented Custom Waveform LFO: Added `DrawableLFO` component to allow users to draw custom LFO shapes for formant modulation. Integrated with `FormantShifter.ts` to convert the drawn array into a `PeriodicWave` using a Discrete Fourier Transform (DFT), passing `formantLfoShape` from the `SamplerPanel` through `SingingVoice` and `useAudioEngine`. Added new ideas: "LFO Rate Sync to Tempo" and "Microtonal Scale Mapping".

--- a/plan.md
+++ b/plan.md
@@ -1,57 +1,58 @@
-# Plan for Vocal Formant Envelope Implementation
-
-1. **Update `types.ts`:**
-   - In `SamplerBankParams` (line ~117), add:
-     - `formantEnvAttack?: number; // Formant Envelope Attack time in seconds`
-     - `formantEnvDecay?: number; // Formant Envelope Decay time in seconds`
-     - `formantEnvAmount?: number; // Formant Envelope Amount (semitones shift, -24 to +24)`
-
-   - In `Note` interface (line ~170), add:
-     - `formantEnvAttack?: number;`
-     - `formantEnvDecay?: number;`
-     - `formantEnvAmount?: number;`
-
-2. **Update `FormantShifter.ts`:**
-   - Add a method to trigger the envelope:
+1. **Add `sidechainGainRef` to Types**:
+   - In `src/hooks/audioEngine/audioPlayback.ts`, update `PlaybackRefs` interface to include `sidechainGainRef: MutableRefObject<GainNode | null>;`.
+2. **Add `sidechainGainRef` to `useAudioEngine` state**:
+   - In `src/hooks/useAudioEngine.ts`, define `const sidechainGainRef = useRef<GainNode | null>(null);`. Add it to `playbackRefs` memoization block.
+3. **Modify `initializeMasterOutput`**:
+   - In `src/hooks/audioEngine/initialization.ts`, modify `initializeMasterOutput` to accept `sidechainGainRef`.
+   - Update its signature:
      ```typescript
-     triggerEnvelope(amount: number, attack: number, decay: number, triggerTime: number): void {
-         if (this.filterNodes.length === 0) return;
-         if (amount === 0) return;
-
-         // We want to temporarily modulate the 'detune' AudioParam of the filter nodes
-         // based on an AD (Attack-Decay) envelope on top of any existing value
-         // However, detune is already used by LFO (via this.lfoGain)
-         // AudioParams automatically sum multiple inputs and their inherent value.
-         // We can schedule values on the param itself, BUT we don't want to mess up
-         // manual base `detune` values or the `updateFilterChain` frequencies.
-         // Actually, `updateFilterChain` changes the `frequency` param, not `detune`.
-         // Let's check `createFilterChain`:
-         // `filter.frequency.value = targetFreq`
-         // `lfoGain.connect(filters[i].detune)`
-         // This means `detune.value` is intrinsically 0, and LFO modulates it.
-         // We can safely use `linearRampToValueAtTime` on `detune` param.
-         // However, doing this overrides any automation applied to `detune.value`?
-         // We're not automating `detune.value` elsewhere (it's 0), we automate `frequency`.
-         // Wait, let's create a dedicated envelope `GainNode` connected to `detune` just like `lfoGain`.
-         // This is cleaner: a constant source -> GainNode (envelope) -> filter.detune
+     export function initializeMasterOutput(
+         context: AudioContext,
+         masterGainRef: MutableRefObject<GainNode | null>,
+         masterPannerRef: MutableRefObject<StereoPannerNode | null>,
+         masterSaturationRef: MutableRefObject<WaveShaperNode | null>,
+         masterCompressorRef: MutableRefObject<DynamicsCompressorNode | null>,
+         sidechainGainRef: MutableRefObject<GainNode | null>
+     ): WaveShaperNode
      ```
-   - Actually, a simple constant source `AudioBufferSourceNode` or `ConstantSourceNode` connected to a `GainNode`, which connects to `filter.detune`. We can automate the `gain` of this node!
-   - Wait, `ConstantSourceNode` is standard.
+   - Inside `initializeMasterOutput`, create `sidechainBus`:
+     ```typescript
+     const sidechainBus = context.createGain();
+     sidechainBus.gain.setValueAtTime(1.0, context.currentTime);
+     sidechainGainRef.current = sidechainBus;
 
-3. **Update `SingingVoice.ts`:**
-   - In `triggerSlice`, grab `formantEnvAttack`, `formantEnvDecay`, `formantEnvAmount` from `params` (global) or `overrides` (per step).
-   - If they exist and `formantEnvAmount !== 0`, call `this.formantShifter.triggerEnvelope(...)`.
-   - Update `setFormantEnvelope(...)` in `SingingVoice` so it can be updated real-time or triggered per step.
+     masterSaturation.connect(sidechainBus);
+     sidechainBus.connect(masterCompressor);
+     masterCompressor.connect(masterGain);
+     ```
+   - *Self-correction*: Currently `masterSaturation` acts as the bus where everything (Synths, Samplers) goes. `masterSaturation.connect(masterCompressor)`. By inserting `sidechainBus` between them, we effectively duck all Synths and Samplers, while Drums (which connect directly to `masterGain`) bypass the ducking and compression. This matches perfectly with the EDM pump style (drums stay punchy, rest of mix ducks).
+4. **Create `triggerSidechainDuck`**:
+   - Add this to `src/hooks/audioEngine/audioPlayback.ts`:
+     ```typescript
+     export const triggerSidechainDuck = (
+       audioCtx: AudioContext,
+       sidechainGainNode: GainNode,
+       time: number,
+       depth: number = 0.15,
+       releaseTime: number = 0.25
+     ) => {
+       const gain = sidechainGainNode.gain;
+       gain.cancelScheduledValues(time);
+       gain.setValueAtTime(gain.value, time);
+       gain.linearRampToValueAtTime(depth, time + 0.01);
+       gain.exponentialRampToValueAtTime(1.0, time + releaseTime);
+     };
+     ```
+5. **Call `triggerSidechainDuck` when Kick plays**:
+   - In `src/hooks/audioEngine/audioPlayback.ts`, update `createPlayDrum` to include `sidechainGainRef` in its `refs`.
+   - Inside the `sound === 'kick'` condition:
+     ```typescript
+     if (refs.sidechainGainRef.current) {
+         triggerSidechainDuck(context, refs.sidechainGainRef.current, now);
+     }
+     ```
+6. **Update `useAudioEngine.ts` to call `initializeMasterOutput` with new arguments**.
+   - `const masterBusInput = initializeMasterOutput(context, masterGainRef, masterPannerRef, masterSaturationRef, masterCompressorRef, sidechainGainRef);`
+7. **Update `agent_plan.md`**: Mark "Sidechain Compression" as implemented.
 
-4. **Update `SamplerPanel.tsx`:**
-   - Add knobs/sliders for `Fmt Attack`, `Fmt Decay`, `Fmt Amount` inside the formant UI section (near Formant Shift, Fmt LFO, etc.).
-   - Add them to state and `paramHandlers`.
-
-5. **Update `NoteSelector.tsx`:**
-   - Add sliders for step-sequenced overrides of these parameters.
-
-6. **Update `useAudioEngine.ts` and `App.tsx`:**
-   - Plumb properties through `NoteSelector` into `noteParams`.
-   - Apply them in `playSamplerVoice`.
-
-Let's check `FormantShifter.ts` code again to see how we should implement the envelope safely.
+Does this plan look correct?

--- a/src/hooks/audioEngine/audioPlayback.ts
+++ b/src/hooks/audioEngine/audioPlayback.ts
@@ -83,6 +83,7 @@ export interface PlaybackRefs {
     loadedAmbianceBuffersRef: MutableRefObject<Map<string, AudioBuffer>>;
     singingVoiceManagerRef: MutableRefObject<SingingVoiceManager | null>;
     harmonizerRef: MutableRefObject<Harmonizer | null>;
+    sidechainGainRef: MutableRefObject<GainNode | null>;
 }
 
 export function createPlaySynth(
@@ -213,9 +214,32 @@ export function createPlaySynth(
     };
 }
 
+export const triggerSidechainDuck = (
+    audioCtx: AudioContext,
+    sidechainGainNode: GainNode,
+    time: number,
+    depth: number = 0.15, // How quiet it gets (0.0 to 1.0)
+    releaseTime: number = 0.25 // How long it takes to recover (in seconds)
+) => {
+    const gain = sidechainGainNode.gain;
+
+    // 1. Cancel any previous automations overlapping this new trigger
+    gain.cancelScheduledValues(time);
+
+    // 2. Anchor the value right before the drop
+    gain.setValueAtTime(gain.value, time);
+
+    // 3. The Attack: Drop the volume instantly (10ms to prevent clicking)
+    gain.linearRampToValueAtTime(depth, time + 0.01);
+
+    // 4. The Release: Ramp exponentially back to 1.0
+    // Exponential ramps sound much more musical and natural than linear for volume!
+    gain.exponentialRampToValueAtTime(1.0, time + releaseTime);
+};
+
 export function createPlayDrum(
     context: AudioContext,
-    refs: Pick<PlaybackRefs, 'masterGainRef' | 'noiseBufferRef' | 'reverbNodesRef' | 'reverbTypeRef'>,
+    refs: Pick<PlaybackRefs, 'masterGainRef' | 'noiseBufferRef' | 'reverbNodesRef' | 'reverbTypeRef' | 'sidechainGainRef'>,
 ): AudioEngine['playDrum'] {
     return (sound, params, time, noteParams, stepTime = 0.125) => {
         if (!refs.masterGainRef.current) {
@@ -229,6 +253,10 @@ export function createPlayDrum(
             const now = time + (i * subStep);
 
             if (sound === 'kick') {
+                if (refs.sidechainGainRef.current) {
+                    triggerSidechainDuck(context, refs.sidechainGainRef.current, now);
+                }
+
                 const kickParams = params as KickParams;
                 const osc = context.createOscillator();
                 const gain = context.createGain();

--- a/src/hooks/audioEngine/initialization.ts
+++ b/src/hooks/audioEngine/initialization.ts
@@ -9,6 +9,7 @@ export function initializeMasterOutput(
     masterPannerRef: MutableRefObject<StereoPannerNode | null>,
     masterSaturationRef: MutableRefObject<WaveShaperNode | null>,
     masterCompressorRef: MutableRefObject<DynamicsCompressorNode | null>,
+    sidechainGainRef: MutableRefObject<GainNode | null>,
 ): WaveShaperNode {
     const masterSaturation = context.createWaveShaper();
     masterSaturation.curve = makeDistortionCurve(0);
@@ -27,7 +28,12 @@ export function initializeMasterOutput(
     masterGain.gain.setValueAtTime(0.8, 0);
     masterGainRef.current = masterGain;
 
-    masterSaturation.connect(masterCompressor);
+    const sidechainBus = context.createGain();
+    sidechainBus.gain.setValueAtTime(1.0, context.currentTime);
+    sidechainGainRef.current = sidechainBus;
+
+    masterSaturation.connect(sidechainBus);
+    sidechainBus.connect(masterCompressor);
     masterCompressor.connect(masterGain);
 
     if (context.createStereoPanner) {

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -88,6 +88,7 @@ export const useAudioEngine = (pyodide: unknown) => {
     // Master Volume & Pan
     const masterGainRef = useRef<GainNode | null>(null);
     const masterSaturationRef = useRef<WaveShaperNode | null>(null);
+    const sidechainGainRef = useRef<GainNode | null>(null);
     const masterCompressorRef = useRef<DynamicsCompressorNode | null>(null);
     const reverbNodesRef = useRef<Record<string, ConvolverNode>>({});
     const reverbNodeRef = useRef<ConvolverNode | null>(null); // Keep for backwards compatibility if needed temporarily
@@ -132,6 +133,7 @@ export const useAudioEngine = (pyodide: unknown) => {
         loadedAmbianceBuffersRef,
         singingVoiceManagerRef,
         harmonizerRef,
+        sidechainGainRef,
     }), []);
 
     useEffect(() => {
@@ -157,7 +159,7 @@ export const useAudioEngine = (pyodide: unknown) => {
                 console.log("AudioContext resumed");
             }
 
-            const masterBusInput = initializeMasterOutput(context, masterGainRef, masterPannerRef, masterSaturationRef, masterCompressorRef);
+            const masterBusInput = initializeMasterOutput(context, masterGainRef, masterPannerRef, masterSaturationRef, masterCompressorRef, sidechainGainRef);
 
             // Initialize Reverb Node
             // Initialize Reverb Nodes (Room, Plate, Hall)


### PR DESCRIPTION
This PR introduces Sidechain Compression as proposed in the Innovation Lab. 

- Created `initializeSidechainBus` logic to route `masterSaturation` through a new `sidechainBus` (`GainNode`) before hitting the `masterCompressor`.
- Drum tracks bypass this saturation and sidechain bus entirely, routing directly to the `masterGain` (guaranteeing clean transients).
- Implemented `triggerSidechainDuck` in `audioPlayback.ts` which uses deterministic, native Web Audio parameter scheduling to dip the volume of the sidechain bus whenever the sequencer triggers a Kick drum slice.
- This creates the classic EDM pumping effect deterministically and with virtually zero CPU footprint.

---
*PR created automatically by Jules for task [16840414620511981747](https://jules.google.com/task/16840414620511981747) started by @ford442*