### PR TITLE
⚡ Bolt: Add GZipMiddleware to compress API responses

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2026-04-28 - [React.memo Optimization for Static/Simple Components]
 **Learning:** Wrapping basic functional UI components that don't depend on deeply nested or rapidly changing contextual states with `React.memo()` prevents unnecessary React reconciliation overhead whenever the top-level app state changes. However, when doing bulk syntax migrations (like automating the insertion of `React.memo`), AST-based tools like `jscodeshift` are vastly superior to naive regex matching, which is prone to missing closing braces or breaking standard imports.
 **Action:** Use AST codemods (like `jscodeshift`) rather than Regex for bulk component refactors. Add `React.memo()` directly to exported functional components (`React.FC`) that are visually heavy or state-agnostic (like Canvas wrappers) to improve rendering performance.
+## 2026-05-01 - [FastAPI GZip Middleware Optimization]
+**Learning:** Returning large, uncompressed JSON payloads (like songs/patterns) from a FastAPI backend wastes bandwidth and increases load times. FastAPI includes a built-in `GZipMiddleware` that can be added in one line to compress these payloads efficiently.
+**Action:** When building backend APIs that return large JSON datasets, always add `GZipMiddleware(minimum_size=...)` near the top of the middleware stack (before CORS) to reduce payload size without manual compression logic.

--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from typing import List, Optional
 from concurrent.futures import ThreadPoolExecutor
 from fastapi import FastAPI, HTTPException, UploadFile, File, Form, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from aiocache import Cache
@@ -149,6 +150,9 @@ async def lifespan(app: FastAPI):
     io_executor.shutdown()
 
 app = FastAPI(lifespan=lifespan)
+
+# ⚡ Bolt: Added GZipMiddleware to compress large JSON responses
+app.add_middleware(GZipMiddleware, minimum_size=1000)
 
 # --- CORS ---
 app.add_middleware(


### PR DESCRIPTION
💡 What: Added `GZipMiddleware` to the FastAPI backend (`app.py`).
🎯 Why: The backend was serving raw uncompressed JSON. For large payloads (like songs and patterns), this wastes significant bandwidth and increases load times. Gzipping handles this natively.
📊 Impact: Expected to reduce payload sizes by ~60-80% for large songs and patterns without any architectural changes. 
🔬 Measurement: Can be verified by inspecting the "Content-Encoding: gzip" headers in browser dev tools for song/pattern fetch requests, and observing the reduced transfer sizes compared to uncompressed JSON.

---
*PR created automatically by Jules for task [6933968362195128913](https://jules.google.com/task/6933968362195128913) started by @ford442*