### PR TITLE
🎨 Palette: Add double-click reset to Knob and DragValue

### DIFF
--- a/src/components/DragValue.tsx
+++ b/src/components/DragValue.tsx
@@ -8,10 +8,11 @@ interface DragValueProps {
   step?: number;
   label?: string;
   className?: string;
+  defaultValue?: number;
 }
 
 // ⚡ Bolt: Added React.memo to prevent unnecessary re-renders when parent state changes.
-export const DragValue: React.FC<DragValueProps> = React.memo(({ value, onChange, min = 0, max = 100, step = 1, label, className }) => {
+export const DragValue: React.FC<DragValueProps> = React.memo(({ value, onChange, min = 0, max = 100, step = 1, label, className, defaultValue }) => {
   const [isDragging, setIsDragging] = useState(false);
   const startY = useRef(0);
   const startValue = useRef(value);
@@ -186,6 +187,7 @@ export const DragValue: React.FC<DragValueProps> = React.memo(({ value, onChange
           aria-valuetext={label ? `${display(value)} ${label}` : display(value)}
           aria-label={label}
           title={label ? `Drag up/down to adjust ${label}` : 'Drag up/down to adjust'}
+          onDoubleClick={() => onChange(defaultValue ?? min)}
         >
           <div className="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-[2px] opacity-0 group-hover:opacity-100 transition-opacity text-[8px] text-yellow-500/50 pointer-events-none">▲</div>
           <div className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-[2px] opacity-0 group-hover:opacity-100 transition-opacity text-[8px] text-yellow-500/50 pointer-events-none">▼</div>

--- a/src/components/Knob.tsx
+++ b/src/components/Knob.tsx
@@ -10,9 +10,10 @@ interface KnobProps {
   color?: 'cyan' | 'pink' | 'yellow' | 'purple' | 'red' | 'green' | 'indigo';
   unit?: string;
   logarithmic?: boolean;
+  defaultValue?: number;
 }
 
-export const Knob: React.FC<KnobProps> = memo(({ label, value, onChange, min, max, step = 1, color = 'cyan', unit = '', logarithmic = false }) => {
+export const Knob: React.FC<KnobProps> = memo(({ label, value, onChange, min, max, step = 1, color = 'cyan', unit = '', logarithmic = false, defaultValue }) => {
   const knobRef = useRef<HTMLDivElement>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [dragStartY, setDragStartY] = useState(0);
@@ -202,6 +203,7 @@ export const Knob: React.FC<KnobProps> = memo(({ label, value, onChange, min, ma
         aria-valuenow={value}
         aria-valuetext={formatValue(value)}
         aria-orientation="vertical"
+        onDoubleClick={() => onChange(defaultValue ?? min)}
       >
         <div
           className="w-12 h-12 bg-gray-800 rounded-full relative shadow-inner"


### PR DESCRIPTION
Added UX enhancement: Double-clicking `Knob` and `DragValue` resets their values.

---
*PR created automatically by Jules for task [12093854350504747166](https://jules.google.com/task/12093854350504747166) started by @ford442*