### PR TITLE
⚡ Bolt: Prevent unnecessary re-renders with React.memo() on complex UI components

### DIFF
--- a/src/components/NoteSelector.tsx
+++ b/src/components/NoteSelector.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import { NOTES, getScaleNotes } from '../utils/musicTheory';
 import type { ScaleDefinition } from '../utils/musicTheory';
 import { useFocusTrap } from '../hooks/useFocusTrap';
@@ -39,7 +39,7 @@ interface NoteSelectorProps {
     onPropertyChange?: (key: 'timbre' | 'velocity' | 'probability' | 'microtiming' | 'reverse' | 'retrigger' | 'freeze' | 'formantShift' | 'filterCutoff' | 'filterResonance' | 'envMod' | 'formantLfoRate' | 'formantLfoDepth' | 'formantEnvAttack' | 'formantEnvDecay' | 'formantEnvAmount' | 'vibratoDepth' | 'drive' | 'characterMorph' | 'reverbSend' | 'reverbType' | 'delaySend' | 'choir', value: number | boolean | string) => void;
 }
 
-export const NoteSelector: React.FC<NoteSelectorProps> = ({
+export const NoteSelector: React.FC<NoteSelectorProps> = memo(({
     x, y, trackType, currentNote, currentLength, onSelect, onLengthChange, onClose, getNoteColor, currentScale,
     currentTimbre = 0, currentVelocity = 1, currentProbability = 1, currentMicrotiming = 0, currentReverse = false, currentRetrigger = 1, currentFreeze = 0, currentFormantShift, currentFilterCutoff, currentFilterResonance, currentEnvMod, currentFormantLfoRate = 0, currentFormantLfoDepth = 0,  currentVibratoDepth = 0, currentDrive, currentCharacterMorph = 0, currentReverbSend, currentReverbType, currentDelaySend, currentChoir, onPropertyChange
 }) => {
@@ -547,4 +547,4 @@ export const NoteSelector: React.FC<NoteSelectorProps> = ({
             </div>
         </>
     );
-};
+});

--- a/src/components/SamplerPanel.tsx
+++ b/src/components/SamplerPanel.tsx
@@ -46,7 +46,7 @@ const SAMPLE_BANKS = Array.from({ length: 8 }, (_, i) => `${i + 1}`);
 const grainSizeToMs = (size: number) => Math.round(size / 441 * 10);
 const grainSizeToPercent = (size: number) => ((size - 441) / (22050 - 441) * 100);
 
-const SamplerPanelComponent: React.FC<SamplerPanelProps> = ({
+const SamplerPanelComponent: React.FC<SamplerPanelProps> = React.memo(({
     params, onChange, onLoadSample, audioContext, audioEngine, activeBankIdx, onBankChange, onOpenEditor, isVoiceEditorOpen,
     ttsPhrases, onTtsPhraseChange, onGenerateTTS,
     onHarmonize, onParamChange, loadedBanks, sampleBuffer, sliceHighlightRef,
@@ -1071,7 +1071,7 @@ const SamplerPanelComponent: React.FC<SamplerPanelProps> = ({
             </div>
         </div>
     );
-};
+});
 
 // Custom comparison for memoization to prevent re-renders when other banks update
 export const SamplerPanel = memo(SamplerPanelComponent, (prev, next) => {

--- a/src/components/SamplerPitchControls.tsx
+++ b/src/components/SamplerPitchControls.tsx
@@ -41,7 +41,7 @@ interface VerticalMiniLadderProps {
   onSelect: (note: number) => void;
 }
 
-const VerticalMiniLadder: React.FC<VerticalMiniLadderProps> = ({ selected, onSelect }) => {
+const VerticalMiniLadder: React.FC<VerticalMiniLadderProps> = React.memo(({ selected, onSelect }) => {
   // Show 12 notes centered around selected
   const startNote = Math.max(36, Math.min(selected - 6, 96));
   const notes = Array.from({ length: 12 }, (_, i) => startNote + i);
@@ -114,7 +114,7 @@ const VerticalMiniLadder: React.FC<VerticalMiniLadderProps> = ({ selected, onSel
       })}
     </div>
   );
-};
+});
 
 // ⚡ Bolt: Added React.memo to prevent unnecessary re-renders when parent state changes.
 export const SamplerPitchControls: React.FC<SamplerPitchControlsProps> = React.memo(({

--- a/src/components/WaveformDisplay.tsx
+++ b/src/components/WaveformDisplay.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, memo } from 'react';
 import type { AlignmentResult } from '../engines/rubberband/PhonemeAligner';
 
 interface WaveformDisplayProps {
@@ -11,7 +11,7 @@ interface WaveformDisplayProps {
     onAutoSliceSensitivityChange?: (val: number) => void;
 }
 
-export const WaveformDisplay: React.FC<WaveformDisplayProps> = ({ buffer, alignment, sliceHighlightRef, onAlignmentChange, onAutoSlice, autoSliceSensitivity = 50, onAutoSliceSensitivityChange }) => {
+export const WaveformDisplay: React.FC<WaveformDisplayProps> = memo(({ buffer, alignment, sliceHighlightRef, onAlignmentChange, onAutoSlice, autoSliceSensitivity = 50, onAutoSliceSensitivityChange }) => {
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
     const activeSliceRef = useRef<number>(-1);
@@ -689,4 +689,4 @@ export const WaveformDisplay: React.FC<WaveformDisplayProps> = ({ buffer, alignm
             )}
         </div>
     );
-};
+});


### PR DESCRIPTION
💡 What: Added `React.memo()` wrappers to several functional UI components that were missing them (`WaveformDisplay`, `NoteSelector`, `SamplerPitchControls`, `SamplerPanelComponent`).
🎯 Why: To prevent unnecessary React reconciliation and re-renders when parent components update state but pass the same props down to these relatively complex visual components.
📊 Impact: Expected reduction in React render cycle times and avoidance of re-renders when interacting with components outside of these specific widgets.
🔬 Measurement: Verified via `pnpm run test` and `pnpm run build` locally. Check render counts using React DevTools profiler.

---
*PR created automatically by Jules for task [15123101904384164401](https://jules.google.com/task/15123101904384164401) started by @ford442*