### PR TITLE
🎨 Palette: Add focus indicators to Song Mode buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-04-28 - App Action Bar Accessibility
 **Learning:** Primary interaction buttons in the bottom action bar lacked WCAG 2.4.7 focus visibility indicators, making them difficult for keyboard users.
 **Action:** Added `focus-visible:ring-2` with color-matched rings and descriptive `aria-label` attributes to the NOTES, AUTO, SAVE, LOAD, and Import buttons in `App.tsx`.
+## 2024-05-02 - Song Mode Button Focus Accessibility
+**Learning:** The Song Mode interface buttons (add/remove bar, toggle mode, clear background) lacked explicit focus states, making keyboard navigation difficult.
+**Action:** Added `focus-visible:ring-2` and appropriate `focus-visible:ring-{color}-500` classes with `focus:outline-none` to all interactive buttons in `SongMode.tsx`.

--- a/src/components/SongMode.tsx
+++ b/src/components/SongMode.tsx
@@ -286,13 +286,13 @@ export const SongMode = memo(({
                 <div className="h-14 bg-gradient-to-r from-[#0b0d10] to-[#0d0f12] border-b-2 border-cyan-900/30 flex items-center justify-between px-6 shrink-0 relative">
                      <h2 className="font-orbitron font-bold text-cyan-400 tracking-widest">SONG ARRANGER</h2>
                      <div className="flex gap-3 items-center">
-                        <button onClick={onRemoveMeasure} aria-label="Remove Measure" className="px-3 py-1.5 bg-gray-800 text-gray-300 text-xs rounded-lg border border-gray-600">- BAR</button>
-                        <button onClick={onAddMeasure} aria-label="Add Measure" className="px-3 py-1.5 bg-gray-800 text-cyan-300 text-xs rounded-lg border border-cyan-900/50">+ BAR</button>
+                        <button onClick={onRemoveMeasure} aria-label="Remove Measure" className="px-3 py-1.5 bg-gray-800 text-gray-300 text-xs rounded-lg border border-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500">- BAR</button>
+                        <button onClick={onAddMeasure} aria-label="Add Measure" className="px-3 py-1.5 bg-gray-800 text-cyan-300 text-xs rounded-lg border border-cyan-900/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500">+ BAR</button>
                         <button
                             onClick={() => onSetIsSongModeActive(!isSongModeActive)}
                             aria-pressed={isSongModeActive}
                             aria-label={isSongModeActive ? 'Loop Song Mode Active' : 'Loop Pattern Mode Active'}
-                            className={`px-3 py-1.5 text-xs rounded-lg border font-bold ${isSongModeActive ? 'bg-purple-600 text-white border-purple-400' : 'bg-gray-800 text-gray-400 border-gray-700'}`}
+                            className={`px-3 py-1.5 text-xs rounded-lg border font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 ${isSongModeActive ? 'bg-purple-600 text-white border-purple-400' : 'bg-gray-800 text-gray-400 border-gray-700'}`}
                         >
                             {isSongModeActive ? 'LOOP SONG' : 'LOOP PATT'}
                         </button>
@@ -382,20 +382,20 @@ export const SongMode = memo(({
                         {backgroundImage && (
                             <button
                                 onClick={() => onSetBackgroundImage('')}
-                                className="text-gray-500 hover:text-white px-1 text-xs"
+                                className="text-gray-500 hover:text-white px-1 text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 rounded"
                                 aria-label="Clear Background Image"
                             >
                                 ✕
                             </button>
                         )}
                     </div>
-                    <button onClick={onRemoveMeasure} aria-label="Remove Measure" className="px-3 py-1.5 bg-gradient-to-r from-gray-800 to-gray-700 text-gray-300 text-xs rounded-lg hover:from-gray-700 hover:to-gray-600 border border-gray-600 shadow-md transition-all">- BAR</button>
-                    <button onClick={onAddMeasure} aria-label="Add Measure" className="px-3 py-1.5 bg-gradient-to-r from-gray-800 to-gray-700 text-cyan-300 text-xs rounded-lg hover:from-gray-700 hover:to-gray-600 border border-cyan-900/50 shadow-md transition-all">+ BAR</button>
+                    <button onClick={onRemoveMeasure} aria-label="Remove Measure" className="px-3 py-1.5 bg-gradient-to-r from-gray-800 to-gray-700 text-gray-300 text-xs rounded-lg hover:from-gray-700 hover:to-gray-600 border border-gray-600 shadow-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500">- BAR</button>
+                    <button onClick={onAddMeasure} aria-label="Add Measure" className="px-3 py-1.5 bg-gradient-to-r from-gray-800 to-gray-700 text-cyan-300 text-xs rounded-lg hover:from-gray-700 hover:to-gray-600 border border-cyan-900/50 shadow-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500">+ BAR</button>
                     <button
                         onClick={() => onSetIsSongModeActive(!isSongModeActive)}
                         aria-pressed={isSongModeActive}
                         aria-label={isSongModeActive ? 'Loop Song Mode Active' : 'Loop Pattern Mode Active'}
-                        className={`px-3 py-1.5 text-xs rounded-lg border font-bold transition-all ${isSongModeActive ? 'bg-purple-600 text-white border-purple-400 shadow-[0_0_10px_rgba(168,85,247,0.5)]' : 'bg-gray-800 text-gray-400 border-gray-700'}`}
+                        className={`px-3 py-1.5 text-xs rounded-lg border font-bold transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 ${isSongModeActive ? 'bg-purple-600 text-white border-purple-400 shadow-[0_0_10px_rgba(168,85,247,0.5)]' : 'bg-gray-800 text-gray-400 border-gray-700'}`}
                     >
                         {isSongModeActive ? 'LOOP SONG' : 'LOOP PATT'}
                     </button>
@@ -411,7 +411,7 @@ export const SongMode = memo(({
                         }}
                         disabled={isExporting}
                         aria-label="Export as XM file"
-                        className={`ml-2 px-4 py-1.5 flex items-center justify-center min-w-[100px] bg-gradient-to-r text-cyan-400 text-xs font-bold border border-cyan-700/50 rounded-lg shadow-lg transition-all ${
+                        className={`ml-2 px-4 py-1.5 flex items-center justify-center min-w-[100px] bg-gradient-to-r text-cyan-400 text-xs font-bold border border-cyan-700/50 rounded-lg shadow-lg transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 ${
                             isExporting
                             ? 'from-cyan-900/20 to-cyan-800/20 opacity-70 cursor-wait'
                             : 'from-cyan-900/40 to-cyan-800/40 hover:from-cyan-800/60 hover:to-cyan-700/60'
@@ -428,7 +428,7 @@ export const SongMode = memo(({
                             </span>
                         ) : 'EXPORT XM'}
                     </button>
-                    <button onClick={onToggle} aria-label="Close Song Mode" title="Close Song Mode" className="ml-2 text-gray-400 hover:text-white text-lg transition-colors">✕</button>
+                    <button onClick={onToggle} aria-label="Close Song Mode" title="Close Song Mode" className="ml-2 text-gray-400 hover:text-white text-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 rounded px-1">✕</button>
                 </div>
             </div>
 


### PR DESCRIPTION
💡 What: Added explicit keyboard focus indicators (Tailwind `focus-visible:ring-2` with matched colors) to the main interactive buttons within the Song Mode overlay interface. Also documented this accessibility pattern in the Palette journal.
🎯 Why: Previously, keyboard users navigating via Tab had no visual indication of which button in the Song Arranger was focused. This violates basic accessibility standards and makes the sequencer difficult to use without a mouse.
📸 Before/After: Verified visually with Playwright.
♿ Accessibility: Directly satisfies WCAG 2.4.7 Focus Visible by providing high-contrast focus rings around buttons on keyboard focus.

---
*PR created automatically by Jules for task [10764371981431963396](https://jules.google.com/task/10764371981431963396) started by @ford442*