### PR TITLE
🎨 Palette: [Advanced Keyboard A11y & Focus Management]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-01 - Fix aria-controls for Harmonizer Popover
 **Learning:** Found that custom dropdowns/popovers acting as modals or flyouts require a clear structural link using `aria-controls` pointing to the exact `id` of the popover content. The `aria-expanded` and `aria-haspopup` tags alone are insufficient for complete screen reader accessibility if the container it targets cannot be identified via an `id` reference.
 **Action:** Always ensure that `aria-controls` matches a specific `id` attribute on the container component whenever implementing custom popup interfaces.
+## 2024-06-25 - Advanced Keyboard Interaction Patterns
+**Learning:** For a complex app like a DAW, simple gestural controls (like dragging up/down to change pitch) are entirely inaccessible to keyboard-only users. Furthermore, when closing deep nested menus like popovers, relying on the browser's default focus management will drop the user back at the top of the page, ruining the navigation flow.
+**Action:** Always provide explicit arrow-key support (`onKeyDown`) for gestural or slider-like UI elements to replicate drag behavior. Always use a `useRef` to track the trigger element that opened a popover, and explicitly call `.focus()` on it when the popover closes.

--- a/src/components/AdvancedNoteSelector.tsx
+++ b/src/components/AdvancedNoteSelector.tsx
@@ -151,6 +151,30 @@ export const AdvancedNoteSelector: React.FC<AdvancedNoteSelectorProps> = React.m
     const color = getNoteColor(value, trackKey);
     const currentNoteName = extractNoteName(value);
 
+    const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLButtonElement>) => {
+        if (e.key === 'ArrowUp' || e.key === 'ArrowRight') {
+            e.preventDefault();
+            let targetMidi = clamp(currentMidi + 1);
+            if (currentScale && !isMidiInScale(targetMidi, currentScale)) {
+                targetMidi = nextScaleNote(currentMidi, 1, currentScale);
+                targetMidi = clamp(targetMidi);
+            }
+            if (targetMidi !== currentMidi) {
+                onChange(midiToNote(targetMidi));
+            }
+        } else if (e.key === 'ArrowDown' || e.key === 'ArrowLeft') {
+            e.preventDefault();
+            let targetMidi = clamp(currentMidi - 1);
+            if (currentScale && !isMidiInScale(targetMidi, currentScale)) {
+                targetMidi = nextScaleNote(currentMidi, -1, currentScale);
+                targetMidi = clamp(targetMidi);
+            }
+            if (targetMidi !== currentMidi) {
+                onChange(midiToNote(targetMidi));
+            }
+        }
+    }, [currentMidi, clamp, currentScale, onChange]);
+
     return (
         <div className="relative inline-block">
             {/* Main button: displays current note, supports drag */}
@@ -164,6 +188,7 @@ export const AdvancedNoteSelector: React.FC<AdvancedNoteSelectorProps> = React.m
                 onPointerDown={handlePointerDown}
                 onPointerMove={handlePointerMove}
                 onPointerUp={handlePointerUp}
+                onKeyDown={handleKeyDown}
                 aria-label={label ?? `Note ${value}`}
                 aria-haspopup="true"
                 aria-expanded={flyoutOpen}

--- a/src/components/SamplerVoicePanel.tsx
+++ b/src/components/SamplerVoicePanel.tsx
@@ -489,6 +489,7 @@ export const SamplerVoicePanel: React.FC<SamplerVoicePanelProps> = React.memo(({
     const [isHarmonizerOpen, setIsHarmonizerOpen] = useState(false);
 
     const ladderButtonRefs = useRef<Map<number, HTMLButtonElement>>(new Map());
+    const harmonizeTriggerRef = useRef<HTMLButtonElement>(null);
 
     const handleRootNoteChange = (midi: number) => {
         setLocalRootNote(midi);
@@ -753,6 +754,7 @@ export const SamplerVoicePanel: React.FC<SamplerVoicePanelProps> = React.memo(({
                             {/* HARMONIZE Button - Hardware style */}
                             <div className="relative">
                                 <button
+                                    ref={harmonizeTriggerRef}
                                     onClick={() => setIsHarmonizerOpen(!isHarmonizerOpen)}
                                     aria-haspopup="dialog"
                                     aria-expanded={isHarmonizerOpen}
@@ -782,7 +784,10 @@ export const SamplerVoicePanel: React.FC<SamplerVoicePanelProps> = React.memo(({
                                 {/* Harmonizer Popover */}
                                 <HarmonizerPopover
                                     isOpen={isHarmonizerOpen}
-                                    onClose={() => setIsHarmonizerOpen(false)}
+                                    onClose={() => {
+                                        setIsHarmonizerOpen(false);
+                                        harmonizeTriggerRef.current?.focus();
+                                    }}
                                     config={harmonizerConfig || defaultConfig}
                                     isActive={isHarmonizeActive}
                                     onApply={onHarmonizerConfigChange || (() => {})}


### PR DESCRIPTION
This PR brings significant accessibility improvements for keyboard users in the DAW interface:

1. **Gestural Fallbacks (`AdvancedNoteSelector.tsx`)**: Keyboard-only users can now adjust notes dynamically! Arrow keys (Up/Right) and (Down/Left) naturally replicate the vertical mouse drag gesture, hooking into the exact same boundary clamping and scale-snapping logic.
2. **Focus Management (`SamplerVoicePanel.tsx`)**: Previously, closing the Harmonizer popover would drop the user's focus back to the top of the page. Now, using a `useRef`, focus correctly snaps back to the specific "Harmonize" trigger button, keeping the user in their active sequencer slot.

Verified to pass all existing tests and linters.

---
*PR created automatically by Jules for task [16449092440723592124](https://jules.google.com/task/16449092440723592124) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard navigation to the note selector, enabling users to adjust pitch using arrow keys with scale-aware pitch snapping.

* **Improvements**
  * Enhanced focus management for harmonizer controls, ensuring proper focus return when closing popovers for better accessibility and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->