### PR TITLE
🎨 Palette: Improved accessibility of HarmonizerPopover

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-06-25 - Advanced Keyboard Interaction Patterns
 **Learning:** For a complex app like a DAW, simple gestural controls (like dragging up/down to change pitch) are entirely inaccessible to keyboard-only users. Furthermore, when closing deep nested menus like popovers, relying on the browser's default focus management will drop the user back at the top of the page, ruining the navigation flow.
 **Action:** Always provide explicit arrow-key support (`onKeyDown`) for gestural or slider-like UI elements to replicate drag behavior. Always use a `useRef` to track the trigger element that opened a popover, and explicitly call `.focus()` on it when the popover closes.
+
+## 2024-05-09 - Accessibility in Canvas Overlays
+**Learning:** Interactive elements within dense, absolute-positioned canvas overlays (like `HarmonizerPopover`) frequently lack focus rings because they aren't part of standard top-to-bottom form flows. Developers often style them as custom widgets but forget keyboard-only navigation needs visible focus states just as much as standard HTML forms do.
+**Action:** Always check custom popovers, context menus, and floating widgets for `focus-visible:ring-2` to ensure keyboard accessibility.

--- a/src/components/sampler/HarmonizerPopover.tsx
+++ b/src/components/sampler/HarmonizerPopover.tsx
@@ -96,7 +96,8 @@ export const HarmonizerPopover: React.FC<HarmonizerPopoverProps> = React.memo(({
                     {/* Toggle switch style ON/OFF button */}
                     <button
                         onClick={() => setLocalActive(!localActive)}
-                        className={`relative px-3 py-1 rounded-full text-[9px] font-bold transition-all border ${
+                        aria-label={localActive ? 'Disable Harmonizer' : 'Enable Harmonizer'}
+                        className={`relative px-3 py-1 rounded-full text-[9px] font-bold transition-all border focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900 focus-visible:ring-cyan-500 ${
                             localActive
                                 ? 'bg-green-500/20 text-green-400 border-green-500/50 shadow-[0_0_10px_rgba(34,197,94,0.3)]'
                                 : 'bg-zinc-800 text-zinc-500 border-zinc-600'
@@ -122,7 +123,7 @@ export const HarmonizerPopover: React.FC<HarmonizerPopoverProps> = React.memo(({
                                     onClick={() => handleVoiceCountChange(count as 2 | 3 | 4)}
                                     aria-label={`${count} Voices`}
                                     aria-checked={localConfig.voiceCount === count}
-                                    className={`flex-1 py-1.5 rounded-md text-[10px] font-bold transition-all ${
+                                    className={`flex-1 py-1.5 rounded-md text-[10px] font-bold transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900 focus-visible:ring-cyan-500 ${
                                         localConfig.voiceCount === count
                                             ? 'text-black shadow-lg'
                                             : 'text-zinc-500 hover:text-zinc-300'
@@ -149,7 +150,7 @@ export const HarmonizerPopover: React.FC<HarmonizerPopoverProps> = React.memo(({
                                     onClick={() => handleHarmonyTypeChange(value)}
                                     aria-label={`${label} Harmony`}
                                     aria-checked={localConfig.harmonyType === value}
-                                    className={`py-1.5 rounded-md text-[9px] font-bold transition-all relative overflow-hidden ${
+                                    className={`py-1.5 rounded-md text-[9px] font-bold transition-all relative overflow-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900 focus-visible:ring-cyan-500 ${
                                         localConfig.harmonyType === value
                                             ? 'text-white'
                                             : 'bg-zinc-800/80 text-zinc-400 border border-zinc-700 hover:bg-zinc-700/80 hover:border-zinc-600'
@@ -239,7 +240,7 @@ export const HarmonizerPopover: React.FC<HarmonizerPopoverProps> = React.memo(({
                                 <button
                                     key={key}
                                     onClick={() => setLocalConfig(HARMONIZE_PRESETS[key as keyof typeof HARMONIZE_PRESETS]())}
-                                    className="flex-1 py-1.5 rounded-md text-[8px] font-bold bg-gradient-to-b from-zinc-800 to-zinc-900 text-zinc-400 border border-zinc-700 hover:text-zinc-200 transition-all shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]"
+                                    className="flex-1 py-1.5 rounded-md text-[8px] font-bold bg-gradient-to-b from-zinc-800 to-zinc-900 text-zinc-400 border border-zinc-700 hover:text-zinc-200 transition-all shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900 focus-visible:ring-cyan-500"
                                     title={desc}
                                     aria-label={`Apply ${desc} Preset`}
                                 >
@@ -254,7 +255,7 @@ export const HarmonizerPopover: React.FC<HarmonizerPopoverProps> = React.memo(({
                         onClick={handleApply}
                         aria-label="Apply Harmonizer Settings"
                         title="Apply Harmonizer Settings"
-                        className="w-full py-2.5 rounded-lg text-xs font-bold font-orbitron tracking-wider transition-all text-black relative overflow-hidden group"
+                        className="w-full py-2.5 rounded-lg text-xs font-bold font-orbitron tracking-wider transition-all text-black relative overflow-hidden group focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900 focus-visible:ring-cyan-500"
                         style={{
                             background: `linear-gradient(135deg, ${color} 0%, ${color}dd 50%, ${color} 100%)`,
                             boxShadow: `0 4px 20px ${color}50, inset 0 1px 0 rgba(255,255,255,0.2)`


### PR DESCRIPTION
🎨 Palette: Improved accessibility of HarmonizerPopover

💡 What: Added missing `aria-label`s and `focus-visible` styling to interactive elements in `HarmonizerPopover`.
🎯 Why: Ensures screen reader accessibility and clear keyboard focus states for elements inside dense canvas overlays that fall outside standard form flows.
♿ Accessibility:
- Added `aria-label` to the ON/OFF toggle switch.
- Added `focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-cyan-500` to the Voice Count, Harmony Type, Quick Presets, and Apply buttons.
- Ensured consistent keyboard focus rings for all interactive elements in the popover.

---
*PR created automatically by Jules for task [3716024745643970440](https://jules.google.com/task/3716024745643970440) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation with visible focus indicators across all interactive elements in popover controls—including buttons, toggles, radio options, and preset selections—providing clear visual feedback for keyboard users.
  * Enhanced screen reader support with more descriptive labels on toggle controls to improve accessibility for assistive technology users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->