### PR TITLE
🎨 Palette: Fix accessibility for GamepadDebugger modal

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-05-09 - Accessibility in Canvas Overlays
 **Learning:** Interactive elements within dense, absolute-positioned canvas overlays (like `HarmonizerPopover`) frequently lack focus rings because they aren't part of standard top-to-bottom form flows. Developers often style them as custom widgets but forget keyboard-only navigation needs visible focus states just as much as standard HTML forms do.
 **Action:** Always check custom popovers, context menus, and floating widgets for `focus-visible:ring-2` to ensure keyboard accessibility.
+
+## 2024-11-20 - Custom Dialog Focus Management
+**Learning:** When implementing custom modals or dialogs using `role="dialog"`, it is critical to include `tabIndex={-1}` on the dialog container itself. Without this, the dialog cannot receive programmatic focus when opened, which can disrupt screen reader announcements and keyboard navigation flow. Additionally, close buttons inside these modals often miss focus rings because they use absolute positioning and custom SVG icons instead of standard button styles.
+**Action:** Always verify that custom dialog containers have `tabIndex={-1}` and ensure interactive elements within them (like close buttons) explicitly implement `focus-visible` utility classes for keyboard accessibility.

--- a/.swarm-state.md
+++ b/.swarm-state.md
@@ -65,3 +65,4 @@ What was done: Added a "Build WASM" step (`pnpm run build:wasm`) to `ci.yml` bef
 Next step: None — task complete.
 Blockers: none
 Adding microtonal tuning instructions to swarm-state
+- UI E2E Verification for GamepadDebugger skipped due to Pyodide initialization delay, which is expected locally. (Verified functionality via unit test execution and component source inspection).

--- a/src/components/GamepadDebugger.tsx
+++ b/src/components/GamepadDebugger.tsx
@@ -28,10 +28,10 @@ export const GamepadDebugger: React.FC<{ onClose: () => void }> = React.memo(({ 
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm p-4 overflow-y-auto" onClick={onClose}>
       <div aria-hidden="true" className="absolute inset-0 z-0"></div>
-      <div className="bg-slate-900 border border-slate-700 rounded-xl shadow-2xl w-full max-w-5xl p-6 relative" role="dialog" aria-modal="true" aria-labelledby="gamepad-debugger-title" aria-describedby="gamepad-debugger-desc" ref={modalRef} onClick={e => e.stopPropagation()}>
+      <div className="bg-slate-900 border border-slate-700 rounded-xl shadow-2xl w-full max-w-5xl p-6 relative" role="dialog" aria-modal="true" aria-labelledby="gamepad-debugger-title" aria-describedby="gamepad-debugger-desc" tabIndex={-1} ref={modalRef} onClick={e => e.stopPropagation()}>
         <button
           onClick={onClose}
-          className="absolute top-4 right-4 text-slate-400 hover:text-white"
+          className="absolute top-4 right-4 text-slate-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 rounded p-1"
           aria-label="Close Debugger"
           title="Close Debugger"
         >


### PR DESCRIPTION
💡 **What:** Added missing `tabIndex={-1}` to the `GamepadDebugger`'s `role="dialog"` container and implemented proper `focus-visible` utility classes for its close button.
🎯 **Why:** To ensure the modal is accessible to keyboard users and screen readers, making it possible for focus to be trapped/placed inside the dialog properly, and to make the close button's focused state clearly visible when navigating via keyboard.
♿ **Accessibility:** Focus management improved via `tabIndex`, and focus visibility improved via `focus-visible` ring on the interactive SVG icon button.

---
*PR created automatically by Jules for task [12968992987816429133](https://jules.google.com/task/12968992987816429133) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Improved keyboard focus management in modal dialogs for better accessibility.
  - Enhanced visual focus indicators on close buttons to provide clearer feedback for keyboard navigation.
  - Better overall support for keyboard-only users in modal interactions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/web_sequencer/pull/534)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->