### PR TITLE
🎨 Palette: Added Focus Visible to GamepadDebugger and LiveKeyboard Close Buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-18 - Added ARIA Labels to Missing Icons
 **Learning:** Found several generic visual indicators or icons missing context for screen readers. Ensure SVG or generic div controls inside buttons use `aria-label` attributes consistently.
 **Action:** Always add descriptive `aria-label` attributes to button elements lacking explicit readable text, particularly in interactive visual elements like canvases or specialized components like `DrawableLFO.tsx` and `Rack.tsx`.
+## 2024-05-12 - Added Focus Visible to LiveKeyboard Close Button
+**Learning:** For floating modals and guides with absolute positioned close buttons (like LiveKeyboard), the `focus-visible:ring-2` class is necessary for keyboard navigation since standard hover effects don't apply when tabbing.
+**Action:** When adding close buttons (`✕`) to popovers or guides, always include `focus:outline-none focus-visible:ring-2 focus-visible:ring-[color] rounded`.

--- a/src/components/GamepadDebugger.tsx
+++ b/src/components/GamepadDebugger.tsx
@@ -31,7 +31,7 @@ export const GamepadDebugger: React.FC<{ onClose: () => void }> = React.memo(({ 
       <div className="bg-slate-900 border border-slate-700 rounded-xl shadow-2xl w-full max-w-5xl p-6 relative" role="dialog" aria-modal="true" aria-labelledby="gamepad-debugger-title" aria-describedby="gamepad-debugger-desc" ref={modalRef} onClick={e => e.stopPropagation()}>
         <button
           onClick={onClose}
-          className="absolute top-4 right-4 text-slate-400 hover:text-white"
+          className="absolute top-4 right-4 text-slate-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 rounded p-1.5"
           aria-label="Close Debugger"
           title="Close Debugger"
         >

--- a/src/components/LiveKeyboard.tsx
+++ b/src/components/LiveKeyboard.tsx
@@ -54,7 +54,7 @@ const KeyboardGuide = ({ onClose }: { onClose: () => void }) => {
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm animate-fadeIn" onClick={onClose}>
             <div role="dialog" aria-modal="true" aria-labelledby="keyboard-guide-title" ref={guideRef} className="relative p-8 border-2 border-dashed border-cyan-500/50 rounded-2xl bg-[#0d1015] shadow-[0_0_50px_rgba(6,182,212,0.15)] max-w-2xl w-full mx-4" onClick={e => e.stopPropagation()}>
-                <button onClick={onClose} className="absolute top-4 right-4 text-gray-500 hover:text-white transition-colors" aria-label="Close guide" title="Close Guide">✕</button>
+                <button onClick={onClose} className="absolute top-4 right-4 text-gray-500 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1015] rounded p-1.5" aria-label="Close guide" title="Close Guide">✕</button>
                 <div className="text-center mb-8">
                     <h3 id="keyboard-guide-title" className="text-2xl font-orbitron font-bold text-cyan-400 mb-2 tracking-widest">PIANO KEYBOARD</h3>
                     <p className="text-gray-400 font-mono text-sm">Classic piano layout with 5 black keys and 8 white keys.</p>


### PR DESCRIPTION
🎨 Palette: Added Focus Visible to GamepadDebugger and LiveKeyboard Close Buttons

💡 What: Added the `focus-visible:ring-2` and `focus-visible:ring-offset-2` class to the absolute positioned close buttons in `GamepadDebugger.tsx` and `LiveKeyboard.tsx`.
🎯 Why: To ensure keyboard navigation works properly, as standard hover effects do not apply when tabbing through the interface.
♿ Accessibility: Improved keyboard navigation by adding a visible focus indicator to the close buttons, making them accessible to keyboard users.

---
*PR created automatically by Jules for task [10063110731236940940](https://jules.google.com/task/10063110731236940940) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated accessibility guidelines for focus styling on close buttons in interactive components.

* **Style**
  * Enhanced keyboard focus visibility on close buttons with improved ring offset styling for better visual feedback during keyboard navigation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/web_sequencer/pull/535)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->