### PR TITLE
fix(audio): remove duplicate gateDepth/gateRate in RubberBandProcesso…

### DIFF
--- a/src/audio-worklets/rubberband-processor.ts
+++ b/src/audio-worklets/rubberband-processor.ts
@@ -72,8 +72,6 @@ class RubberBandProcessor extends AudioWorkletProcessor {
       { name: 'freezeEnvDepth', defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },
       { name: 'grainEnvDepth', defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },
       { name: 'grainPitchQuantize', defaultValue: 0.0, minValue: 0.0, maxValue: 12.0 },
-      { name: 'gateDepth', defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },
-      { name: 'gateRate', defaultValue: 0.0, minValue: 0.0, maxValue: 20.0 },
       { name: 'tranceGate', defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 }
     ];
   }


### PR DESCRIPTION
…r parameterDescriptors

The vocal-overdrive-worklet merge added a second gateDepth and gateRate entry to the parameterDescriptors() array (lines 75-76), duplicating the originals at lines 62-63. The Web Audio API throws NotSupportedError on duplicate parameter names, which prevented RubberBandProcessor from registering at all. This cascaded into every SingingVoice init failing and all TTS/sampler voice synthesis being silent.

Kept the first occurrence (gateRate defaultValue: 4.0, maxValue: 50.0) and removed the duplicates. The new tranceGate parameter from the same merge is distinct and kept.

https://claude.ai/code/session_019PJh23or5kEaMXo44ZktrW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new audio processing parameter to the RubberBand processor.

* **Refactor**
  * Adjusted gating parameter values for improved audio processing control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/web_sequencer/pull/553)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->