### PR TITLE
fix(singing-voice): fix MessagePort delivery causing 10s init timeout

### DIFF
--- a/src/audio-worklets/rubberband-processor.ts
+++ b/src/audio-worklets/rubberband-processor.ts
@@ -95,7 +95,7 @@ class RubberBandProcessor extends AudioWorkletProcessor {
     switch (type) {
       case 'INIT_WASM':
         try {
-          const { inputBuffer, outputBuffer, wasmBinary } = event.data;
+          const { inputBuffer, outputBuffer, wasmBinary, baseUrl } = event.data;
 
           this.inputRingBuffer = new RingBuffer(inputBuffer);
           this.outputRingBuffer = new RingBuffer(outputBuffer);
@@ -104,12 +104,13 @@ class RubberBandProcessor extends AudioWorkletProcessor {
             throw new Error("WASM binary not provided in INIT_WASM message");
           }
 
+          const wasmPath = `${baseUrl || '/'}rubberband.wasm`;
           // Instantiate WASM module with the provided binary
           // @ts-ignore
           const module = await createRubberBandModule({
             wasmBinary: wasmBinary,
             locateFile: (path: string) => {
-              if (path.endsWith('.wasm')) return '/rubberband.wasm';
+              if (path.endsWith('.wasm')) return wasmPath;
               return path;
             }
           });

--- a/src/engines/SingingVoice.ts
+++ b/src/engines/SingingVoice.ts
@@ -212,50 +212,30 @@ export class SingingVoice {
                 inputBuffer,
                 outputBuffer,
                 wasmBinary: binary,
-                moduleUrl: '/rubberband.js'
+                moduleUrl: '/rubberband.js',
+                baseUrl: import.meta.env.BASE_URL
             });
 
-            // Wait for ready signal
+            // Wait for ready signal.
+            // IMPORTANT: use port.onmessage (not addEventListener) — setting onmessage
+            // automatically calls port.start(), which is required to begin message delivery
+            // on a MessagePort. addEventListener alone does NOT start delivery.
             await new Promise<void>((resolve, reject) => {
-                let timeoutId: any = 0;
+                let timeoutId: ReturnType<typeof setTimeout>;
                 const handler = (event: MessageEvent) => {
-                    try { clearTimeout(timeoutId); } catch (_) {}
+                    clearTimeout(timeoutId);
+                    this.workletNode!.port.onmessage = null;
                     if (event.data.type === 'READY') {
-                        try {
-                            if (typeof (this.workletNode!.port as any).removeEventListener === 'function') {
-                                (this.workletNode!.port as any).removeEventListener('message', handler);
-                            } else {
-                                (this.workletNode!.port as any).onmessage = null;
-                            }
-                        } catch (_) {}
                         resolve();
                     } else if (event.data.type === 'ERROR') {
-                        try {
-                            if (typeof (this.workletNode!.port as any).removeEventListener === 'function') {
-                                (this.workletNode!.port as any).removeEventListener('message', handler);
-                            } else {
-                                (this.workletNode!.port as any).onmessage = null;
-                            }
-                        } catch (_) {}
                         reject(new Error(event.data.error || 'Worklet initialization failed'));
                     }
                 };
-                // Support MessagePort implementations that expose addEventListener or onmessage
-                if (typeof (this.workletNode!.port as any).addEventListener === 'function') {
-                    (this.workletNode!.port as any).addEventListener('message', handler);
-                } else {
-                    (this.workletNode!.port as any).onmessage = handler;
-                }
+                this.workletNode!.port.onmessage = handler;
 
                 // Timeout after 10 seconds
                 timeoutId = setTimeout(() => {
-                    try {
-                        if (typeof (this.workletNode!.port as any).removeEventListener === 'function') {
-                            (this.workletNode!.port as any).removeEventListener('message', handler);
-                        } else {
-                            (this.workletNode!.port as any).onmessage = null;
-                        }
-                    } catch (_) {}
+                    this.workletNode!.port.onmessage = null;
                     reject(new Error('Worklet initialization timeout'));
                 }, 10000);
             });


### PR DESCRIPTION
## Summary

- **Root cause**: `AudioWorkletNode.port` is a `MessagePort`. Using `addEventListener('message', handler)` on a `MessagePort` does **not** activate message delivery — `port.start()` must be called explicitly, or `port.onmessage` must be set (which implicitly calls `start()`). All 12 `SingingVoice` instances were timing out after 10 s because the `READY` messages from `RubberBandProcessor` were queued in an unstarted port and never dispatched.
- **Fix**: Replace the `addEventListener` / `else onmessage` branch in `SingingVoice.initWorklet()` with a direct `port.onmessage = handler` assignment, which activates the port and starts delivery.
- **Defense-in-depth**: Pass `import.meta.env.BASE_URL` through the `INIT_WASM` message and use it in `locateFile` inside `RubberBandProcessor` so that `rubberband.wasm` is resolved correctly under subdirectory deployments (e.g. `/hyphon/rubberband.wasm`).

## Test plan

- [ ] Open the app; confirm browser console shows `SingingVoice: AudioWorklet initialized successfully` for all 12 voices instead of `Worklet initialization timeout`
- [ ] Play back a pattern that uses the vocal/singing track — confirm audio output
- [ ] Verify no `NotSupportedError` from duplicate `parameterDescriptors` (fixed in prior commit)
- [ ] Confirm `tsc --noEmit` exits clean

https://claude.ai/code/session_019PJh23or5kEaMXo44ZktrW

---
_Generated by [Claude Code](https://claude.ai/code/session_019PJh23or5kEaMXo44ZktrW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced audio worklet asset resolution with configurable path handling
  * Streamlined audio worklet initialization communication process

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/web_sequencer/pull/554)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->