### PR TITLE
fix(keyboard): live keyboard produces no sound due to zero-duration n…

### DIFF
--- a/src/hooks/audioEngine/audioPlayback.ts
+++ b/src/hooks/audioEngine/audioPlayback.ts
@@ -434,7 +434,7 @@ export function createNoteOnSynth(
         }
 
         if (manager) {
-            const voice = manager.playNote(params, note, now, 0);
+            const voice = manager.noteOn(params, note, now);
             const id = refs.nextSynthNoteId.current++;
             refs.activeSynthNotes.current.set(id, {
                 stop: () => voice.stopNote(context.currentTime, params)

--- a/src/hooks/useAppState.tsx
+++ b/src/hooks/useAppState.tsx
@@ -600,8 +600,8 @@ export function useAppState() {
     const handleKeyboardPlay = useCallback((note: string) => {
         if (!audioEngine) return;
         const time = audioEngine.context.currentTime;
-        if (selectedTrack === 'partA') { const maybe = audioEngine.noteOnSynth?.(synthARef.current, note, time, 'partA'); Promise.resolve(maybe).then((id) => { if (id) activeKeyboardNotesRef.current.set(note, id); }); }
-        else if (selectedTrack === 'partB') { const maybe = audioEngine.noteOnSynth?.(synthBRef.current, note, time, 'partB'); Promise.resolve(maybe).then((id) => { if (id) activeKeyboardNotesRef.current.set(note, id); }); }
+        if (selectedTrack === 'partA') { const maybe = audioEngine.noteOnSynth?.(synthARef.current, note, time, 'partA'); Promise.resolve(maybe).then((id) => { if (id !== null && id !== undefined) activeKeyboardNotesRef.current.set(note, id); }); }
+        else if (selectedTrack === 'partB') { const maybe = audioEngine.noteOnSynth?.(synthBRef.current, note, time, 'partB'); Promise.resolve(maybe).then((id) => { if (id !== null && id !== undefined) activeKeyboardNotesRef.current.set(note, id); }); }
         else if (selectedTrack === 'bass2') { 
             const bass2Params: SynthParams = {
                 waveform: bass2Ref.current.waveform,
@@ -620,7 +620,7 @@ export function useAppState() {
                 delayMix: 0,
             };
             const maybe = audioEngine.noteOnSynth?.(bass2Params, note, time, 'bass2'); 
-            Promise.resolve(maybe).then((id) => { if (id) activeKeyboardNotesRef.current.set(note, id); }); 
+            Promise.resolve(maybe).then((id) => { if (id !== null && id !== undefined) activeKeyboardNotesRef.current.set(note, id); });
         }
         else if (selectedTrack === 'kick') audioEngine.playDrum('kick', { ...kickRef.current, pitch: 60 }, time);
         else if (selectedTrack === 'snare') audioEngine.playDrum('snare', snareRef.current, time);


### PR DESCRIPTION
…oteOn

manager.playNote(params, note, now, 0) schedules both startNote(now) and stopNote(now + 0), so every keyboard note is immediately stopped before any audio is heard. Switch to manager.noteOn() which calls only startNote(), leaving stopNote to be triggered manually by handleKeyboardStop.

Also guard activeKeyboardNotesRef.current.set against falsy-0 ids: use id !== null && id !== undefined so voice-id 0 is properly tracked and its noteOff fires correctly.

https://claude.ai/code/session_019PJh23or5kEaMXo44ZktrW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved synth note triggering mechanism for more reliable voice creation.
* Enhanced voice state tracking for interactive synth keyboard playback to properly record active notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/web_sequencer/pull/556)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->