### PR TITLE
fix(deploy): remove bogus .1ijs extension from WASM upload list

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -23,7 +23,7 @@ WASM_SOURCE_DIRS = ["dist", "public"]
 # File patterns to upload (base names without extension)
 WASM_FILE_BASES = ["jc303-single", "jc303-threaded", "jc303"]
 # Extensions to upload for each base
-WASM_FILE_EXTENSIONS = [".js", ".1ijs", ".wasm", ".worker.js"]
+WASM_FILE_EXTENSIONS = [".js", ".wasm", ".worker.js"]
 
 def upload_directory(sftp_client, local_path, remote_path):
     """


### PR DESCRIPTION
.1ijs is a typo — no such files are produced by the Emscripten build. .worker.js warnings for single-threaded builds are expected and harmless.

https://claude.ai/code/session_019PJh23or5kEaMXo44ZktrW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an obsolete file extension from asset uploads during deployment, streamlining configuration and improving deployment efficiency by reducing unnecessary file transfers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/web_sequencer/pull/558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->