### PR TITLE
🎨 Palette: Hide decorative UI elements from screen readers

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import App from '../App';
 import { vi } from 'vitest';
+import { AppStateProvider } from '../contexts/AppStateContext';
 
 vi.mock('../services/AISongStorage', () => ({
     AISongStorage: {
@@ -14,7 +15,11 @@ vi.mock('../services/AISongStorage', () => ({
 
 describe('App', () => {
   it('renders HYPHON heading', () => {
-    render(<App />);
+    render(
+      <AppStateProvider>
+        <App />
+      </AppStateProvider>
+    );
     // There are now multiple HYPHON headings (one in overlay, one in header)
     const headings = screen.getAllByRole('heading', { level: 1, name: /HYPHON/i });
     expect(headings.length).toBeGreaterThan(0);
@@ -22,12 +27,20 @@ describe('App', () => {
   });
 
   it('renders volume control', () => {
-    render(<App />);
+    render(
+      <AppStateProvider>
+        <App />
+      </AppStateProvider>
+    );
     expect(screen.getByLabelText(/Master Volume/i)).toBeInTheDocument();
   });
 
   it('renders song controls', () => {
-    render(<App />);
+    render(
+      <AppStateProvider>
+        <App />
+      </AppStateProvider>
+    );
     // Check for multiple occurrences of "Song" related UI
     const songElements = screen.getAllByText(/Song/i);
     expect(songElements.length).toBeGreaterThan(0);
@@ -41,7 +54,11 @@ describe('App', () => {
   });
 
   it('renders Tape Stop button', () => {
-    render(<App />);
+    render(
+      <AppStateProvider>
+        <App />
+      </AppStateProvider>
+    );
     const tapeStopButton = screen.getByRole('button', { name: /Trigger Tape Stop Effect/i });
     expect(tapeStopButton).toBeInTheDocument();
     expect(tapeStopButton).toHaveTextContent(/Tape Stop/i);

--- a/src/__tests__/AppAccessibility.test.tsx
+++ b/src/__tests__/AppAccessibility.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { App } from '../App';
+import { AppStateProvider } from '../contexts/AppStateContext';
 
 const mockTriggerTapeStop = vi.fn();
 
@@ -30,7 +31,11 @@ vi.mock('../hooks/usePyodideEngine', () => ({
 
 describe('App Accessibility', () => {
   it('resets master volume when pressing Delete/Backspace', () => {
-    render(<App />);
+    render(
+      <AppStateProvider>
+        <App />
+      </AppStateProvider>
+    );
     const volumeSlider = screen.getByLabelText('Master Volume');
 
     // Simulate changing the value first
@@ -50,7 +55,11 @@ describe('App Accessibility', () => {
   });
 
   it('resets global pan when pressing Delete/Backspace', () => {
-    render(<App />);
+    render(
+      <AppStateProvider>
+        <App />
+      </AppStateProvider>
+    );
     const panSlider = screen.getByLabelText('Global Pan');
 
     // Simulate changing the value first
@@ -70,7 +79,11 @@ describe('App Accessibility', () => {
   });
 
   it('triggers tape stop on Escape key press', () => {
-    render(<App />);
+    render(
+      <AppStateProvider>
+        <App />
+      </AppStateProvider>
+    );
     mockTriggerTapeStop.mockClear();
 
     fireEvent.keyDown(window, { key: 'Escape' });

--- a/src/components/BottomBar.tsx
+++ b/src/components/BottomBar.tsx
@@ -176,7 +176,7 @@ export const BottomBar = memo(function BottomBar({
                 >
                     {isImportingAISong ? (
                         <span className="flex items-center gap-1">
-                            <span className="animate-spin">⏳</span>
+                            <span className="animate-spin" aria-hidden="true">⏳</span>
                             <span>{aiImportStage === 'parsing' && 'Parsing...'}
                             {aiImportStage === 'validating' && 'Validating...'}
                             {aiImportStage === 'converting' && 'Converting...'}
@@ -187,7 +187,7 @@ export const BottomBar = memo(function BottomBar({
                             {!aiImportStage && 'Processing...'} {aiImportProgress}%</span>
                         </span>
                     ) : (
-                        <span>🤖 Import AI Song</span>
+                        <span><span aria-hidden="true">🤖</span> Import AI Song</span>
                     )}
                 </button>
                 <button
@@ -197,7 +197,7 @@ export const BottomBar = memo(function BottomBar({
                     title={isImportingAISong ? "Importing AI song..." : "Cloud Library"}
                     aria-label="Open Cloud Library"
                 >
-                    ☁️ CLOUD
+                    <span aria-hidden="true">☁️</span> CLOUD
                 </button>
             </div>
 
@@ -211,7 +211,7 @@ export const BottomBar = memo(function BottomBar({
                         title="Auto-Mix Assistant (AI Panning & Leveling)"
                         aria-label="Auto-Mix Assistant"
                     >
-                        ✨ AUTO-MIX
+                        <span aria-hidden="true">✨</span> AUTO-MIX
                     </button>
                 </div>
                 <div className="flex flex-col items-center justify-center gap-1 min-w-[60px]">
@@ -278,7 +278,7 @@ export const BottomBar = memo(function BottomBar({
                     title="Gamepad Debugger"
                     aria-label="Open Gamepad Debugger"
                 >
-                    <span className="text-xs">🎮</span>
+                    <span className="text-xs" aria-hidden="true">🎮</span>
                 </button>
 
                 {/* AudioWorklet Fallback Toggle */}
@@ -299,7 +299,7 @@ export const BottomBar = memo(function BottomBar({
                     aria-pressed={forceScriptProcessorFallback}
                     aria-label={forceScriptProcessorFallback ? "Disable ScriptProcessor fallback" : "Enable ScriptProcessor fallback"}
                 >
-                    {forceScriptProcessorFallback ? '⚠️ AW' : '🔊 AW'}
+                    {forceScriptProcessorFallback ? <><span aria-hidden="true">⚠️</span> AW</> : <><span aria-hidden="true">🔊</span> AW</>}
                 </button>
 
                 <div className="w-px h-4 bg-gray-700 mx-1" />

--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -145,7 +145,10 @@ export const LoadingOverlay: React.FC<LoadingOverlayProps> = React.memo(({ isVis
             aria-controls="loading-steps-details"
             aria-label={`${showDetails ? 'Hide' : 'Show'} initialization steps`}
           >
-            <span className={`transform transition-transform ${showDetails ? 'rotate-90' : ''}`}>
+            <span
+              className={`transform transition-transform ${showDetails ? 'rotate-90' : ''}`}
+              aria-hidden="true"
+            >
               ▶
             </span>
             <span>


### PR DESCRIPTION
🎨 Palette: Hide decorative UI elements from screen readers

This PR implements an accessibility and UX improvement to ensure screen readers provide a cleaner audio experience by explicitly hiding decorative visual elements within buttons.

**What:**
- Added `aria-hidden="true"` to the decorative chevron `▶` in `LoadingOverlay.tsx`.
- Added `aria-hidden="true"` to several decorative emojis (☁️, 🤖, ⏳, ✨, 🎮, ⚠️, 🔊) in `BottomBar.tsx` buttons to prevent redundant screen reader announcements since these buttons already contain descriptive text or ARIA labels.
- Added `<AppStateProvider>` to `App.test.tsx` and `AppAccessibility.test.tsx` to fix context errors during testing.

**Why:**
- Without `aria-hidden="true"`, screen readers will often read out the name of decorative icons (e.g. "Cloud emoji", "Right pointing triangle", "Warning emoji") in addition to the button's actual accessible label, making navigation cluttered. This aligns precisely with our `palette.md` UX principles.

**Accessibility:**
- Better, less redundant auditory feedback for non-visual navigation. The visual UI is unchanged.

---
*PR created automatically by Jules for task [14584846351178684554](https://jules.google.com/task/14584846351178684554) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Enhanced screen reader support for interactive buttons by improving how decorative visual elements are handled.

* **Tests**
  * Updated test suite to verify functionality within the complete application context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/web_sequencer/pull/567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->