### PR TITLE
fix(jc303): detect stub WASM early and wire manager to apply303Params

### DIFF
--- a/src/engines/Open303Manager.ts
+++ b/src/engines/Open303Manager.ts
@@ -283,6 +283,20 @@ export class Open303Manager {
         this.setBass2Mute(false);
     }
 
+    // ---- Open303Oscillator-compatible API (delegates to bass1) ----
+    // synthPlayback.ts calls these via the Open303Oscillator interface. Routing
+    // them to bass1 keeps the live-play and sequencer paths consistent.
+    setWaveform(v: number) { this.bass1?.setWaveform(v); }
+    setCutoff(v: number) { this.bass1?.setCutoff(v); }
+    setResonance(v: number) { this.bass1?.setResonance(v); }
+    setFilterMode(v: number) { this.bass1?.setFilterMode(v); }
+    setDecay(v: number) { this.bass1?.setDecay(v); }
+    setEnvMod(v: number) { this.bass1?.setEnvMod(v); }
+    setAccent(v: number) { this.bass1?.setAccent(v); }
+    setVolume(v: number) { this.bass1?.setVolume(v); }
+    noteOn(note: number, velocity: number = 100) { this.noteOnBass1(note, velocity); }
+    noteOff(note: number) { this.noteOffBass1(note); }
+
     /**
      * Get bass1 ready state
      */

--- a/src/engines/Open303Oscillator.ts
+++ b/src/engines/Open303Oscillator.ts
@@ -48,6 +48,16 @@ export class Open303Oscillator {
                 const wasmBytes = await wasmResponse.arrayBuffer();
                 console.log(`[Open303Oscillator] Fetched ${wasmBytes.byteLength} bytes`);
 
+                // Guard against the committed 8-byte build stub. A real jc303 binary
+                // is hundreds of KB; anything under 1 KB means the Colab build hasn't
+                // been run yet. Skip the worklet entirely rather than burning 3 retries.
+                if (wasmBytes.byteLength < 1024) {
+                    console.warn(`[Open303] WASM is a stub (${wasmBytes.byteLength} bytes). Run: bash tools/build_jc303_omp.sh release single`);
+                    try { engineTelemetry.registerResolution('jc303', 'fallback', 'wasm-stub'); } catch (_) {}
+                    this.activateFallback();
+                    return true;
+                }
+
                 // 2. Add the Worklet Module and create the node
                 await audioContext.audioWorklet.addModule(workletUrl);
 


### PR DESCRIPTION
Two bugs causing 'falls back to default waveform':

1. Stub WASM causes 3-retry failure: src/wasm/jc303-single.wasm is an 8-byte placeholder. The fetch succeeds (HTTP 200) so no fallback was triggered, but the worklet failed on all 3 init attempts (no jc303_init/jc303_process exports) before falling back. Added a <1024-byte guard that activates the fallback immediately with a clear console message pointing to the build command rather than wasting 3 retries and 20s timeout.

2. apply303Params called setWaveform/setCutoff/etc. on Open303Manager which doesn't expose those methods — calls were silent no-ops (or TypeErrors) meaning params from the UI were never forwarded to the WASM engine via the synthPlayback.ts live-play path. Added delegating setters on Open303Manager that proxy to bass1, satisfying the Open303Oscillator-shaped API that synthPlayback.ts (and apply303Params) expects.

https://claude.ai/code/session_01DpUkdhuF15N5ETvMpGjHQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness of audio engine initialization with automatic fallback activation when binary loading encounters issues.

* **Improvements**
  * Enhanced oscillator API compatibility to ensure consistent parameter control across all playback modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/web_sequencer/pull/572?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->