### PR TITLE
Fix duplicate biquadFilter mock and optional onPitchChange prop

### DIFF
--- a/src/__tests__/Open303Config.test.ts
+++ b/src/__tests__/Open303Config.test.ts
@@ -75,13 +75,6 @@ describe('Open303 Oscillator', () => {
                 start: vi.fn(),
                 stop: vi.fn()
             })),
-            createBiquadFilter: vi.fn(() => ({
-                connect: vi.fn(),
-                disconnect: vi.fn(),
-                type: 'lowpass',
-                frequency: { value: 1000 },
-                Q: { value: 1.0 }
-            })),
             sampleRate: 44100,
             currentTime: 0,
             audioWorklet: {

--- a/src/components/MelodicSequencerRow.tsx
+++ b/src/components/MelodicSequencerRow.tsx
@@ -88,7 +88,7 @@ interface MelodicSequencerRowProps {
   activeSlot: number;
   trackSlots: (PartSequence | PartSequence[] | null)[];
   onToggle: (k: TrackKey, i: number, e: React.PointerEvent) => void;
-  onPitchChange: (k: TrackKey, i: number, pitch: number) => void;
+  onPitchChange?: (k: TrackKey, i: number, pitch: number) => void;
   onEditLength: (k: TrackKey, i: number, len: number) => void;
   onSelectRow: (k: TrackKey) => void;
   onSelectSlot: (k: TrackKey, slot: number) => void;


### PR DESCRIPTION
## Summary
- Remove duplicate `createBiquadFilter` property in `Open303Config.test.ts` mock object (TS1117)
- Make `onPitchChange` optional in `MelodicSequencerRowProps` to match its optional usage in `MainSequencer` (TS2322)

## Test plan
- [ ] `npx tsc --noEmit` passes with no errors
- [ ] Existing tests still pass

https://claude.ai/code/session_013Wcn9oSLorrdwiW1j3y5mB

---
_Generated by [Claude Code](https://claude.ai/code/session_013Wcn9oSLorrdwiW1j3y5mB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Melodic sequencer now functions without requiring a pitch-change handler.

* **Tests**
  * Enhanced test mocks for improved audio configuration testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/web_sequencer/pull/588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->