### PR TITLE
feat(audio): Formant-Aware Reverb with dynamic lowpass pre-reverb

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -61,7 +61,8 @@
 
 * [2026-04-25] - Implemented Step-Sequenced Reverb Types: Added `reverbType` parameter to `Note` interface and updated `NoteSelector` UI to include a space dropdown (Room, Plate, Hall). Refactored `useAudioEngine.ts` to instantiate all three convolution spaces simultaneously to prevent pop artifacts on hot-swapping and updated `audioPlayback.ts` routing to send signals to the correct active `reverbNodesRef` based on the sequence step.
 ## 🧠 Innovation Lab (The "Dream" Log)
-* **Idea:** "Formant-Aware Reverb" - Dynamically adjust the reverb decay and EQ based on the active vowel being sung to prevent high-frequency sibilance buildup.
+* **Idea:** "Dynamic Reverb Density LFO" - Modulate the density or size of the reverb tail dynamically using an LFO for swirling, breathing spaces.
+* [x] **Idea:** "Formant-Aware Reverb" - Dynamically adjust the reverb decay and EQ based on the active vowel being sung to prevent high-frequency sibilance buildup. (Implemented in `useAudioEngine.ts` via dynamic lowpass filter before convolution!)
 * **Idea:** "Spectral Panning" - Split the TTS audio into multiple frequency bands and dynamically pan them across the stereo field based on an LFO to create wide, swirling vocal textures.
 * [x] **Idea:** "Spectral Sidechaining" - Duck specific frequencies (like low-end) instead of broadband gain when the kick drum hits, avoiding pumping artifacts on the highs. (Implemented via BiquadFilterNode lowshelf modulation!)
 * [x] **Idea:** "AI Auto-EQ Assistant" - Automatically analyze the frequency spectrum of all tracks and subtly EQ conflicting frequencies to prevent masking (e.g., dipping 200Hz on Synths when the Bass plays).
@@ -123,6 +124,7 @@
 ---
 
 ## 📜 Changelog
+* [2026-07-05] - Implemented Formant-Aware Reverb: Dynamically adjusted reverb send EQ (lowpass cutoff) based on active `formantShift` parameters in `useAudioEngine.ts` to prevent high-frequency sibilance buildup on bright vowels. Added new idea: Dynamic Reverb Density LFO.
 * [2026-07-04] - Implemented Multiband Distortion for TTS: Updated `vocal-overdrive-processor.ts` to include a 1-pole state variable filter crossover. Applied asymmetric tube clipping specifically to the high-frequency band to prevent fundamental pitch muddying.
 * [2026-07-03] - Implemented Vocal Harmony Parallel Bus: Created a dedicated parallel bus (`harmonyBusGainRef` -> `harmonyCompressorRef` -> `harmonyEQRef`) in `useAudioEngine.ts`. Routed harmony voices (where `isHarmonyVoice` is true) through this bus for independent glue compression and EQ before re-joining the master chain. Fulfills the "Vocal Harmony Parallel Bus" idea.
 * [2026-07-01] - Implemented Rhythmic Gating: Added `gateDepth` and `gateRate` parameters to the `Note` interface and `SamplerBankParams`. Exposed UI controls in `NoteSelector` and connected them through `useAudioEngine.ts` to the `rubberband-processor.ts` AudioWorklet, creating a smoothed, step-sequenced trance gate effect.

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -577,14 +577,38 @@ export const useAudioEngine = (pyodide: unknown, tempo: number = 120) => {
 
                             voice.connectOutput(finalDest);
 
-                            // Setup Reverb Send
+                            // Setup Reverb Send (Formant-Aware)
                             const reverbSendAmount = noteParams?.reverbSend !== undefined ? noteParams.reverbSend : 0;
                             const currentReverbType = (noteParams as any)?.reverbType || reverbTypeRef.current;
                             const targetReverbNode = reverbNodesRef.current[currentReverbType] || reverbNodesRef.current['plate'];
                             if (reverbSendAmount > 0 && targetReverbNode) {
                                 const reverbGain = context.createGain();
                                 reverbGain.gain.value = reverbSendAmount;
-                                reverbGain.connect(targetReverbNode);
+
+                                // Calculate Formant Brightness for Reverb EQ
+                                const baseShift = params.formantShift || 0;
+                                const currentShift = noteParams?.formantShift !== undefined ? (baseShift + noteParams.formantShift) : baseShift;
+                                const characterMorph = noteParams?.characterMorph !== undefined ? noteParams.characterMorph : (params.characterMorph ?? 0);
+
+                                // High formant shifts or brighter characters -> more high frequencies -> lower cutoff to tame sibilance
+                                // Neutral/Low shifts -> higher cutoff to keep reverb clear
+                                // We map currentShift from roughly -12 to +12
+                                const normalizedShift = Math.max(-12, Math.min(12, currentShift)) / 12; // -1.0 to 1.0
+
+                                // Base cutoff around 6000Hz. If bright (+1), drop to 2000Hz. If dark (-1), raise to 10000Hz.
+                                let reverbEqCutoff = 6000 - (normalizedShift * 4000);
+
+                                // Further adjust by character morph (0 to 1). 1 usually means brighter/female.
+                                reverbEqCutoff -= (characterMorph * 1000);
+                                reverbEqCutoff = Math.max(1000, Math.min(12000, reverbEqCutoff));
+
+                                const formantReverbEq = context.createBiquadFilter();
+                                formantReverbEq.type = 'lowpass';
+                                formantReverbEq.frequency.value = reverbEqCutoff;
+                                formantReverbEq.Q.value = 0.5; // Gentle slope
+
+                                reverbGain.connect(formantReverbEq);
+                                formantReverbEq.connect(targetReverbNode);
                                 voice.connectOutput(reverbGain); // connectOutput appends to existing connections
                             }
 


### PR DESCRIPTION
Implemented the "Formant-Aware Reverb" feature from the Innovation Lab. This dynamically adjusts the reverb EQ (lowpass filter cutoff) based on the active vowel being sung (`formantShift` and `characterMorph`) to prevent high-frequency sibilance buildup, ensuring clearer mixes when using bright TTS parameters. Included updates to `agent_plan.md` per the recursion loop instructions.

---
*PR created automatically by Jules for task [11682575189248065412](https://jules.google.com/task/11682575189248065412) started by @ford442*