### PR TITLE
🎨 Palette: Improved mouse-click focus rings with focus-visible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -39,3 +39,6 @@
 ## 2026-05-13 - [NoteSelector Accessibility Improvements]
 **Learning:** Grouping related slider inputs (like Velocity, Duration, Expression) in a complex custom modal component using `<fieldset>` with `sr-only` `<legend>` dramatically improves screen reader navigation and context without affecting the existing visual layout, as long as utility classes like `border-none p-0 m-0` are applied to the fieldset.
 **Action:** Always wrap logical groups of parameter controls in `<fieldset>` tags with descriptive `<legend>` elements instead of generic `div` containers, especially in dense UI sections.
+## 2026-05-20 - Prevent Lingering Mouse-Click Focus Rings
+**Learning:** Using standard `focus:ring-2` on custom slider/button components (like DragValue and Knob) causes an ugly, lingering focus ring after a standard mouse click. Keyboard navigation accessibility must be maintained without penalizing mouse users.
+**Action:** When styling interactive elements for accessibility, always prefer `focus-visible:ring-2` and `focus-visible:border-[color]` over `focus:ring-2`. This ensures that keyboard navigators get clear focus indicators while mouse users do not see lingering rings after clicking.

--- a/src/components/DragValue.tsx
+++ b/src/components/DragValue.tsx
@@ -142,7 +142,7 @@ export const DragValue: React.FC<DragValueProps> = React.memo(({ value, onChange
           onMouseDown={() => startRepeat(-1)}
           onMouseUp={stopRepeat}
           onMouseLeave={stopRepeat}
-          className="w-6 h-8 flex items-center justify-center bg-gray-800 hover:bg-gray-700 border border-gray-600 rounded text-gray-400 hover:text-white text-lg font-bold select-none"
+          className="w-6 h-8 flex items-center justify-center bg-gray-800 hover:bg-gray-700 border border-gray-600 rounded text-gray-400 hover:text-white text-lg font-bold select-none focus:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400 focus-visible:ring-offset-1 focus-visible:ring-offset-gray-900"
           aria-label={label ? `Decrease ${label}` : 'Decrease'}
           title={label ? `Decrease ${label}` : 'Decrease'}
         >
@@ -150,7 +150,7 @@ export const DragValue: React.FC<DragValueProps> = React.memo(({ value, onChange
         </button>
         <div
           ref={sliderRef}
-          className="group relative bg-gray-800 rounded-md border border-gray-700 px-2 py-1 text-2xl font-orbitron text-yellow-400 cursor-ns-resize select-none min-w-[60px] text-center focus:outline-none focus:ring-2 focus:ring-yellow-400"
+          className="group relative bg-gray-800 rounded-md border border-gray-700 px-2 py-1 text-2xl font-orbitron text-yellow-400 cursor-ns-resize select-none min-w-[60px] text-center focus:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400"
           onMouseDown={handleMouseDown}
           onWheel={handleWheel}
           tabIndex={0}
@@ -214,7 +214,7 @@ export const DragValue: React.FC<DragValueProps> = React.memo(({ value, onChange
           onMouseDown={() => startRepeat(1)}
           onMouseUp={stopRepeat}
           onMouseLeave={stopRepeat}
-          className="w-6 h-8 flex items-center justify-center bg-gray-800 hover:bg-gray-700 border border-gray-600 rounded text-gray-400 hover:text-white text-lg font-bold select-none"
+          className="w-6 h-8 flex items-center justify-center bg-gray-800 hover:bg-gray-700 border border-gray-600 rounded text-gray-400 hover:text-white text-lg font-bold select-none focus:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400 focus-visible:ring-offset-1 focus-visible:ring-offset-gray-900"
           aria-label={label ? `Increase ${label}` : 'Increase'}
           title={label ? `Increase ${label}` : 'Increase'}
         >

--- a/src/components/Knob.tsx
+++ b/src/components/Knob.tsx
@@ -153,13 +153,13 @@ export const Knob: React.FC<KnobProps> = memo(({ label, value, onChange, min, ma
   };
 
   const focusBorderClasses = {
-    cyan: 'focus:border-cyan-400 focus:ring-1 focus:ring-cyan-400',
-    pink: 'focus:border-pink-400 focus:ring-1 focus:ring-pink-400',
-    yellow: 'focus:border-yellow-400 focus:ring-1 focus:ring-yellow-400',
-    purple: 'focus:border-purple-400 focus:ring-1 focus:ring-purple-400',
-    red: 'focus:border-red-400 focus:ring-1 focus:ring-red-400',
-    green: 'focus:border-green-400 focus:ring-1 focus:ring-green-400',
-    indigo: 'focus:border-indigo-400 focus:ring-1 focus:ring-indigo-400',
+    cyan: 'focus-visible:border-cyan-400 focus-visible:ring-1 focus-visible:ring-cyan-400',
+    pink: 'focus-visible:border-pink-400 focus-visible:ring-1 focus-visible:ring-pink-400',
+    yellow: 'focus-visible:border-yellow-400 focus-visible:ring-1 focus-visible:ring-yellow-400',
+    purple: 'focus-visible:border-purple-400 focus-visible:ring-1 focus-visible:ring-purple-400',
+    red: 'focus-visible:border-red-400 focus-visible:ring-1 focus-visible:ring-red-400',
+    green: 'focus-visible:border-green-400 focus-visible:ring-1 focus-visible:ring-green-400',
+    indigo: 'focus-visible:border-indigo-400 focus-visible:ring-1 focus-visible:ring-indigo-400',
   };
 
   return (


### PR DESCRIPTION
💡 **What**: Replaced `focus:` tailwind utility classes with `focus-visible:` on `DragValue` and `Knob` components, and added `focus-visible` styling to the plus/minus buttons in `DragValue`.

🎯 **Why**: When a user clicks and drags a slider (`DragValue`) or a knob (`Knob`), the standard `focus:ring-2` utility causes an ugly focus ring to linger on the element after the interaction completes. By switching to `focus-visible`, we maintain strict keyboard accessibility (tabbing still shows focus rings) while completely eliminating the visual artifacts for mouse users.

♿ **Accessibility**: Keyboard navigation remains fully supported, and the `DragValue` step buttons (`+` / `-`) now have explicit focus rings that they were previously missing.

---
*PR created automatically by Jules for task [11508465898978901805](https://jules.google.com/task/11508465898978901805) started by @ford442*