### PR TITLE
Fix oscillator selector icons and wire engine voices

### DIFF
--- a/src/components/WaveformSelector.tsx
+++ b/src/components/WaveformSelector.tsx
@@ -13,26 +13,26 @@ interface WaveformSelectorProps {
 const WaveformIcon: React.FC<{ type: Waveform }> = React.memo(({ type }) => {
   switch (type) {
     case 'sawtooth':
-      return <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M0 18 L12 6 L12 18 L24 6 L24 18" /></svg>;
+      return <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M0 18 L12 6 L12 18 L24 6 L24 18" /></svg>;
     case 'square':
-      return <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M0 18 L0 6 L12 6 L12 18 L24 18 L24 6" /></svg>;
+      return <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M0 18 L0 6 L12 6 L12 18 L24 18 L24 6" /></svg>;
     case 'triangle':
-      return <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M0 12 L6 6 L18 18 L24 12" /></svg>;
+      return <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M0 12 L6 6 L18 18 L24 12" /></svg>;
     case 'sine':
-      return <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M0 12 Q6 0, 12 12 T24 12" /></svg>;
+      return <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M0 12 Q6 0, 12 12 T24 12" /></svg>;
     // Native WAV icons
     case 'wav-saw':
       return (
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <svg className="w-7 h-7" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
           <text x="0" y="8" fontSize="8" fill="currentColor" stroke="none">WAV</text>
-          <path d="M0 20 L12 10 L12 20 L24 10 L24 20" transform="translate(0, 0)" />
+          <path d="M0 20 L12 10 L12 20 L24 10 L24 20" />
         </svg>
       );
     case 'wav-sqr':
       return (
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <svg className="w-7 h-7" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
           <text x="0" y="8" fontSize="8" fill="currentColor" stroke="none">WAV</text>
-          <path d="M0 20 L0 10 L12 10 L12 20 L24 20 L24 10" transform="translate(0, 0)" />
+          <path d="M0 20 L0 10 L12 10 L12 20 L24 20 L24 10" />
         </svg>
       );
     // NEW: Pyodide icons

--- a/src/engines/VoiceManager.ts
+++ b/src/engines/VoiceManager.ts
@@ -1,6 +1,13 @@
 import { type SynthParams } from '../types';
 import { tunedNoteToFrequency } from '../constants';
 import type { ScaleDefinition } from '../utils/musicTheory';
+import { parseWaveform, shapeToOscillatorType, type WaveShape } from '../utils/waveformParser';
+import type { WasmOscillator } from './WasmOscillator';
+
+export interface VoiceEngineDeps {
+    wasmEngine?: WasmOscillator | null;
+    wgslBuffers?: Partial<Record<WaveShape, AudioBuffer | null>>;
+}
 
 export class Voice {
     context: AudioContext;
@@ -29,18 +36,22 @@ export class Voice {
     private globalDelayNode?: DelayNode;
     private globalDelaySendGain?: GainNode;
 
+    private engineDeps?: VoiceEngineDeps;
+
     constructor(
         context: AudioContext,
         destination: AudioNode,
         wavSaw?: AudioBuffer,
         wavSqr?: AudioBuffer,
-        globalDelayNode?: DelayNode
+        globalDelayNode?: DelayNode,
+        engineDeps?: VoiceEngineDeps,
     ) {
         this.context = context;
         this.destination = destination;
         this.wavSawBuffer = wavSaw;
         this.wavSqrBuffer = wavSqr;
         this.globalDelayNode = globalDelayNode;
+        this.engineDeps = engineDeps;
 
         // Create permanent nodes
         this.filter = context.createBiquadFilter();
@@ -97,7 +108,8 @@ export class Voice {
         const freq = tunedNoteToFrequency(note, tuning);
 
         const waveform = params.waveform;
-        const isWav = waveform.startsWith('wav-');
+        const parsed = parseWaveform(waveform);
+        const isWav = parsed.engine === 'wav';
         const canReuse = this.source &&
                         this.isActive &&
                         slideFromFreq !== undefined &&
@@ -128,20 +140,57 @@ export class Voice {
             // === FULL NEW NOTE ===
             this.stop(now);
 
+            let createdSource: OscillatorNode | AudioBufferSourceNode | null = null;
+
             if (isWav) {
                 const src = this.context.createBufferSource();
-                src.buffer = (waveform === 'wav-sqr' ? this.wavSqrBuffer : this.wavSawBuffer) ?? null;
+                src.buffer = (parsed.shape === 'sqr' ? this.wavSqrBuffer : this.wavSawBuffer) ?? null;
                 src.loop = true;
                 src.playbackRate.value = freq / 261.63; // C4 base
-                this.source = src;
-            } else {
-                const osc = this.context.createOscillator();
-                osc.type = (['sawtooth', 'square', 'triangle', 'sine'] as const).includes(
-                    waveform as any
-                ) ? (waveform as OscillatorType) : 'sawtooth';
-                osc.frequency.value = freq;
-                this.source = osc;
+                createdSource = src;
+            } else if (parsed.engine === 'wasm' && this.engineDeps?.wasmEngine?.isReady) {
+                // Render a ~2s buffer at C4 reference frequency, then retune via playbackRate.
+                const REF_FREQ = 261.63;
+                const float = this.engineDeps.wasmEngine.generate(
+                    REF_FREQ,
+                    2.0,
+                    this.context.sampleRate,
+                    parsed.shape,
+                    Math.max(20, Math.min(this.context.sampleRate / 2.1, params.filterCutoff)),
+                    Math.max(0.1, params.filterResonance),
+                );
+                if (float && float.length > 0) {
+                    const buf = this.context.createBuffer(1, float.length, this.context.sampleRate);
+                    buf.getChannelData(0).set(float);
+                    const src = this.context.createBufferSource();
+                    src.buffer = buf;
+                    src.loop = true;
+                    src.playbackRate.value = freq / REF_FREQ;
+                    createdSource = src;
+                }
+            } else if (parsed.engine === 'wgsl') {
+                const buf = this.engineDeps?.wgslBuffers?.[parsed.shape];
+                if (buf) {
+                    const src = this.context.createBufferSource();
+                    src.buffer = buf;
+                    src.loop = true;
+                    // wgsl buffers are pre-rendered at C4 reference
+                    src.playbackRate.value = freq / 261.63;
+                    createdSource = src;
+                }
             }
+
+            // Fallback: JS oscillator using the parsed base shape so the user at
+            // least hears the right wave family for engines we haven't wired up
+            // (pyodide, wam, rust) or that failed to initialise.
+            if (!createdSource) {
+                const osc = this.context.createOscillator();
+                osc.type = shapeToOscillatorType(parsed.shape);
+                osc.frequency.value = freq;
+                createdSource = osc;
+            }
+
+            this.source = createdSource;
 
             this.currentSourceType = waveform;
             this.source.connect(this.filter);
@@ -249,11 +298,12 @@ export class VoiceManager {
         monophonic: boolean,
         wavSaw?: AudioBuffer,
         wavSqr?: AudioBuffer,
-        globalDelayNode?: DelayNode
+        globalDelayNode?: DelayNode,
+        engineDeps?: VoiceEngineDeps,
     ) {
         this.monophonic = monophonic;
         this.voices = Array.from({ length: Math.max(1, polyphony) }, () =>
-            new Voice(context, destination, wavSaw, wavSqr, globalDelayNode)
+            new Voice(context, destination, wavSaw, wavSqr, globalDelayNode, engineDeps)
         );
     }
 

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -320,9 +320,32 @@ export const useAudioEngine = (pyodide: unknown, tempo: number = 120) => {
                 console.warn('Engine telemetry registration failed for oscillators', e);
             }
 
+            // Pre-render WebGPU oscillator cycles at C4 reference so they can be
+            // looped synchronously per-note (gpuEngine.generate is async).
+            const wgslBuffers: Partial<Record<'saw' | 'sqr' | 'tri' | 'sin', AudioBuffer | null>> = {};
+            if ((gpuEngine as any).isSupported) {
+                const REF_FREQ = 261.63;
+                const REF_DUR = 2.0;
+                const shapes: Array<'saw' | 'sqr' | 'tri' | 'sin'> = ['saw', 'sqr', 'tri', 'sin'];
+                await Promise.all(shapes.map(async (shape) => {
+                    try {
+                        const float = await gpuEngine.generate(REF_FREQ, REF_DUR, context.sampleRate, shape);
+                        if (float && float.length > 0) {
+                            const buf = context.createBuffer(1, float.length, context.sampleRate);
+                            buf.getChannelData(0).set(float);
+                            wgslBuffers[shape] = buf;
+                        }
+                    } catch (e) {
+                        console.warn(`WebGPU pre-render for ${shape} failed`, e);
+                    }
+                }));
+            }
+
+            const voiceEngineDeps = { wasmEngine: wasmEngineRef.current, wgslBuffers };
+
             // Initialize Voice Managers
-            voiceManagerARef.current = new VoiceManager(context, masterSaturationRef.current!, 8, false, sawBuf || undefined, sqrBuf || undefined, delayNodeRef.current || undefined);
-            voiceManagerBRef.current = new VoiceManager(context, masterSaturationRef.current!, 1, true, sawBuf || undefined, sqrBuf || undefined, delayNodeRef.current || undefined);
+            voiceManagerARef.current = new VoiceManager(context, masterSaturationRef.current!, 8, false, sawBuf || undefined, sqrBuf || undefined, delayNodeRef.current || undefined, voiceEngineDeps);
+            voiceManagerBRef.current = new VoiceManager(context, masterSaturationRef.current!, 1, true, sawBuf || undefined, sqrBuf || undefined, delayNodeRef.current || undefined, voiceEngineDeps);
 
             await initializeSustainProcessor(context, sustainProcessorUrl, sustainNodeRef, masterGainRef);
 

--- a/src/utils/waveformParser.ts
+++ b/src/utils/waveformParser.ts
@@ -1,0 +1,42 @@
+import type { Waveform } from '../types';
+
+export type OscEngineId = 'js' | 'wav' | 'wasm' | 'wgsl' | 'rust' | 'pyodide' | 'wam' | '303';
+export type WaveShape = 'saw' | 'sqr' | 'tri' | 'sin';
+
+const ENGINE_MAP: Record<string, OscEngineId> = {
+    wav: 'wav',
+    pyodide: 'pyodide',
+    wgsl: 'wgsl',
+    wam: 'wam',
+    rust: 'rust',
+    '303': '303',
+};
+
+const SHAPE_ALIASES: Record<string, WaveShape> = {
+    saw: 'saw',
+    sawtooth: 'saw',
+    sqr: 'sqr',
+    square: 'sqr',
+    tri: 'tri',
+    triangle: 'tri',
+    sin: 'sin',
+    sine: 'sin',
+};
+
+export function parseWaveform(w: Waveform): { engine: OscEngineId; shape: WaveShape } {
+    if (w === 'sawtooth' || w === 'square' || w === 'triangle' || w === 'sine') {
+        return { engine: 'js', shape: SHAPE_ALIASES[w] };
+    }
+    const dash = w.indexOf('-');
+    if (dash > 0) {
+        const prefix = w.slice(0, dash);
+        const suffix = w.slice(dash + 1);
+        const engine = ENGINE_MAP[prefix] ?? 'js';
+        const shape = SHAPE_ALIASES[suffix] ?? 'saw';
+        return { engine, shape };
+    }
+    return { engine: 'js', shape: 'saw' };
+}
+
+export const shapeToOscillatorType = (s: WaveShape): OscillatorType =>
+    s === 'saw' ? 'sawtooth' : s === 'sqr' ? 'square' : s === 'tri' ? 'triangle' : 'sine';


### PR DESCRIPTION
## Summary

Two distinct bugs in the oscillator selector / playback chain:

**Selector UI** — `JavaScript` and `PCM` groups rendered as blank buttons because their SVG icons had only a `viewBox` and no explicit size. Inside the small flex buttons they collapsed to 0×0. The other engines use text `<div>` icons, which is why only those groups appeared to show up.

**Audio routing** — `createPlaySynth` → `VoiceManager` → `Voice.startNote` only handled the four JS oscillator types and the `wav-*` buffers. Every other waveform (`pyodide-*`, `wgsl-*`, `wam-*`, `rust-*`, `wasm` shapes via WAM) silently fell through to a hardcoded `osc.type = 'sawtooth'`, which is why everything sounded like the default OSC voice.

## Changes

- New `src/utils/waveformParser.ts` — parses a `Waveform` id into `{engine, shape}` (e.g. `wgsl-tri` → `{engine: 'wgsl', shape: 'tri'}`).
- `WaveformSelector.tsx` — added `w-6 h-6` / `w-7 h-7` to the JS/PCM icon SVGs so they render at a visible size.
- `VoiceManager.ts`:
  - Takes optional engine deps (`wasmEngine`, pre-rendered `wgslBuffers`).
  - `Voice.startNote` routes by parsed engine: WAV buffers for `wav-*`; WASM `generate()` rendered into an AudioBuffer for `wasm-*`-shape notes; pre-rendered WebGPU buffers for `wgsl-*`; otherwise a JS oscillator with the *parsed base shape* (`sawtooth` / `square` / `triangle` / `sine`) so pyodide/wam/rust fall back to the right wave family instead of always sawtooth.
- `useAudioEngine.ts`:
  - Pre-renders WebGPU oscillator cycles at C4 reference once during audio init (gpu `generate()` is async, so per-note rendering would block) and passes them to the voice managers along with the WASM engine ref.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.app.json` clean
- [x] `npx vitest run` on selector + engine tests — 61 passed
- [ ] Manual: open the selector panel — JavaScript and PCM groups now show waveform icons
- [ ] Manual: pick each waveform and confirm distinct timbres (WAV / WASM / WGSL produce engine output; pyodide / WAM / Rust play the correct base shape via JS fallback)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vuh8X9L5Nq1FmTcRcyybzU)_