### PR TITLE
🎨 Palette: Add explicit aria-hidden to decorative text icons (✕)

### DIFF
--- a/src/components/AISongModal.tsx
+++ b/src/components/AISongModal.tsx
@@ -688,9 +688,7 @@ export const AISongModal = React.memo(function AISongModal({ isOpen, onClose, on
               className="w-8 h-8 rounded-lg bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-all"
               aria-label="Close modal"
               title="Close modal"
-            >
-              ✕
-            </button>
+            ><span aria-hidden="true">✕</span></button>
           </Tooltip>
         </div>
 
@@ -857,9 +855,7 @@ export const AISongModal = React.memo(function AISongModal({ isOpen, onClose, on
                             onClick={() => removeDroppedFile(droppedFile.id)}
                             className="w-6 h-6 rounded hover:bg-red-500/20 text-gray-500 hover:text-red-400 transition-all shrink-0"
                             aria-label={`Remove ${droppedFile.file.name}`}
-                          >
-                            ✕
-                          </button>
+                          ><span aria-hidden="true">✕</span></button>
                         </Tooltip>
                       </div>
                     ))}
@@ -1367,7 +1363,7 @@ export const AISongModal = React.memo(function AISongModal({ isOpen, onClose, on
                 aria-label="Cancel Import"
               >
                 <span className="hidden sm:inline">Cancel</span>
-                <span className="sm:hidden">✕</span>
+                <span className="sm:hidden" aria-hidden="true">✕</span>
               </button>
             </Tooltip>
             <Tooltip text={parsedData ? "Ctrl+Enter to import" : "Enter valid JSON first"} position="top">

--- a/src/components/LiveKeyboard.tsx
+++ b/src/components/LiveKeyboard.tsx
@@ -54,7 +54,7 @@ const KeyboardGuide = ({ onClose }: { onClose: () => void }) => {
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm animate-fadeIn" onClick={onClose}>
             <div role="dialog" aria-modal="true" aria-labelledby="keyboard-guide-title" ref={guideRef} className="relative p-8 border-2 border-dashed border-cyan-500/50 rounded-2xl bg-[#0d1015] shadow-[0_0_50px_rgba(6,182,212,0.15)] max-w-2xl w-full mx-4" onClick={e => e.stopPropagation()}>
-                <button onClick={onClose} className="absolute top-4 right-4 text-gray-500 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1015] rounded p-1.5" aria-label="Close guide" title="Close Guide">✕</button>
+                <button onClick={onClose} className="absolute top-4 right-4 text-gray-500 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1015] rounded p-1.5" aria-label="Close guide" title="Close Guide"><span aria-hidden="true">✕</span></button>
                 <div className="text-center mb-8">
                     <h3 id="keyboard-guide-title" className="text-2xl font-orbitron font-bold text-cyan-400 mb-2 tracking-widest">PIANO KEYBOARD</h3>
                     <p className="text-gray-400 font-mono text-sm">Classic piano layout with 5 black keys and 8 white keys.</p>

--- a/src/components/LyricTrack.tsx
+++ b/src/components/LyricTrack.tsx
@@ -54,9 +54,7 @@ export const LyricTrack: React.FC<LyricTrackProps> = React.memo(({
                 className="px-2 py-1.5 text-gray-500 hover:text-white"
                 aria-label="Close Lyric Track"
                 title="Close Lyric Track"
-            >
-                ✕
-            </button>
+            ><span aria-hidden="true">✕</span></button>
         </div>
     );
 });

--- a/src/components/NoteSelector.tsx
+++ b/src/components/NoteSelector.tsx
@@ -135,7 +135,7 @@ export const NoteSelector: React.FC<NoteSelectorProps> = memo(({
             >
                 <div className="flex justify-between items-center pb-2 border-b border-cyan-900/30">
                     <span id="note-selector-title" className="text-xs font-bold font-orbitron text-cyan-400 tracking-widest drop-shadow-[0_0_8px_rgba(6,182,212,0.5)]">NOTE PROPERTIES</span>
-                    <button onClick={onClose} aria-label="Close note properties" title="Close note properties (Esc)" className="text-cyan-600 hover:text-white focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-400 rounded">✕</button>
+                    <button onClick={onClose} aria-label="Close note properties" title="Close note properties (Esc)" className="text-cyan-600 hover:text-white focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-400 rounded"><span aria-hidden="true">✕</span></button>
                 </div>
 
                 {/* NEW: Duration Control */}

--- a/src/components/PatternSelector.tsx
+++ b/src/components/PatternSelector.tsx
@@ -65,7 +65,7 @@ export const PatternSelector: React.FC<PatternSelectorProps> = React.memo(({
             >
                 <div className="flex justify-between items-center mb-2 px-1">
                     <span id="pattern-selector-title" className="text-xs font-bold text-gray-400">SELECT PTN</span>
-                    <button onClick={onClose} aria-label="Close pattern selector" title="Close pattern selector" className="text-gray-500 hover:text-white text-xs focus:outline-none focus-visible:ring-1 focus-visible:ring-white rounded">✕</button>
+                    <button onClick={onClose} aria-label="Close pattern selector" title="Close pattern selector" className="text-gray-500 hover:text-white text-xs focus:outline-none focus-visible:ring-1 focus-visible:ring-white rounded"><span aria-hidden="true">✕</span></button>
                 </div>
 
                 <div

--- a/src/components/RbsImportModal.tsx
+++ b/src/components/RbsImportModal.tsx
@@ -407,9 +407,7 @@ export const RbsImportModal = React.memo(function RbsImportModal({ isOpen, onClo
             className="w-8 h-8 rounded-lg bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-all"
             title="Close (Esc)"
             aria-label="Close modal"
-          >
-            ✕
-          </button>
+          ><span aria-hidden="true">✕</span></button>
         </div>
 
         {/* Progress Bar */}

--- a/src/components/SamplerPanel.tsx
+++ b/src/components/SamplerPanel.tsx
@@ -754,9 +754,7 @@ const SamplerPanelComponent: React.FC<SamplerPanelProps> = React.memo(({
                                     className="absolute right-1 text-gray-500 hover:text-white text-[10px] rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400"
                             aria-label="Clear Text-to-Speech phrase input"
                             title="Clear Text-to-Speech phrase input"
-                                >
-                                    ✕
-                                </button>
+                                ><span aria-hidden="true">✕</span></button>
                             )}
                         </div>
                         <div

--- a/src/components/ShortcutsHelp.tsx
+++ b/src/components/ShortcutsHelp.tsx
@@ -73,9 +73,7 @@ export const ShortcutsHelp: React.FC<ShortcutsHelpProps> = React.memo(({ onClose
                         className="text-gray-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 rounded p-1"
                         aria-label="Close Shortcuts"
                         title="Close Shortcuts"
-                    >
-                        ✕
-                    </button>
+                    ><span aria-hidden="true">✕</span></button>
                 </div>
 
                 {/* Content */}

--- a/src/components/SongMode.tsx
+++ b/src/components/SongMode.tsx
@@ -449,9 +449,7 @@ export const SongMode = memo(forwardRef<SongModeHandle, SongModeProps & { is3D?:
                                 onClick={() => onSetBackgroundImage('')}
                                 className="text-gray-500 hover:text-white px-1 text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 rounded"
                                 aria-label="Clear Background Image"
-                            >
-                                ✕
-                            </button>
+                            ><span aria-hidden="true">✕</span></button>
                         )}
                     </div>
                     <button onClick={onRemoveMeasure} aria-label="Remove Measure" className="px-3 py-1.5 bg-gradient-to-r from-gray-800 to-gray-700 text-gray-300 text-xs rounded-lg hover:from-gray-700 hover:to-gray-600 border border-gray-600 shadow-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500">- BAR</button>
@@ -493,7 +491,7 @@ export const SongMode = memo(forwardRef<SongModeHandle, SongModeProps & { is3D?:
                             </span>
                         ) : 'EXPORT XM'}
                     </button>
-                    <button onClick={onToggle} aria-label="Close Song Mode" title="Close Song Mode" className="ml-2 text-gray-400 hover:text-white text-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 rounded px-1">✕</button>
+                    <button onClick={onToggle} aria-label="Close Song Mode" title="Close Song Mode" className="ml-2 text-gray-400 hover:text-white text-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 rounded px-1"><span aria-hidden="true">✕</span></button>
                 </div>
             </div>
 

--- a/src/components/VoiceEditor.tsx
+++ b/src/components/VoiceEditor.tsx
@@ -108,7 +108,7 @@ export const VoiceEditor: React.FC<VoiceEditorProps> = React.memo(({ onClose }) 
             >
                 <div className="flex justify-between items-center mb-4">
                     <h2 id="voice-designer-title" className="text-xl font-orbitron text-purple-400">VOICE DESIGNER <span className="text-xs text-gray-500 ml-2">(WebGPU)</span></h2>
-                    <button onClick={onClose} className="text-gray-400 hover:text-white focus-visible:ring-2 focus-visible:ring-purple-400 rounded" aria-label="Close Voice Designer" title="Close Voice Designer">✕</button>
+                    <button onClick={onClose} className="text-gray-400 hover:text-white focus-visible:ring-2 focus-visible:ring-purple-400 rounded" aria-label="Close Voice Designer" title="Close Voice Designer"><span aria-hidden="true">✕</span></button>
                 </div>
 
                 {/* Heatmap Area */}

--- a/src/components/WaveformFloatingToggle.tsx
+++ b/src/components/WaveformFloatingToggle.tsx
@@ -24,7 +24,7 @@ export const WaveformFloatingToggle: React.FC<WaveformFloatingToggleProps> = Rea
         disabled={disabled}
         className={`rounded-md px-3 py-2 font-mono text-xs font-bold shadow-lg transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-offset-gray-900 focus-visible:ring-cyan-400 ${disabled ? 'opacity-50 cursor-not-allowed bg-gray-800' : 'bg-cyan-900 hover:bg-cyan-800 text-cyan-300 border border-cyan-700'}`}
       >
-        {open ? '✕ Close' : '♪ Waveforms'}
+        {open ? <><span aria-hidden="true">✕</span> Close</> : <><span aria-hidden="true">♪</span> Waveforms</>}
       </button>
       {open && (
         <div id="waveform-selector-popover" className="absolute top-full right-0 mt-2 z-[100] pointer-events-auto p-2 bg-gray-900 border border-cyan-900/50 rounded-md shadow-2xl min-w-[300px]">


### PR DESCRIPTION
💡 What: Added explicit `aria-hidden="true"` tags to decorative `✕` and `♪` characters used in buttons across various UI components.
🎯 Why: Without these tags, screen readers often read out "multiplication X" or "cross" for close buttons, causing a confusing auditory experience. All affected buttons already have descriptive `aria-label`s, so hiding the visual icon from the screen reader ensures clean navigation.
♿ Accessibility: Improved screen reader UX by preventing redundant or awkward character announcements in standard interactive elements. Components updated include `NoteSelector`, `SongMode`, `SamplerPanel`, `RbsImportModal`, `PatternSelector`, `AISongModal`, `VoiceEditor`, `LiveKeyboard`, `LyricTrack`, `ShortcutsHelp`, and `WaveformFloatingToggle`.

---
*PR created automatically by Jules for task [7434403358994453416](https://jules.google.com/task/7434403358994453416) started by @ford442*