### PR TITLE
⚡ Bolt: Fix inline callbacks in SamplerVoicePanel to preserve memoization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,10 @@
 ## 2026-05-21 - Stabilized Global Context Handlers
 **Learning:** Passing unstabilized inline functions through context completely invalidates `React.memo` on all downstream consumer components, leading to massive re-renders.
 **Action:** Always wrap global context handlers (like those in `useAppState.tsx`) in `useCallback` with precise dependency arrays before passing them down.
+## 2024-05-19 - Component Memoization
+**Learning:** Components wrapped with React.memo that take callbacks as props will still re-render if the callbacks are recreated on every render of the parent component. Replacing React.memo with memo and use callbacks helps minimize renders and improve UI fluidity
+**Action:** Use memo everywhere where React.memo is used and use useCallback.
+
+## 2025-10-24 - Stable fallbacks for React.memo
+**Learning:** Using an inline fallback like `onApply={onApply || (() => {})}` silently defeats `React.memo` on the child component because a new arrow function reference is created on every render.
+**Action:** Create a module-scoped constant (e.g. `const noop = () => {};`) and use it as the fallback (`onApply={onApply || noop}`) to ensure a stable reference is passed down, preserving memoization. For functions that require component state, wrap them in `useCallback` with a proper dependency array.

--- a/src/components/SamplerVoicePanel.tsx
+++ b/src/components/SamplerVoicePanel.tsx
@@ -28,6 +28,8 @@ interface SamplerVoicePanelProps {
     isHarmonizeActive?: boolean;
 }
 
+const noopHarmonizerConfigChange = () => {};
+
 const NOTES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
 
 const midiToNote = (midi: number) => {
@@ -509,6 +511,11 @@ export const SamplerVoicePanel: React.FC<SamplerVoicePanelProps> = React.memo(({
     const ladderButtonRefs = useRef<Map<number, HTMLButtonElement>>(new Map());
     const harmonizeTriggerRef = useRef<HTMLButtonElement>(null);
 
+    const handleHarmonizerClose = useCallback(() => {
+        setIsHarmonizerOpen(false);
+        harmonizeTriggerRef.current?.focus();
+    }, []);
+
     const handleRootNoteChange = (midi: number) => {
         setLocalRootNote(midi);
         onSamplerParamChange?.('rootNote', midi);
@@ -802,13 +809,10 @@ export const SamplerVoicePanel: React.FC<SamplerVoicePanelProps> = React.memo(({
                                 {/* Harmonizer Popover */}
                                 <HarmonizerPopover
                                     isOpen={isHarmonizerOpen}
-                                    onClose={() => {
-                                        setIsHarmonizerOpen(false);
-                                        harmonizeTriggerRef.current?.focus();
-                                    }}
+                                    onClose={handleHarmonizerClose}
                                     config={harmonizerConfig || defaultConfig}
                                     isActive={isHarmonizeActive}
-                                    onApply={onHarmonizerConfigChange || (() => {})}
+                                    onApply={onHarmonizerConfigChange || noopHarmonizerConfigChange}
                                     colorHex={colorHex}
                                 />
                             </div>


### PR DESCRIPTION
⚡ Bolt: Fix inline callbacks in SamplerVoicePanel to preserve memoization

💡 What: Extracted the inline fallback `() => {}` in `HarmonizerPopover`'s `onApply` prop to a module-scoped constant `noopHarmonizerConfigChange`. Wrapped the `onClose` callback in `useCallback`.
🎯 Why: `HarmonizerPopover` is wrapped in `React.memo`, but it was receiving new function references on every render of `SamplerVoicePanel` due to the inline arrow functions. This defeated the memoization, causing a "heavy" component to re-render unnecessarily.
📊 Impact: Prevents `HarmonizerPopover` from re-rendering whenever `SamplerVoicePanel` updates, improving UI fluidity.
🔬 Measurement: Verify with React DevTools Profiler that `HarmonizerPopover` no longer re-renders when parent state changes but its own props remain stable. All tests in `pnpm test` pass.

---
*PR created automatically by Jules for task [18104117402510256080](https://jules.google.com/task/18104117402510256080) started by @ford442*