### PR TITLE
🎨 Palette: Add `aria-description` to sequencer components for gestural hints

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -42,3 +42,6 @@
 ## 2026-05-20 - Prevent Lingering Mouse-Click Focus Rings
 **Learning:** Using standard `focus:ring-2` on custom slider/button components (like DragValue and Knob) causes an ugly, lingering focus ring after a standard mouse click. Keyboard navigation accessibility must be maintained without penalizing mouse users.
 **Action:** When styling interactive elements for accessibility, always prefer `focus-visible:ring-2` and `focus-visible:border-[color]` over `focus:ring-2`. This ensures that keyboard navigators get clear focus indicators while mouse users do not see lingering rings after clicking.
+## 2026-05-23 - Reveal Complex Gestural Patterns with Aria-Description
+**Learning:** Found that complex matrix components like `MainSequencer` use dual-interaction models (left-click vs right-click). These gestural actions are opaque to keyboard and screen reader users without proper hints.
+**Action:** Use `aria-description` on complex interactive UI components to explicitly document primary and secondary actions (e.g., "Left-click to select pattern. Right-click to copy/paste/clear.") to improve discoverability without cluttering the visible UI.

--- a/src/components/MainSequencer.tsx
+++ b/src/components/MainSequencer.tsx
@@ -476,7 +476,7 @@ const SequencerRow = memo(forwardRef<SequencerRowHandle, {
 
     return (
         <g transform={`translate(0, ${rowIndex * 60})`}>
-            <g className="track-label" onClick={handleRowClick} cursor="pointer" role="button" tabIndex={0} aria-label={`Select ${label} track`} aria-pressed={isSelected} onKeyDown={handleRowKeyDown}>
+            <g className="track-label" onClick={handleRowClick} cursor="pointer" role="button" tabIndex={0} aria-label={`Select ${label} track`} aria-description="Left-click to select row. Right-click for options." aria-pressed={isSelected} onKeyDown={handleRowKeyDown}>
                 {isSelected && (
                     <rect 
                         x={-10} 

--- a/src/components/MelodicSequencerRow.tsx
+++ b/src/components/MelodicSequencerRow.tsx
@@ -237,6 +237,7 @@ export const MelodicSequencerRow = memo(forwardRef<MelodicSequencerRowHandle, Me
           role="button"
           tabIndex={0}
           aria-label={`Select ${label} track`}
+          aria-description="Left-click to select row. Right-click for options."
           aria-pressed={isSelected}
           onKeyDown={handleRowKeyDown}
         >

--- a/src/components/sequencer/SequencerRow.tsx
+++ b/src/components/sequencer/SequencerRow.tsx
@@ -95,7 +95,7 @@ export const SequencerRow = memo(forwardRef<SequencerRowHandle, SequencerRowProp
 
     return (
         <g transform={`translate(0, ${rowIndex * 60})`}>
-            <g className="track-label" onClick={handleRowClick} cursor="pointer" role="button" tabIndex={0} aria-label={`Select ${label} track`} aria-pressed={isSelected} onKeyDown={handleRowKeyDown}>
+            <g className="track-label" onClick={handleRowClick} cursor="pointer" role="button" tabIndex={0} aria-label={`Select ${label} track`} aria-description="Left-click to select row. Right-click for options." aria-pressed={isSelected} onKeyDown={handleRowKeyDown}>
                 {isSelected && <rect x={-10} y={8} width={4} height={36} fill="#3fa34d" rx={2} />}
                 <text x={-20} y={30} textAnchor="end" fontFamily="Orbitron, monospace" fontSize={12} fill={isSelected ? '#3fa34d' : '#5a6b60'} fontWeight={isSelected ? 'bold' : 'normal'} style={{ textShadow: isSelected ? '0 0 8px rgba(63,163,77,0.5)' : 'none' }}>{label.toUpperCase()}</text>
             </g>

--- a/src/components/sequencer/TrackSlotButton.tsx
+++ b/src/components/sequencer/TrackSlotButton.tsx
@@ -14,7 +14,7 @@ export const TrackSlotButton = memo(({ index, isActive, hasData, trackKey, onSel
     const patternColor = getPatternColor(index);
     const inactiveColor = hasData ? patternColor : '#0f1812';
     return (
-        <g transform={`translate(${index * 22}, 0)`} className="track-slot" onClick={() => onSelect(trackKey, index)} cursor="pointer" role="button" tabIndex={0} aria-label={`Pattern Slot ${index + 1}`} aria-pressed={isActive} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect(trackKey, index); } }} onContextMenu={(e) => e.preventDefault()}>
+        <g transform={`translate(${index * 22}, 0)`} className="track-slot" onClick={() => onSelect(trackKey, index)} cursor="pointer" role="button" tabIndex={0} aria-label={`Pattern Slot ${index + 1}`} aria-description="Left-click to select pattern. Right-click to copy/paste/clear." aria-pressed={isActive} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect(trackKey, index); } }} onContextMenu={(e) => e.preventDefault()}>
             <rect width={18} height={18} rx={2} fill={isActive ? patternColor : inactiveColor} fillOpacity={isActive ? 1 : (hasData ? 0.4 : 1)} stroke={isActive ? '#fff' : patternColor} strokeOpacity={isActive ? 1 : 0.6} strokeWidth={1} />
             <text x={9} y={13} textAnchor="middle" fontSize={10} fill={isActive ? '#000' : patternColor} fontFamily="monospace" fontWeight="bold">{index + 1}</text>
         </g>


### PR DESCRIPTION
💡 **What**: Added `aria-description` to track labels and slots in the sequencer grid.
🎯 **Why**: The sequencer matrix relies heavily on gestural interactions (left-click to toggle, right-click for menus). Keyboard and screen-reader users need context on how to interact with these elements since it's not visually obvious or communicated via standard ARIA labels alone.
♿ **Accessibility**: Improved discoverability of advanced features for users reliant on screen readers by explicitly detailing the right-click options.

---
*PR created automatically by Jules for task [1864479725387078661](https://jules.google.com/task/1864479725387078661) started by @ford442*