### PR TITLE
🎨 Palette: Add ARIA labels and pressed states to SamplerVoicePanel toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -15,3 +15,6 @@
 ## 2026-05-13 - [NoteSelector Accessibility Improvements]
 **Learning:** Grouping related slider inputs (like Velocity, Duration, Expression) in a complex custom modal component using `<fieldset>` with `sr-only` `<legend>` dramatically improves screen reader navigation and context without affecting the existing visual layout, as long as utility classes like `border-none p-0 m-0` are applied to the fieldset.
 **Action:** Always wrap logical groups of parameter controls in `<fieldset>` tags with descriptive `<legend>` elements instead of generic `div` containers, especially in dense UI sections.
+## 2026-05-14 - Aria Labeling in Mode-Switching Components
+**Learning:** Found that custom toggle switches and mutually exclusive selection buttons (like Voice Type and Harmony Type) frequently lack proper ARIA attributes (`aria-label` and `aria-pressed`). These mode-switching controls are critical for screen reader users to understand the state of complex UI features.
+**Action:** Always bind `aria-pressed` or `aria-selected` to the active state of mode-switching components, and ensure descriptive `aria-label`s are applied, especially when visual feedback is purely styling-based.

--- a/src/components/SamplerVoicePanel.tsx
+++ b/src/components/SamplerVoicePanel.tsx
@@ -296,6 +296,8 @@ const HarmonizerPopover: React.FC<{
                     {/* Toggle switch style ON/OFF button */}
                     <button 
                         onClick={() => setLocalActive(!localActive)}
+                        aria-label={localActive ? "Disable Harmonizer" : "Enable Harmonizer"}
+                        aria-pressed={localActive}
                         className={`relative px-3 py-1 rounded-full text-[9px] font-bold transition-all border ${
                             localActive 
                                 ? 'bg-green-500/20 text-green-400 border-green-500/50 shadow-[0_0_10px_rgba(34,197,94,0.3)]' 
@@ -319,6 +321,8 @@ const HarmonizerPopover: React.FC<{
                                 <button
                                     key={count}
                                     onClick={() => handleVoiceCountChange(count as 2 | 3 | 4)}
+                                    aria-label={`${count} Voices`}
+                                    aria-pressed={localConfig.voiceCount === count}
                                     className={`flex-1 py-1.5 rounded-md text-[10px] font-bold transition-all ${
                                         localConfig.voiceCount === count
                                             ? 'text-black shadow-lg'
@@ -343,6 +347,8 @@ const HarmonizerPopover: React.FC<{
                                 <button
                                     key={value}
                                     onClick={() => handleHarmonyTypeChange(value)}
+                                    aria-label={`${label} Harmony`}
+                                    aria-pressed={localConfig.harmonyType === value}
                                     className={`py-1.5 rounded-md text-[9px] font-bold transition-all relative overflow-hidden ${
                                         localConfig.harmonyType === value
                                             ? 'text-white'


### PR DESCRIPTION
🎨 Palette: Accessibility improvements for SamplerVoicePanel

💡 **What**: Added missing `aria-label` and `aria-pressed` attributes to several interactive toggle controls within the `SamplerVoicePanel` component.
🎯 **Why**: These controls (Harmonizer ON/OFF toggle, Voice Count, and Harmony Type) act as stateful, mode-switching elements. Previously, they relied entirely on visual styling (colors, shadows) to indicate their active state. Adding `aria-label` and `aria-pressed` ensures that screen readers can accurately announce both the purpose of the buttons and their current selection state, making the harmonizer interface fully accessible to non-visual users.
♿ **Accessibility**: 
- Added `aria-label` to the Harmonizer toggle, dynamically indicating "Enable Harmonizer" or "Disable Harmonizer" based on state.
- Bound `aria-pressed` to the `localActive` state for the Harmonizer toggle.
- Added descriptive `aria-label`s to the Voice Count buttons (e.g., "2 Voices").
- Bound `aria-pressed` to the Voice Count buttons.
- Added descriptive `aria-label`s to the Harmony Type buttons (e.g., "Major Harmony").
- Bound `aria-pressed` to the Harmony Type buttons.
- Documented findings in `.Jules/palette.md` for future reference regarding mode-switching components.

(Non-visual change, verified via Playwright and standard unit tests)

---
*PR created automatically by Jules for task [4240759892709138176](https://jules.google.com/task/4240759892709138176) started by @ford442*