### PR TITLE
🎨 Palette: Add tabIndex={-1} to dialogs for focus management

### DIFF
--- a/src/components/AISongImportOverlay.tsx
+++ b/src/components/AISongImportOverlay.tsx
@@ -28,7 +28,7 @@ export const AISongImportOverlay = memo(function AISongImportOverlay({
     const currentIdx = aiImportStage ? stageOrder.indexOf(aiImportStage) : -1;
 
     return (
-        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/80 backdrop-blur-sm" role="dialog" aria-modal="true" aria-label="AI Song Import Progress">
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/80 backdrop-blur-sm" role="dialog" aria-modal="true" aria-label="AI Song Import Progress" tabIndex={-1}>
             <div className="bg-[#0f1115] border border-emerald-500/30 rounded-xl shadow-[0_0_60px_rgba(16,185,129,0.3)] p-8 max-w-md w-full mx-4">
                 <div className="flex items-center gap-4 mb-6">
                     <div className="w-12 h-12 rounded-full bg-emerald-500/10 border border-emerald-500/30 flex items-center justify-center">

--- a/src/components/LiveKeyboard.tsx
+++ b/src/components/LiveKeyboard.tsx
@@ -53,7 +53,7 @@ const KeyboardGuide = ({ onClose }: { onClose: () => void }) => {
 
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm animate-fadeIn" onClick={onClose}>
-            <div role="dialog" aria-modal="true" aria-labelledby="keyboard-guide-title" ref={guideRef} className="relative p-8 border-2 border-dashed border-cyan-500/50 rounded-2xl bg-[#0d1015] shadow-[0_0_50px_rgba(6,182,212,0.15)] max-w-2xl w-full mx-4" onClick={e => e.stopPropagation()}>
+            <div role="dialog" aria-modal="true" aria-labelledby="keyboard-guide-title" tabIndex={-1} ref={guideRef} className="relative p-8 border-2 border-dashed border-cyan-500/50 rounded-2xl bg-[#0d1015] shadow-[0_0_50px_rgba(6,182,212,0.15)] max-w-2xl w-full mx-4" onClick={e => e.stopPropagation()}>
                 <button onClick={onClose} className="absolute top-4 right-4 text-gray-500 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1015] rounded p-1.5" aria-label="Close guide" title="Close Guide"><span aria-hidden="true">✕</span></button>
                 <div className="text-center mb-8">
                     <h3 id="keyboard-guide-title" className="text-2xl font-orbitron font-bold text-cyan-400 mb-2 tracking-widest">PIANO KEYBOARD</h3>

--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -69,6 +69,7 @@ export const LoadingOverlay: React.FC<LoadingOverlayProps> = React.memo(({ isVis
       aria-modal="true"
       aria-labelledby="loading-title"
       aria-describedby="loading-desc"
+      tabIndex={-1}
     >
       <div className="w-full max-w-xl p-8 mx-4 bg-[#1f2937] border-2 border-cyan-500 rounded-2xl shadow-2xl">
         {/* Header */}

--- a/src/components/PhonemePainter.tsx
+++ b/src/components/PhonemePainter.tsx
@@ -407,6 +407,7 @@ export const PhonemePainter: React.FC<PhonemePainterProps> = React.memo(({
       role="dialog"
       aria-modal="true"
       aria-labelledby="phoneme-painter-title"
+      tabIndex={-1}
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}

--- a/src/components/StartOverlay.tsx
+++ b/src/components/StartOverlay.tsx
@@ -9,7 +9,7 @@ interface StartOverlayProps {
 // ⚡ Bolt: Added React.memo to prevent unnecessary re-renders when parent state changes.
 export const StartOverlay: React.FC<StartOverlayProps> = React.memo(({ onStart, isReady }) => {
     return (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#111827] bg-opacity-95 backdrop-blur-sm" role="dialog" aria-modal="true" aria-labelledby="start-overlay-title">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#111827] bg-opacity-95 backdrop-blur-sm" role="dialog" aria-modal="true" aria-labelledby="start-overlay-title" tabIndex={-1}>
             <div className="text-center p-8 bg-[#1f2937] border-2 border-cyan-500 rounded-2xl shadow-2xl max-w-lg w-full">
                 <h1 id="start-overlay-title" className="text-4xl font-bold font-orbitron text-cyan-400 mb-2 tracking-widest drop-shadow-[0_0_10px_rgba(6,182,212,0.8)]">HYPHON</h1>
                 <p className="text-gray-400 mb-8 font-mono text-sm tracking-wide">BROWSER AUDIO WORKSTATION</p>


### PR DESCRIPTION
🎨 Palette: Add `tabIndex={-1}` to dialog containers

This PR addresses a critical UX and accessibility issue documented in the `.Jules/palette.md` journal. When custom modals or dialogs use `role="dialog"`, they must have `tabIndex={-1}` to allow programmatic focus to move into the dialog container when it opens. 

Without this attribute, focus management breaks, preventing screen readers from correctly announcing the dialog and potentially trapping keyboard users or ruining the navigation flow upon closing.

Changes made:
- Added `tabIndex={-1}` to the `role="dialog"` container in `LoadingOverlay.tsx`
- Added `tabIndex={-1}` to the `role="dialog"` container in `AISongImportOverlay.tsx`
- Added `tabIndex={-1}` to the `role="dialog"` container in `StartOverlay.tsx`
- Added `tabIndex={-1}` to the `role="dialog"` container in `PhonemePainter.tsx`
- Added `tabIndex={-1}` to the `role="dialog"` container in `LiveKeyboard.tsx`

All tests pass, and this aligns with our documented accessibility standards.

---
*PR created automatically by Jules for task [16456724351723317077](https://jules.google.com/task/16456724351723317077) started by @ford442*