### PR TITLE
feat(audio): implement step-sequenced bitcrusher/decimator

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -10,6 +10,8 @@
 ## 🚀 Active Backlog (Prioritized)
 
 ### Domain A: Audio Engine (Synth & Sampler)
+- [x] **Step-Sequenced Bitcrusher / Decimator:** Add per-step bit reduction and downsampling to `rubberband-processor.ts` for rhythmically evolving lo-fi crunch textures on TTS vocals.
+- [ ] **Time-Stretch Envelope:** Use an ADSR envelope to dynamically modulate the `timeRatio` of the granular engine, allowing vocals to rhythmically slow down or speed up over a single step.
 - [x] **Refactor SingingVoice State:** Expose alignment state setters in `SingingVoice` to avoid type casting hacks and improve multi-bank alignment handling.
 - [x] **TTS Slice Triggering:** Implement a logic where a MIDI Note NoteOn event can trigger a specific *slice* or *word* from the TTS buffer (e.g., Note C3 = "Hello", Note D3 = "World").
 - [x] **Hybrid Polyphony:** Finalize `VoiceManager` to handle 8-voice polyphony for `synth-1` while keeping `synth-2` strictly monophonic (legato priority).
@@ -61,6 +63,8 @@
 
 * [2026-04-25] - Implemented Step-Sequenced Reverb Types: Added `reverbType` parameter to `Note` interface and updated `NoteSelector` UI to include a space dropdown (Room, Plate, Hall). Refactored `useAudioEngine.ts` to instantiate all three convolution spaces simultaneously to prevent pop artifacts on hot-swapping and updated `audioPlayback.ts` routing to send signals to the correct active `reverbNodesRef` based on the sequence step.
 ## 🧠 Innovation Lab (The "Dream" Log)
+* [x] **Idea:** "Step-Sequenced Bitcrusher / Decimator" - Add per-step bit reduction and downsampling to the sampler for rhythmically evolving lo-fi crunch textures on TTS vocals.
+* [ ] **Idea:** "Time-Stretch Envelope" - Use an ADSR envelope to dynamically modulate the `timeRatio` of the granular engine, allowing vocals to rhythmically slow down or speed up over a single step.
 * [x] **Idea:** "Dynamic Reverb Density LFO" - Modulate the density or size of the reverb tail dynamically using an LFO for swirling, breathing spaces. (Implemented by modulating reverb send gain using a dedicated sine LFO in useAudioEngine!)
 * [x] **Idea:** "Formant-Aware Reverb" - Dynamically adjust the reverb decay and EQ based on the active vowel being sung to prevent high-frequency sibilance buildup. (Implemented in `useAudioEngine.ts` via dynamic lowpass filter before convolution!)
 * [x] **Idea:** "Spectral Panning" - Split the TTS audio into multiple frequency bands and dynamically pan them across the stereo field based on an LFO to create wide, swirling vocal textures.

--- a/fix_components3.py
+++ b/fix_components3.py
@@ -1,0 +1,7 @@
+with open('src/components/NoteSelector.tsx', 'r') as f:
+    content = f.read()
+
+content = content.replace("        | 'tranceGate'", "        | 'tranceGate'\n        | 'bitcrush'\n        | 'downsample'")
+
+with open('src/components/NoteSelector.tsx', 'w') as f:
+    f.write(content)

--- a/src/__tests__/SamplerPanel.perf.test.tsx
+++ b/src/__tests__/SamplerPanel.perf.test.tsx
@@ -50,8 +50,8 @@ describe('SamplerPanel Memoization', () => {
     it('re-renders children when active bank params change', () => {
         const { rerender } = render(<SamplerPanel {...defaultProps} />);
 
-        // Initial render: 37 knobs (Added Gate Depth and Gate Rate)
-        expect(Knob).toHaveBeenCalledTimes(37);
+        // Initial render: 39 knobs (Added Gate Depth and Gate Rate)
+        expect(Knob).toHaveBeenCalledTimes(39);
         vi.clearAllMocks();
 
         // Update params for ACTIVE bank (0)
@@ -61,15 +61,15 @@ describe('SamplerPanel Memoization', () => {
 
         rerender(<SamplerPanel {...defaultProps} params={newParams} />);
 
-        // Should re-render (37 knobs now)
-        expect(Knob).toHaveBeenCalledTimes(37);
+        // Should re-render (39 knobs now)
+        expect(Knob).toHaveBeenCalledTimes(39);
     });
 
     it('does NOT re-render children when inactive bank params change', () => {
         const { rerender } = render(<SamplerPanel {...defaultProps} />);
 
         // Initial render: 37
-        expect(Knob).toHaveBeenCalledTimes(37);
+        expect(Knob).toHaveBeenCalledTimes(39);
         vi.clearAllMocks();
 
         // Update params for INACTIVE bank (1)
@@ -89,7 +89,7 @@ describe('SamplerPanel Memoization', () => {
 
         rerender(<SamplerPanel {...defaultProps} activeBankIdx={1} />);
 
-        // Should re-render (37 knobs now)
-        expect(Knob).toHaveBeenCalledTimes(37);
+        // Should re-render (39 knobs now)
+        expect(Knob).toHaveBeenCalledTimes(39);
     });
 });

--- a/src/audio-worklets/rubberband-processor.ts
+++ b/src/audio-worklets/rubberband-processor.ts
@@ -47,6 +47,10 @@ class RubberBandProcessor extends AudioWorkletProcessor {
   private freezeLfoPhase: number = 0;
   private gatePhase: number = 0;
   private currentGateLfo: number = 1.0;
+
+  // Bitcrusher states
+  private downsamplePhase: number[] = [0, 0];
+  private lastSampleValue: number[] = [0, 0];
   private currentSamplePtr = 0;
   private startSamplePtr = 0;
   private endSamplePtr = 0;
@@ -72,7 +76,9 @@ class RubberBandProcessor extends AudioWorkletProcessor {
       { name: 'freezeEnvDepth', defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },
       { name: 'grainEnvDepth', defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },
       { name: 'grainPitchQuantize', defaultValue: 0.0, minValue: 0.0, maxValue: 12.0 },
-      { name: 'tranceGate', defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 }
+      { name: 'tranceGate', defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },
+      { name: 'bitcrush', defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },
+      { name: 'downsample', defaultValue: 1.0, minValue: 1.0, maxValue: 32.0 }
     ];
   }
 
@@ -256,6 +262,9 @@ class RubberBandProcessor extends AudioWorkletProcessor {
     const tremRate = parameters.tremoloRate ? parameters.tremoloRate[0] : 0;
     const gateDepth = parameters.gateDepth ? parameters.gateDepth[0] : 0;
     const gateRate = parameters.gateRate ? parameters.gateRate[0] : 4.0;
+    const tranceGateAmt = parameters.tranceGate ? parameters.tranceGate[0] : 0.0;
+    const bitcrushAmount = parameters.bitcrush ? parameters.bitcrush[0] : 0.0;
+    const downsampleFactor = parameters.downsample ? parameters.downsample[0] : 1.0;
     const breath = parameters.breathIntensity[0];
     const attack = parameters.attack ? parameters.attack[0] : 0.05;
     const decay = parameters.decay ? parameters.decay[0] : 0.1;
@@ -456,6 +465,33 @@ class RubberBandProcessor extends AudioWorkletProcessor {
 
           const gateMultiplier = 1.0 - (gateDepth * (1.0 - this.currentGateLfo));
           outputChannel[i] *= gateMultiplier;
+        }
+      }
+
+      // Apply Bitcrush & Downsample
+      if (bitcrushAmount > 0 || downsampleFactor > 1.0) {
+        for (let channel = 0; channel < outputs[0].length; channel++) {
+          const outCh = outputs[0][channel];
+          if (!outCh) continue;
+
+          for (let i = 0; i < outCh.length; i++) {
+            this.downsamplePhase[channel] += 1.0;
+            if (this.downsamplePhase[channel] >= downsampleFactor) {
+              this.downsamplePhase[channel] -= downsampleFactor;
+
+              // Bitcrush
+              if (bitcrushAmount > 0) {
+                  // bitcrushAmount 0.0 -> 16 bits, 1.0 -> 2 bits
+                  // Map 0-1 to 16-2 bits linearly
+                  const bits = 16 - (bitcrushAmount * 14);
+                  const steps = Math.pow(2, bits);
+                  this.lastSampleValue[channel] = Math.floor(outCh[i] * steps) / steps;
+              } else {
+                  this.lastSampleValue[channel] = outCh[i];
+              }
+            }
+            outCh[i] = this.lastSampleValue[channel];
+          }
         }
       }
         // Check for completion when no output is available but we're still marked as playing

--- a/src/components/NoteSelector.tsx
+++ b/src/components/NoteSelector.tsx
@@ -64,6 +64,8 @@ interface NoteSelectorProps {
         | 'freezeEnvDepth'
         | 'grainEnvDepth'
         | 'grainPitchQuantize'
+        | 'bitcrush'
+        | 'downsample'
         | 'tranceGate'
         | 'formantShift'
         | 'filterCutoff'
@@ -348,6 +350,45 @@ export const NoteSelector: React.FC<NoteSelectorProps> = memo(({
                                     className="w-full h-2 bg-gray-800 rounded-lg appearance-none cursor-pointer accent-cyan-400 border border-cyan-900/30 hover:accent-cyan-300 transition-all"
                                     aria-valuetext={`${currentGrainPitchQuantize} semitones`}
                                     aria-label="Granular Pitch Quantization"
+                                />                            </div>
+
+                            <div className="flex flex-col gap-1.5" role="group" aria-label="Bitcrush Override">
+                                <div className="flex justify-between items-center text-xs px-1">
+                                    <span className="text-gray-400 font-medium tracking-wide">Bitcrush</span>
+                                    <span className="text-indigo-400 font-mono bg-indigo-500/10 px-1.5 py-0.5 rounded shadow-inner border border-indigo-500/20">
+                                        {((currentNote?.bitcrush ?? 0) * 100).toFixed(0)}%
+                                    </span>
+                                </div>
+                                <input
+                                    type="range"
+                                    min="0"
+                                    max="1"
+                                    step="0.01"
+                                    value={currentNote?.bitcrush ?? 0}
+                                    onChange={(e) => onPropertyChange?.("bitcrush", parseFloat(e.target.value))}
+                                    className="w-full h-2 bg-gray-800 rounded-lg appearance-none cursor-pointer accent-indigo-400 border border-indigo-900/30 hover:accent-indigo-300 transition-all"
+                                    aria-valuetext={`${((currentNote?.bitcrush ?? 0) * 100).toFixed(0)} percent`}
+                                    aria-label="Bitcrush Amount"
+                                />
+                            </div>
+
+                            <div className="flex flex-col gap-1.5" role="group" aria-label="Downsample Override">
+                                <div className="flex justify-between items-center text-xs px-1">
+                                    <span className="text-gray-400 font-medium tracking-wide">Downsample</span>
+                                    <span className="text-indigo-400 font-mono bg-indigo-500/10 px-1.5 py-0.5 rounded shadow-inner border border-indigo-500/20">
+                                        {currentNote?.downsample ?? 1}x
+                                    </span>
+                                </div>
+                                <input
+                                    type="range"
+                                    min="1"
+                                    max="32"
+                                    step="1"
+                                    value={currentNote?.downsample ?? 1}
+                                    onChange={(e) => onPropertyChange?.("downsample", parseFloat(e.target.value))}
+                                    className="w-full h-2 bg-gray-800 rounded-lg appearance-none cursor-pointer accent-indigo-400 border border-indigo-900/30 hover:accent-indigo-300 transition-all"
+                                    aria-valuetext={`${currentNote?.downsample ?? 1} times downsampled`}
+                                    aria-label="Downsample Factor"
                                 />
                             </div>
 

--- a/src/components/NoteSelector.tsx
+++ b/src/components/NoteSelector.tsx
@@ -69,6 +69,8 @@ interface NoteSelectorProps {
         | 'bitcrush'
         | 'downsample'
         | 'tranceGate'
+        | 'bitcrush'
+        | 'downsample'
         | 'formantShift'
         | 'filterCutoff'
         | 'filterResonance'

--- a/src/components/NoteSelector.tsx
+++ b/src/components/NoteSelector.tsx
@@ -23,6 +23,8 @@ interface NoteSelectorProps {
     currentReverse?: boolean;
     currentRetrigger?: number;
     currentFreeze?: number;
+    currentBitcrush?: number;
+    currentDownsample?: number;
     currentFormantShift?: number;
     currentSlideFormant?: boolean;
     currentFilterCutoff?: number;
@@ -126,6 +128,8 @@ export const NoteSelector: React.FC<NoteSelectorProps> = memo(({
     currentFreezeEnvDepth = 0,
     currentGrainEnvDepth = 0,
     currentGrainPitchQuantize = 0,
+    currentBitcrush = 0,
+    currentDownsample = 1,
     currentChoir,
     currentTranceGate = 0, // from jules branch
 
@@ -356,7 +360,7 @@ export const NoteSelector: React.FC<NoteSelectorProps> = memo(({
                                 <div className="flex justify-between items-center text-xs px-1">
                                     <span className="text-gray-400 font-medium tracking-wide">Bitcrush</span>
                                     <span className="text-indigo-400 font-mono bg-indigo-500/10 px-1.5 py-0.5 rounded shadow-inner border border-indigo-500/20">
-                                        {((currentNote?.bitcrush ?? 0) * 100).toFixed(0)}%
+                                        {((currentBitcrush ?? 0) * 100).toFixed(0)}%
                                     </span>
                                 </div>
                                 <input
@@ -364,10 +368,10 @@ export const NoteSelector: React.FC<NoteSelectorProps> = memo(({
                                     min="0"
                                     max="1"
                                     step="0.01"
-                                    value={currentNote?.bitcrush ?? 0}
+                                    value={currentBitcrush ?? 0}
                                     onChange={(e) => onPropertyChange?.("bitcrush", parseFloat(e.target.value))}
                                     className="w-full h-2 bg-gray-800 rounded-lg appearance-none cursor-pointer accent-indigo-400 border border-indigo-900/30 hover:accent-indigo-300 transition-all"
-                                    aria-valuetext={`${((currentNote?.bitcrush ?? 0) * 100).toFixed(0)} percent`}
+                                    aria-valuetext={`${((currentBitcrush ?? 0) * 100).toFixed(0)} percent`}
                                     aria-label="Bitcrush Amount"
                                 />
                             </div>
@@ -376,7 +380,7 @@ export const NoteSelector: React.FC<NoteSelectorProps> = memo(({
                                 <div className="flex justify-between items-center text-xs px-1">
                                     <span className="text-gray-400 font-medium tracking-wide">Downsample</span>
                                     <span className="text-indigo-400 font-mono bg-indigo-500/10 px-1.5 py-0.5 rounded shadow-inner border border-indigo-500/20">
-                                        {currentNote?.downsample ?? 1}x
+                                        {currentDownsample ?? 1}x
                                     </span>
                                 </div>
                                 <input
@@ -384,10 +388,10 @@ export const NoteSelector: React.FC<NoteSelectorProps> = memo(({
                                     min="1"
                                     max="32"
                                     step="1"
-                                    value={currentNote?.downsample ?? 1}
+                                    value={currentDownsample ?? 1}
                                     onChange={(e) => onPropertyChange?.("downsample", parseFloat(e.target.value))}
                                     className="w-full h-2 bg-gray-800 rounded-lg appearance-none cursor-pointer accent-indigo-400 border border-indigo-900/30 hover:accent-indigo-300 transition-all"
-                                    aria-valuetext={`${currentNote?.downsample ?? 1} times downsampled`}
+                                    aria-valuetext={`${currentDownsample ?? 1} times downsampled`}
                                     aria-label="Downsample Factor"
                                 />
                             </div>

--- a/src/components/SamplerPanel.tsx
+++ b/src/components/SamplerPanel.tsx
@@ -203,7 +203,7 @@ const SamplerPanelComponent: React.FC<SamplerPanelProps> = React.memo(({
             'tremoloRate', 'tremoloDepth', 'breathIntensity', 'freeze',
             'freezeLfoSync', 'formantLfoSync', 'freezeLfoRate', 'freezeLfoDepth', 'freezeEnvDepth', 'grainEnvDepth', 'grainPitchQuantize',
             'formantLfoRate', 'formantLfoDepth', 'formantLfoShape', 'characterMorph', 'attack', 'decay',
-            'sustain', 'release', 'choir', 'glitchChance', 'gateDepth', 'gateRate', 'reverbLfoRate', 'reverbLfoDepth'
+            'sustain', 'release', 'choir', 'glitchChance', 'gateDepth', 'gateRate', 'reverbLfoRate', 'reverbLfoDepth', 'bitcrush', 'downsample'
         ] as const;
         return Object.fromEntries(paramNames.map(p => [p, (v: any) => {
             if (onParamChange) onParamChange(activeBankIdx, p, v);
@@ -232,6 +232,8 @@ const SamplerPanelComponent: React.FC<SamplerPanelProps> = React.memo(({
     const handleFreezeEnvDepthChange = paramHandlers.freezeEnvDepth;
     const handleGrainEnvDepthChange = paramHandlers.grainEnvDepth;
     const handleGrainPitchQuantizeChange = paramHandlers.grainPitchQuantize;
+    const handleBitcrushChange = paramHandlers.bitcrush;
+    const handleDownsampleChange = paramHandlers.downsample;
     const handleFormantLfoRateChange = paramHandlers.formantLfoRate;
     const handleFormantLfoDepthChange = paramHandlers.formantLfoDepth;
     const handleFormantLfoShapeChange = paramHandlers.formantLfoShape;
@@ -1087,6 +1089,8 @@ const SamplerPanelComponent: React.FC<SamplerPanelProps> = React.memo(({
                             <Knob label="Env → Freeze" value={currentParams.freezeEnvDepth || 0} onChange={handleFreezeEnvDepthChange} min={0} max={1.0} step={0.01} color="indigo" unit="%" />
                             <Knob label="Env → Grain" value={currentParams.grainEnvDepth || 0} onChange={handleGrainEnvDepthChange} min={0} max={1.0} step={0.01} color="indigo" unit="%" />
                             <Knob label="Grain Quant" value={currentParams.grainPitchQuantize || 0} onChange={handleGrainPitchQuantizeChange} min={0} max={12.0} step={1} color="indigo" unit="st" />
+                            <Knob label="Bitcrush" value={currentParams.bitcrush || 0} onChange={handleBitcrushChange} min={0} max={1.0} step={0.01} color="indigo" unit="%" />
+                            <Knob label="Downsample" value={currentParams.downsample || 1} onChange={handleDownsampleChange} min={1} max={32} step={1} color="indigo" unit="x" />
                             <Knob label="Fmt LFO Rate" value={currentParams.formantLfoRate ?? 0} onChange={handleFormantLfoRateChange} min={0} max={20.0} step={0.1} color="indigo" unit="Hz" />
                             <Knob label="Fmt LFO Depth" value={currentParams.formantLfoDepth ?? 0} onChange={handleFormantLfoDepthChange} min={0} max={1.0} step={0.01} color="indigo" unit="%" />
                             <Knob label="Reverb LFO Rate" value={currentParams.reverbLfoRate ?? 0.1} onChange={handleReverbLfoRateChange} min={0.1} max={10.0} step={0.1} color="indigo" unit="Hz" />

--- a/src/engines/SingingVoice.ts
+++ b/src/engines/SingingVoice.ts
@@ -1175,6 +1175,28 @@ export class SingingVoice {
         }
     }
 
+    /**
+     * Set bitcrush amount.
+     * @param amount Bitcrush amount (0-1)
+     * @param time Optional time to apply the change
+     */
+    setBitcrush(amount: number, time?: number): void {
+        if (this.workletNode) {
+            this.workletNode.parameters.get('bitcrush')?.setValueAtTime(amount, time || this.audioContext.currentTime);
+        }
+    }
+
+    /**
+     * Set downsample factor.
+     * @param factor Downsample factor (1-32)
+     * @param time Optional time to apply the change
+     */
+    setDownsample(factor: number, time?: number): void {
+        if (this.workletNode) {
+            this.workletNode.parameters.get('downsample')?.setValueAtTime(factor, time || this.audioContext.currentTime);
+        }
+    }
+
     // === SAMPLER VOICE PARAMETER METHODS ===
 
     /**

--- a/src/hooks/useAppState.tsx
+++ b/src/hooks/useAppState.tsx
@@ -1193,7 +1193,7 @@ const handleNotePropertyChange = useCallback((
          'filterCutoff' | 'filterResonance' | 'envMod' | 'formantLfoRate' | 'formantLfoDepth' | 
          'formantEnvAttack' | 'formantEnvDecay' | 'formantEnvAmount' | 'vibratoDepth' | 'drive' | 
          'characterMorph' | 'reverbSend' | 'reverbType' | 'reverbLfoRate' | 'reverbLfoDepth' | 'delayLfoRate' | 'delayLfoDepth' | 'delaySend' | 'freezeEnvDepth' | 'pan' |
-         'grainEnvDepth' | 'grainPitchQuantize' | 'choir' | 'gateDepth' | 'gateRate' | 'tranceGate' |
+         'grainEnvDepth' | 'grainPitchQuantize' | 'choir' | 'gateDepth' | 'gateRate' | 'tranceGate' | 'bitcrush' | 'downsample' |
          'vowel' | 'portamento' | 'slideFormant',
     value: number | boolean | string
 ) => {

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -975,6 +975,18 @@ export const useAudioEngine = (pyodide: unknown, tempo: number = 120) => {
                             } else if (params.grainPitchQuantize !== undefined) {
                                 voice.setGrainPitchQuantize(params.grainPitchQuantize, triggerTime);
                             }
+                            if (noteParams?.bitcrush !== undefined) {
+                                voice.setBitcrush(noteParams.bitcrush, triggerTime);
+                            } else if (params.bitcrush !== undefined) {
+                                voice.setBitcrush(params.bitcrush, triggerTime);
+                            }
+
+                            if (noteParams?.downsample !== undefined) {
+                                voice.setDownsample(noteParams.downsample, triggerTime);
+                            } else if (params.downsample !== undefined) {
+                                voice.setDownsample(params.downsample, triggerTime);
+                            }
+
 
                             if (noteParams?.tranceGate !== undefined) {
                                 voice.setTranceGate(noteParams.tranceGate, triggerTime);

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,8 @@ export interface SamplerBankParams {
   formantLfoDepth?: number;
   reverbLfoRate?: number;
   reverbLfoDepth?: number;
+  bitcrush?: number;
+  downsample?: number;
   delayLfoRate?: number;
   delayLfoDepth?: number;
   formantLfoShape?: number[];
@@ -217,6 +219,8 @@ export interface Note {
   reverbType?: ReverbType;
   reverbLfoRate?: number;
   reverbLfoDepth?: number;
+  bitcrush?: number;
+  downsample?: number;
   delayLfoRate?: number;
   delayLfoDepth?: number;
   delaySend?: number;


### PR DESCRIPTION
Implements the "Step-Sequenced Bitcrusher / Decimator" feature from the Innovation Lab.
- Adds `bitcrush` and `downsample` parameters to `Note` and `SamplerBankParams` interfaces.
- Implements DSP bit-reduction and sample-and-hold downsampling within `rubberband-processor.ts` (with per-channel phase tracking for stereo safety).
- Routes properties cleanly from the `SamplerPanel` and `NoteSelector` components down through `useAudioEngine.ts` and `SingingVoice.ts` directly to the `AudioWorkletNode`.
- Fully documented in `agent_plan.md` using the Daily Loop procedure.

---
*PR created automatically by Jules for task [2562930835694532830](https://jules.google.com/task/2562930835694532830) started by @ford442*