### PR TITLE
Fix 12 TypeScript compile errors

### DIFF
--- a/src/__tests__/RbsIffParser.test.ts
+++ b/src/__tests__/RbsIffParser.test.ts
@@ -19,7 +19,7 @@ function buildSyntheticIffFile(options: {
   loopStart?: number;
   loopEnd?: number;
   trakEvents?: Array<{ delta: number; ctrl: number; value: number }>;
-} = {}): Uint8Array {
+} = {}): Uint8Array<ArrayBuffer> {
   const {
     playMode = 1,
     tempo = 1350, // 135.0 BPM × 10

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -617,6 +617,8 @@ export const useAudioEngine = (pyodide: unknown, tempo: number = 120) => {
                     breathIntensity?: number,
                     formantShift?: number,
                     grainPitchQuantize?: number,
+                    bitcrush?: number,
+                    downsample?: number,
                     tranceGate?: number,
                     gateRate?: number,
                     gateDepth?: number,

--- a/src/importers/rbs/RebirthRBSParser.ts
+++ b/src/importers/rbs/RebirthRBSParser.ts
@@ -27,10 +27,11 @@ import type {
   AutomationLane,
   RbsTrakEvent,
   RbsSongData,
+  Tb303Step,
 } from './types';
 import { TRAK_TRACK_INDEX, TICKS_PER_BAR } from './types';
 import { RbsParser } from './RbsParser';
-import type { RbsParserError, Tb303Step } from './RbsParser';
+import type { RbsParserError } from './RbsParser';
 
 // ============================================================================
 // Public return-type interfaces for each spec method


### PR DESCRIPTION
## Summary

Fixes the 12 TypeScript compilation errors reported by `tsc --noEmit`.

### Changes

1. **`src/hooks/useAudioEngine.ts`** — Added the missing `bitcrush?: number` and `downsample?: number` fields to the inline `noteParams` type, so the per-step `noteParams.bitcrush` / `noteParams.downsample` accesses (lines 978–985) type-check.

2. **`src/importers/rbs/RebirthRBSParser.ts`** — `Tb303Step` is exported from `./types`, not `./RbsParser`. Moved the `Tb303Step` import to the `./types` import group and left only `RbsParserError` importing from `./RbsParser`.

3. **`src/__tests__/RbsIffParser.test.ts`** — Changed the `buildSyntheticIffFile` return type from `Uint8Array` to `Uint8Array<ArrayBuffer>`. The default `Uint8Array<ArrayBufferLike>` was not assignable to `BlobPart` in `new File([bytes], ...)` (the `SharedArrayBuffer` branch is incompatible). This fixes all 7 `File` construction errors at the source.

### Verification

`npx tsc --noEmit` now reports no errors.

https://claude.ai/code/session_01G5oRbdfD9ZUioStqkktYEM

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5oRbdfD9ZUioStqkktYEM)_