### PR TITLE
plan(2026-06-01) + feat(telemetry): weekly plan & exportable engine session report (#699)

### DIFF
--- a/weekly_plan.md
+++ b/weekly_plan.md
@@ -1,24 +1,29 @@
 # web_sequencer — Weekly Plan
 
 ## Today's focus
-**2026-05-25 (Sun) — User Idea mode.** Holographic knob WGSL render pass unification — route `HardwareModule.tsx`'s per-component WebGPU knob rendering through the `KnobGPUContext` singleton (shared pipeline + RAF, same WGSL shader already used by `MagicKnob.tsx`), retire the duplicate per-component `GPUDevice` init + per-component RAF in `HardwareModule.tsx`, and unify the visual output so the 2D Canvas fallback (`renderWith2D`) and the WebGPU path share the same lighting/material contracts and don't visually drift.
+**2026-06-01 (Mon) — User Idea mode.** Finish the holographic-knob drift-kill: last week's *plumbing* landed (HardwareModule routes through `KnobGPUContext` singleton, per-knob canvas, ResizeObserver, 2D palette contract — all on `main`, build passing), but the idea's core goal is still open. The two render paths still hardcode **independent palettes** and provably drift:
+- WGSL (`KnobGPUContext.ts`): base `vec3f(0,0.9,1.0)`, arc `mix(vec3(0,0.6,0.5) → vec3(0.2,1.0,0.8))`, ×1.5 bloom, transparent bg.
+- 2D (`HardwareModule.renderWith2D`): ring `#00e5ff`, arc `#00e5ff → #00897b`, solid `#0d0f13` bg, no bloom — comment admits it "approximates" the WGSL look.
+
+**Task:** extract a single `knobMaterial` source-of-truth module (palette stops, ring/arc geometry, 270° sweep angles, bloom factor, background) consumed by **both** the WGSL uniform packing in `KnobGPUContext` *and* `renderWith2D`, so the two paths derive from identical constants and cannot drift. Verify `MagicKnob` (already singleton-ported) inherits the same contract.
 
 ## Ideas
 - [done — 2026-04-27] **Verify bug-report.md staleness** — confirmed stale: `useAudioEngine.ts` is 938 lines; the try/catch at line 1393 no longer exists. `bug-report.md` can be deleted.
 - [done — 2026-05-25] **Holographic knob GPU context unification** — `KnobGPUContext.ts` singleton fully implemented (shared `GPURenderPipeline`, single batched RAF, per-knob `uniformBuffer`+`bindGroup`, `register`/`unregister` API); `MagicKnob.tsx` fully ported. N-device anti-pattern retired.
-- [in progress — 2026-05-25] Holographic knob WGSL render pass unification — single compute-driven render path so every knob shares lighting/material, kill drift between the 2D fallback and the WebGPU canvas path. (multi-day; depends on perf audit findings)
+- [in progress — 2026-06-01] Holographic knob WGSL render pass unification — single compute-driven render path so every knob shares lighting/material, kill drift between the 2D fallback and the WebGPU canvas path. (multi-day; depends on perf audit findings)
+  - Plumbing/singleton routing landed 2026-05-25 (see Done). Remaining = shared `knobMaterial` constants module so WGSL + 2D fallback can't visually drift. This is today's focus.
 
 ## Backlog
-- [ ] **PR #506** "Fix: Resolve TypeScript errors related to Note interface" — open (Jules, May 3), needs review/merge or feedback.
-- [ ] **PR #507** "Palette: Fix orphaned aria-describedby in GamepadDebugger" — open (Jules, May 3), needs review/merge or feedback.
-- [ ] **Open issue #330** Live Keyboard UI arrangement — CSS-grid piano-shape layout; Jules-labeled, still unimplemented. Plan draft referenced but `live-kbd-plan.md` not found at root — verify.
-- [ ] **Issue #465** Docs consolidation — Phase 1 (DOCS.md root index, zero-move) is the immediate deliverable; Phase 2 (physical migration to `docs/`) deferred. Phase 1 spec fully written in the issue.
-- [ ] **Issue #672** test+docs polish for RBS import + automation — expand Vitest coverage for parser/importer/scheduler and document automation architecture.
-- [ ] **Repo hygiene** — 30+ `*.md` files at repo root; Phase 1 resolved by issue #465 DOCS.md index.
+- [ ] **Duplicate Copilot PRs #685 & #686** — both "[WIP] Map Rebirth .rbs data to Hyphon internal models" (open drafts, May 30). Close one to avoid divergence; #685 has the better task checklist.
+- [ ] **PR #693** "feat(tts): add consonantEmphasis control" — open Jules draft (May 31), needs review/merge or feedback.
+- [ ] **GitHub reports 0 OPEN issues** (API, 2026-06-01) — prior backlog refs #330 (live-keyboard CSS grid), #465 (DOCS.md index), #672 (RBS test+docs) appear closed/resolved or were never filed as issues. VERIFY before re-actioning; #672 is cited as a "parser" issue by PRs #685/#686 so likely closed-on-merge.
+- [ ] **Repo hygiene** — 30+ `*.md` files + dozens of one-off `fix*.py` / `patch*.py` / `update_*.py` scripts at repo root. Candidate: DOCS.md zero-move root index + archive scripts into `tools/`.
 - [ ] Rubberband phoneme-aware time-stretch + `ExpressiveVoiceProcessor.ts` pending per `RUBBERBAND_ENHANCEMENT_PLAN.md`.
-- [ ] Dozens of one-off `fix*.py` / `patch*.py` / `update_*.py` scripts at repo root — candidate for archival into `tools/`.
+- [ ] RBS import test+docs polish (was issue #672) — expand Vitest coverage for parser/importer/scheduler + document automation architecture. Partly in flight via Copilot PRs #685/#686.
 
 ## Done
+- 2026-06-01 — Holographic knob render-pass PLUMBING landed on `main`: `HardwareModule.tsx` routes all knobs through `KnobGPUContext` singleton (per-knob `<canvas>`, `register`/`unregister`, ResizeObserver sizing, ~320 lines of per-component WebGPU init removed), `renderWith2D` extracted as standalone fn with a contracted palette. Build passes. NOTE: visual-drift kill (shared material contract) is NOT done — carried into today's focus.
+- 2026-06-01 — Backlog reconcile: PRs #506 & #507 confirmed CLOSED-unmerged (2026-05-15), removed from backlog. GitHub reports 0 open issues — #330/#465/#672 flagged for verification.
 - 2026-05-25 — Holographic knob GPU context unification: `KnobGPUContext.ts` singleton + `MagicKnob.tsx` fully ported (PR #617 context: WASM memory fix also landed).
 - 2026-05-18 — jc303/Open303 WASM pipeline stabilized: stub-WASM early detection, `Open303Manager` params wiring, WASM promoted to Vite content-hashed asset (PRs #569 + #572, Claude Code).
 - 2026-05-18 — Live keyboard triggers drum voices with MIDI note pitch shifting (PR #571, Copilot).
@@ -51,7 +56,8 @@
 - 2026-04-12 — AdvancedNoteSelector + ScaleSelector (PR #443).
 
 ## Last run
-Date: 2026-05-25
+Date: 2026-06-01
 Mode: User Idea
-Focus: Holographic knob WGSL render pass unification — route HardwareModule.tsx per-component knob WebGPU rendering through KnobGPUContext singleton; unify 2D fallback visual contract with WebGPU path.
+Focus: Finish holographic-knob drift-kill — extract a shared `knobMaterial` constants module (palette/geometry/bloom/bg) consumed by BOTH the WGSL uniform packing in KnobGPUContext AND HardwareModule.renderWith2D, so the WebGPU and 2D-fallback paths derive from identical constants and cannot drift.
 Outcome: (to be filled at end-of-day)
+Prior-run note: 2026-05-25 plumbing/singleton routing landed on main (build passing), but the visual-drift goal was left open — verified 2026-06-01 by diffing WGSL vs renderWith2D palettes (independently hardcoded). Hence continued, not new.


### PR DESCRIPTION
## 1. Weekly planner run — 2026-06-01 (User Idea mode)
Updates `weekly_plan.md`: knob render-pass *plumbing* moved to Done (landed on `main`, build passing); the idea's core drift-kill carried into today's focus (shared `knobMaterial` contract). Reconciled backlog — closed-unmerged PRs #506/#507 removed, 0-open-issues flagged, duplicate Copilot PRs #685/#686 + Jules PR #693 added.

## 2. feat(telemetry): exportable hybrid-engine session report — Closes #699

Adds a manual, privacy-preserving export of hybrid audio-engine telemetry.

**Changes**
- **`src/utils/engineTelemetry.ts`** — bounded per-subsystem `resolutionHistory` (cap 20); `sampleCount` + `p95Reliable` on `snapshot()` (threshold **128**, consistent with the 256-sample ring cap — *not* 500); `getBrowserCapabilities()` (capability `tier`; **no raw userAgent**, optional low-entropy `userAgentData`); pure `serializeEngineReport()`; injectable `DownloadProvider`; `generateReportJSON()` + `exportReport()`.
- **`src/main.tsx`** — registers `window.__devtools.exportEngineReport` at **app bootstrap** (not on HUD/component mount), gated on `import.meta.env.DEV || ?devtools`.
- **`src/components/EngineHUD.tsx`** — "Download Report" + "Copy JSON" buttons via **event delegation** (survives the 500ms `innerHTML` re-render); clears `inert` while visible so buttons are clickable.
- **`src/utils/__tests__/engineTelemetry.test.ts`** — 9 tests: serialization shape, no-userAgent-leak, filename safety, capability shape, p95Reliable boundary (127→128), history cap (25→20), ring cap (300→256), injected export provider.

**Verification**
- `npx tsc -b` → 0 errors
- `npx vitest run` → **934 passed, 1 skipped, 0 failed** (new file: 9/9)
- `eslint` on touched files → clean
- Full `npm run build` not run here — needs the WASM toolchain (asc/wasm-pack/emscripten) absent from this container; covered by CI / the mid-day pipeline task.

**Design notes (resolved open questions)**
- Decoupled export from the HUD (registered at bootstrap) so it works even if the user never opened the HUD.
- Privacy: capability tier, no raw userAgent; manual-only; dev/`?devtools` gated.
- IndexedDB cross-session persistence explicitly rejected as over-engineered; in-memory ring buffer only.

https://claude.ai/code/session_01WGd5LsqEqQawHbQ4QKT4dd