### PR TITLE
feat(telemetry): exportable hybrid-engine session report from EngineHUD

### DIFF
--- a/src/components/EngineHUD.tsx
+++ b/src/components/EngineHUD.tsx
@@ -28,14 +28,24 @@ if (typeof window !== 'undefined' && !document.getElementById(CONTAINER_ID)) {
   #${CONTAINER_ID} .backend-js { background:#6b7280; }
   #${CONTAINER_ID} .backend-wav { background:#f59e0b; color:#000 }
   #${CONTAINER_ID} .backend-open303 { background:#7c3aed }
+  #${CONTAINER_ID} .hud-actions { display:flex; gap:8px; margin-top:8px; border-top:1px solid rgba(255,255,255,0.1); padding-top:8px; }
+  #${CONTAINER_ID} button { background: rgba(255,255,255,0.1); border:1px solid rgba(255,255,255,0.2); color:#fff; padding:4px 8px; border-radius:4px; cursor:pointer; font-size:11px; }
+  #${CONTAINER_ID} button:hover { background: rgba(255,255,255,0.2); }
   `;
   document.head.appendChild(style);
 
   let visible = new URLSearchParams(location.search).get('hud') === '1';
 
   function render() {
-    if (!visible) { container.style.display = 'none'; return; }
+    if (!visible) {
+      container.style.display = 'none';
+      // Keep it inert while hidden so it stays out of the a11y tree / input.
+      if ('inert' in container) { (container as HTMLElement & { inert: boolean }).inert = true; }
+      return;
+    }
     container.style.display = 'block';
+    // Clear inert while shown so the action buttons are operable (inert blocks clicks).
+    if ('inert' in container) { (container as HTMLElement & { inert: boolean }).inert = false; }
     const data = engineTelemetry.snapshot();
     const keys = Object.keys(data).sort();
     const rows = keys.map(k => {
@@ -47,8 +57,27 @@ if (typeof window !== 'undefined' && !document.getElementById(CONTAINER_ID)) {
       return `<div class="row"><div class="badge backend-${backend}">${backend}</div><div style="flex:1">${k}</div><div style="min-width:90px;text-align:right">${p50}/${p95} ms</div><div style="width:64px;text-align:right">${err}</div></div>`;
     }).join('');
 
-    container.innerHTML = `<div class="header">Engine HUD</div>${rows}`;
+    container.innerHTML = `<div class="header">Engine HUD</div>${rows}<div class="hud-actions"><button type="button" id="hud-export-btn">Download Report</button><button type="button" id="hud-copy-btn">Copy JSON</button></div>`;
   }
+
+  // Event delegation: render() replaces innerHTML every 500ms, so per-render
+  // listeners would be discarded. Bind once on the persistent container instead.
+  container.addEventListener('click', (e) => {
+    const target = e.target as HTMLElement | null;
+    if (!target) return;
+    if (target.id === 'hud-export-btn') {
+      engineTelemetry.exportReport();
+    } else if (target.id === 'hud-copy-btn') {
+      const json = engineTelemetry.generateReportJSON();
+      if (navigator.clipboard?.writeText) {
+        const orig = target.textContent;
+        navigator.clipboard.writeText(json).then(() => {
+          target.textContent = 'Copied!';
+          setTimeout(() => { target.textContent = orig; }, 1500);
+        }).catch(() => { /* clipboard denied; no-op */ });
+      }
+    }
+  });
 
   render();
   const timer = setInterval(render, 500);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,23 @@ import './index.css'
 import './components/EngineHUD' // side-effect: register Engine HUD mount
 import App from './App'
 import { AppStateProvider } from './contexts/AppStateContext'
+import { engineTelemetry } from './utils/engineTelemetry'
+
+// Register the engine-report export hook at app bootstrap (NOT on HUD/component
+// mount) so it is available regardless of view state — a user hitting an audio
+// glitch may never have opened the HUD. Gated to dev builds or ?devtools so it is
+// not ambiently exposed in the public build.
+if (
+  import.meta.env.DEV ||
+  (typeof location !== 'undefined' && new URLSearchParams(location.search).has('devtools'))
+) {
+  const w = window as unknown as { __devtools?: Record<string, unknown> }
+  w.__devtools = w.__devtools || {}
+  w.__devtools.exportEngineReport = () => {
+    engineTelemetry.exportReport()
+    console.log('[devtools] engine report exported')
+  }
+}
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/utils/__tests__/engineTelemetry.test.ts
+++ b/src/utils/__tests__/engineTelemetry.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+  EngineTelemetry,
+  serializeEngineReport,
+  getBrowserCapabilities,
+  reportFilename,
+  browserDownloadProvider,
+  P95_MIN_SAMPLES,
+  type BrowserCapabilities,
+  type SubsystemReport,
+  type DownloadProvider,
+} from '../engineTelemetry';
+
+const fakeCaps: BrowserCapabilities = {
+  webgpu: true,
+  audioWorklet: true,
+  wasmSimd: false,
+  pyodide: false,
+  secureContext: true,
+  tier: 'medium',
+};
+
+function fakeSubsystem(overrides: Partial<SubsystemReport> = {}): SubsystemReport {
+  return {
+    resolution: { backend: 'wasm', reason: 'fallback', ts: 1000 },
+    p50: 1.2,
+    p95: 2.4,
+    sampleCount: 200,
+    p95Reliable: true,
+    last: [1, 2, 3],
+    errors: { count: 0, lastError: undefined, lastTs: null },
+    resolutionHistory: [{ backend: 'webgpu', ts: 1 }, { backend: 'wasm', ts: 2 }],
+    ...overrides,
+  };
+}
+
+describe('serializeEngineReport', () => {
+  it('wraps the snapshot + capabilities into a versioned report', () => {
+    const snapshot = { synthA: fakeSubsystem() };
+    const parsed = JSON.parse(serializeEngineReport(snapshot, fakeCaps));
+
+    expect(parsed.version).toBe(1);
+    expect(typeof parsed.exportedAt).toBe('string');
+    expect(new Date(parsed.exportedAt).toString()).not.toBe('Invalid Date');
+    expect(typeof parsed.sessionDurationMs).toBe('number');
+    expect(parsed.capabilities).toEqual(fakeCaps);
+    expect(parsed.subsystems.synthA.resolution.backend).toBe('wasm');
+    expect(parsed.subsystems.synthA.p50).toBe(1.2);
+  });
+
+  it('never leaks a raw userAgent string', () => {
+    const json = serializeEngineReport({ s: fakeSubsystem() }, fakeCaps);
+    expect(json).not.toContain('"userAgent"');
+    const parsed = JSON.parse(json);
+    expect('userAgent' in parsed.capabilities).toBe(false);
+  });
+});
+
+describe('reportFilename', () => {
+  it('produces a filesystem-safe filename (no colons or dots in the timestamp)', () => {
+    const name = reportFilename(new Date('2026-06-01T12:34:56.789Z'));
+    expect(name).toBe('hyphon-engine-report-2026-06-01T12-34-56-789Z.json');
+  });
+});
+
+describe('getBrowserCapabilities', () => {
+  it('returns a structured capability snapshot without a raw userAgent', () => {
+    const caps = getBrowserCapabilities();
+    expect(typeof caps.webgpu).toBe('boolean');
+    expect(typeof caps.audioWorklet).toBe('boolean');
+    expect(typeof caps.wasmSimd).toBe('boolean');
+    expect(['high', 'medium', 'low']).toContain(caps.tier);
+    expect('userAgent' in caps).toBe(false);
+  });
+});
+
+describe('EngineTelemetry.snapshot', () => {
+  it('flags p95 as unreliable below the sample threshold and reliable at/above it', () => {
+    const t = new EngineTelemetry();
+    for (let i = 0; i < P95_MIN_SAMPLES - 1; i++) t.recordLatency('synthA', i % 5);
+    expect(t.snapshot().synthA.sampleCount).toBe(P95_MIN_SAMPLES - 1);
+    expect(t.snapshot().synthA.p95Reliable).toBe(false);
+
+    t.recordLatency('synthA', 1); // now exactly P95_MIN_SAMPLES
+    expect(t.snapshot().synthA.sampleCount).toBe(P95_MIN_SAMPLES);
+    expect(t.snapshot().synthA.p95Reliable).toBe(true);
+  });
+
+  it('bounds the resolution history at 20 entries and keeps the most recent', () => {
+    const t = new EngineTelemetry();
+    for (let i = 0; i < 25; i++) t.registerResolution('open303', `backend-${i}`);
+    const snap = t.snapshot().open303;
+    expect(snap.resolutionHistory.length).toBe(20);
+    expect(snap.resolutionHistory[snap.resolutionHistory.length - 1].backend).toBe('backend-24');
+    expect(snap.resolution?.backend).toBe('backend-24');
+  });
+
+  it('caps the latency ring at maxLatencySamples (256)', () => {
+    const t = new EngineTelemetry();
+    for (let i = 0; i < 300; i++) t.recordLatency('sampler', i);
+    expect(t.snapshot().sampler.sampleCount).toBe(256);
+  });
+});
+
+describe('EngineTelemetry.exportReport', () => {
+  it('routes a JSON report and filename through an injected DownloadProvider', () => {
+    const t = new EngineTelemetry();
+    t.registerResolution('synthA', 'webgpu');
+    t.recordLatency('synthA', 1.5);
+
+    const calls: Array<{ json: string; filename: string }> = [];
+    const provider: DownloadProvider = {
+      triggerDownload: (json, filename) => calls.push({ json, filename }),
+    };
+
+    t.exportReport(provider);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].filename).toMatch(/^hyphon-engine-report-.*\.json$/);
+    const parsed = JSON.parse(calls[0].json);
+    expect(parsed.version).toBe(1);
+    expect(parsed.subsystems.synthA.resolution.backend).toBe('webgpu');
+  });
+
+  it('exposes a browser download provider', () => {
+    expect(typeof browserDownloadProvider.triggerDownload).toBe('function');
+  });
+});

--- a/src/utils/engineTelemetry.ts
+++ b/src/utils/engineTelemetry.ts
@@ -1,14 +1,32 @@
 // Lightweight runtime telemetry for engine backends
 // Records backend resolution, recent latencies, and error counts.
+// Also produces an exportable, privacy-preserving session report (see issue #699).
 
 type Resolution = { backend: string; reason?: string; ts: number };
 
+// Bound the per-subsystem fallback-transition log. ~20 * ~50 bytes = negligible.
+const MAX_RESOLUTION_HISTORY = 20;
+// The latency ring caps at maxLatencySamples (256). Below this many samples a p95
+// is anecdotal, so we flag it rather than implying false statistical rigor.
+export const P95_MIN_SAMPLES = 128;
+
 type TelemetryData = {
   resolution?: Resolution | null;
+  resolutionHistory: Resolution[];
   latencies: number[];
   errors: { count: number; lastError?: string; lastTs?: number | null };
   maxLatencySamples: number;
 };
+
+function emptyData(): TelemetryData {
+  return {
+    resolution: null,
+    resolutionHistory: [],
+    latencies: [],
+    errors: { count: 0, lastError: undefined, lastTs: null },
+    maxLatencySamples: 256,
+  };
+}
 
 function percentile(arr: number[], p: number): number | null {
   if (!arr || arr.length === 0) return null;
@@ -17,48 +35,183 @@ function percentile(arr: number[], p: number): number | null {
   return copy[idx] ?? null;
 }
 
-class EngineTelemetry {
+// ── Capability snapshot (privacy-preserving) ────────────────────────────────
+// Deliberately excludes the raw navigator.userAgent string (User-Agent Reduction
+// makes it low-value and a fingerprinting footgun). Only low-entropy Client Hints
+// (userAgentData brands/platform) are included when the browser exposes them.
+
+export interface BrowserCapabilities {
+  webgpu: boolean;
+  audioWorklet: boolean;
+  wasmSimd: boolean;
+  pyodide: boolean;
+  secureContext: boolean;
+  tier: 'high' | 'medium' | 'low';
+  userAgentData?: { brands?: unknown; platform?: string };
+}
+
+// Minimal valid WASM module exercising a v128 (SIMD) result type — used purely to
+// feature-detect SIMD support via WebAssembly.validate (zero dependency).
+const WASM_SIMD_PROBE = new Uint8Array([
+  0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 96, 0, 1, 123, 3, 2, 1, 0, 10, 10, 1, 8, 0,
+  65, 0, 253, 15, 253, 98, 11,
+]);
+
+export function getBrowserCapabilities(): BrowserCapabilities {
+  const nav = typeof navigator !== 'undefined' ? (navigator as unknown as Record<string, unknown>) : undefined;
+  const webgpu = !!(nav && nav.gpu);
+  const audioWorklet = typeof AudioWorkletNode !== 'undefined';
+  let wasmSimd = false;
+  try {
+    wasmSimd = typeof WebAssembly !== 'undefined' && WebAssembly.validate(WASM_SIMD_PROBE);
+  } catch {
+    wasmSimd = false;
+  }
+  const pyodide =
+    typeof window !== 'undefined' &&
+    ('loadPyodide' in window || !!(window as unknown as Record<string, unknown>).pyodide);
+  const secureContext = typeof window !== 'undefined' ? !!window.isSecureContext : false;
+  const tier: BrowserCapabilities['tier'] =
+    webgpu && audioWorklet && wasmSimd ? 'high' : audioWorklet && wasmSimd ? 'medium' : 'low';
+
+  const caps: BrowserCapabilities = { webgpu, audioWorklet, wasmSimd, pyodide, secureContext, tier };
+
+  const uad = nav && (nav.userAgentData as { brands?: unknown; platform?: string } | undefined);
+  if (uad) {
+    caps.userAgentData = { brands: uad.brands, platform: uad.platform };
+  }
+  return caps;
+}
+
+// ── Report shapes ───────────────────────────────────────────────────────────
+
+export interface SubsystemReport {
+  resolution: Resolution | null;
+  p50: number | null;
+  p95: number | null;
+  sampleCount: number;
+  p95Reliable: boolean;
+  last: number[];
+  errors: { count: number; lastError?: string; lastTs?: number | null };
+  resolutionHistory: Resolution[];
+}
+
+export interface EngineReport {
+  version: 1;
+  exportedAt: string;
+  sessionDurationMs: number;
+  capabilities: BrowserCapabilities;
+  subsystems: Record<string, SubsystemReport>;
+}
+
+// ── Download abstraction (injectable so the pure logic stays DOM-free/testable) ─
+
+export interface DownloadProvider {
+  triggerDownload(json: string, filename: string): void;
+}
+
+export const browserDownloadProvider: DownloadProvider = {
+  triggerDownload(json: string, filename: string) {
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    try {
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+    } finally {
+      // Revoke after the click has been processed by the event loop.
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    }
+  },
+};
+
+export function reportFilename(now: Date = new Date()): string {
+  return `hyphon-engine-report-${now.toISOString().replace(/[:.]/g, '-')}.json`;
+}
+
+/**
+ * Pure serialization of a telemetry snapshot + capability snapshot into a report
+ * JSON string. No DOM, no globals beyond Date/performance — unit-testable directly.
+ */
+export function serializeEngineReport(
+  snapshot: Record<string, SubsystemReport>,
+  capabilities: BrowserCapabilities,
+): string {
+  const report: EngineReport = {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    sessionDurationMs: typeof performance !== 'undefined' ? Math.round(performance.now()) : 0,
+    capabilities,
+    subsystems: snapshot,
+  };
+  return JSON.stringify(report, null, 2);
+}
+
+export class EngineTelemetry {
   private data = new Map<string, TelemetryData>();
 
   registerResolution(subsystem: string, backend: string, reason?: string) {
     let s = this.data.get(subsystem);
-    if (!s) s = { latencies: [], errors: { count: 0, lastError: undefined, lastTs: null }, maxLatencySamples: 256 };
-    s.resolution = { backend, reason, ts: Date.now() };
-    this.data.set(subsystem, s);
+    if (!s) {
+      s = emptyData();
+      this.data.set(subsystem, s);
+    }
+    const res: Resolution = { backend, reason, ts: Date.now() };
+    s.resolution = res;
+    s.resolutionHistory.push(res);
+    if (s.resolutionHistory.length > MAX_RESOLUTION_HISTORY) s.resolutionHistory.shift();
   }
 
   recordLatency(subsystem: string, ms: number) {
     let s = this.data.get(subsystem);
-    if (!s) s = { latencies: [], errors: { count: 0, lastError: undefined, lastTs: null }, maxLatencySamples: 256 };
+    if (!s) {
+      s = emptyData();
+      this.data.set(subsystem, s);
+    }
     s.latencies.push(ms);
     if (s.latencies.length > s.maxLatencySamples) s.latencies.shift();
-    this.data.set(subsystem, s);
   }
 
   recordError(subsystem: string, err: unknown) {
     let s = this.data.get(subsystem);
-    if (!s) s = { latencies: [], errors: { count: 0, lastError: undefined, lastTs: null }, maxLatencySamples: 256 };
+    if (!s) {
+      s = emptyData();
+      this.data.set(subsystem, s);
+    }
     s.errors.count += 1;
     s.errors.lastError = err instanceof Error ? err.message : String(err);
     s.errors.lastTs = Date.now();
-    this.data.set(subsystem, s);
   }
 
-  snapshot() {
-    const out: Record<string, any> = {};
+  snapshot(): Record<string, SubsystemReport> {
+    const out: Record<string, SubsystemReport> = {};
     for (const [k, v] of this.data.entries()) {
       const last = v.latencies.slice(-v.maxLatencySamples);
-      const p50 = percentile(last, 50);
-      const p95 = percentile(last, 95);
       out[k] = {
         resolution: v.resolution || null,
-        p50,
-        p95,
+        p50: percentile(last, 50),
+        p95: percentile(last, 95),
+        sampleCount: last.length,
+        p95Reliable: last.length >= P95_MIN_SAMPLES,
         last: last.slice(-16),
         errors: { ...v.errors },
+        resolutionHistory: v.resolutionHistory.slice(),
       };
     }
     return out;
+  }
+
+  /** Serialize the current state to a report JSON string. */
+  generateReportJSON(): string {
+    return serializeEngineReport(this.snapshot(), getBrowserCapabilities());
+  }
+
+  /** Trigger a manual export (download). Provider is injectable for testing. */
+  exportReport(provider: DownloadProvider = browserDownloadProvider): void {
+    provider.triggerDownload(this.generateReportJSON(), reportFilename());
   }
 }
 


### PR DESCRIPTION
Add a manual, privacy-preserving session-report export for the hybrid audio engine telemetry (issue #699).

- engineTelemetry: bounded per-subsystem resolutionHistory (cap 20), sampleCount
  + p95Reliable (threshold 128, consistent with the 256-sample ring cap), getBrowserCapabilities() (capability tier; no raw userAgent), pure serializeEngineReport(), injectable DownloadProvider, generateReportJSON() and exportReport().
- main.tsx: register window.__devtools.exportEngineReport at app bootstrap (not on HUD/component mount), gated on DEV or ?devtools.
- EngineHUD: Download Report + Copy JSON buttons wired via event delegation (survives the 500ms innerHTML re-render); clear inert while visible so the buttons are operable.
- Add unit tests for serializeEngineReport / capabilities / snapshot thresholds / history cap / injected export provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Engine HUD now includes interactive "Download Report" and "Copy JSON" buttons for quick telemetry export
  * Added dev tools API for engine report export via URL parameter or programmatic access
  * Enhanced telemetry system with browser capability detection and comprehensive reporting

* **Tests**
  * Added comprehensive test suite for telemetry utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->