### PR TITLE
🎨 Palette: Improve accessibility of Engine303Selector buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2024-05-31 - Interactive SVG Element Accessibility
 **Learning:** Data visualization components (like automation curves) often render interactive points as basic SVG `<circle>` or `<g>` tags relying solely on pointer events (`onMouseDown`). This completely excludes keyboard users from interacting with the data.
 **Action:** When rendering interactive nodes inside SVGs, always add `tabIndex={0}`, `role="button"`, an informative `aria-label`, visible focus styling (e.g., `outline-none focus:stroke-cyan-200 focus:stroke-[2px]`), and an explicit `onKeyDown` handler that replicates the pointer drag functionality (using Arrow keys) and deletion (using Delete/Backspace).
+## 2026-05-26 - Engine303Selector Keyboard Navigation and Screen Reader Labels
+**Learning:** The Engine303Selector's engine toggle buttons only relied on plain text labels without explicit screen reader context, and lacked focus-visible states for keyboard navigation, making them difficult to use for non-mouse users.
+**Action:** Added `focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2` to make keyboard focus visible, and explicit `aria-label`s ("Select Custom Open303 engine", "Select Authentic JC303 engine") to provide screen readers with better context on what the buttons do.

--- a/src/components/Engine303Selector.tsx
+++ b/src/components/Engine303Selector.tsx
@@ -71,7 +71,8 @@ export const Engine303Selector: React.FC<Engine303SelectorProps> = memo(({
                 onClick={() => onChange('open303')}
                 title="Custom Open303 synthesizer — uses the built-in open303_* WASM API in hyphon_native.wasm"
                 aria-pressed={!isJc303}
-                className={`px-3 py-1.5 text-[9px] font-bold rounded-md transition-all border ${
+                aria-label="Select Custom Open303 engine"
+                className={`px-3 py-1.5 text-[9px] font-bold rounded-md transition-all border focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 ${
                     !isJc303 ? activeStyle : inactiveStyle
                 }`}
             >
@@ -83,7 +84,8 @@ export const Engine303Selector: React.FC<Engine303SelectorProps> = memo(({
                 onClick={() => onChange('jc303')}
                 title="Authentic rosic::Open303 — per-voice JC303 engine from the jc303_wasm submodule (rosic_Open303). Enables the accurate TB-303 DSP introduced in the May 2026 per-voice engine update."
                 aria-pressed={isJc303}
-                className={`px-3 py-1.5 text-[9px] font-bold rounded-md transition-all border ${
+                aria-label="Select Authentic JC303 engine"
+                className={`px-3 py-1.5 text-[9px] font-bold rounded-md transition-all border focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 ${
                     isJc303 ? activeStyle : inactiveStyle
                 }`}
             >


### PR DESCRIPTION
🎨 Palette: Engine303Selector Keyboard Navigation & Screen Reader Improvements

**💡 What:** Added `focus-visible` outline styles and descriptive `aria-label`s to the toggle buttons in the `Engine303Selector` component.
**🎯 Why:** To make the engine selection accessible to keyboard users (who previously couldn't see focus state) and screen reader users (who previously just got the button text without semantic meaning).
**📸 Before/After:** Buttons now show a cyan focus ring when navigated via keyboard.
**♿ Accessibility:** Added `aria-label="Select Custom Open303 engine"` and `aria-label="Select Authentic JC303 engine"`, plus standard `focus-visible:ring-2 focus-visible:ring-cyan-500` classes.

---
*PR created automatically by Jules for task [8411126430672647722](https://jules.google.com/task/8411126430672647722) started by @ford442*