### PR TITLE
⚡ Bolt: Optimize AudioWorklet `loadBuffer` Allocation

### DIFF
--- a/src/engines/SingingVoice.ts
+++ b/src/engines/SingingVoice.ts
@@ -496,7 +496,7 @@ export class SingingVoice {
 
         this.workletNode.port.postMessage({
             type: 'loadBuffer',
-            data: { buffer: audio.buffer.slice(0) } // Copy buffer
+            data: { buffer: audio.buffer } // Let structured clone handle it natively
         });
     }
 


### PR DESCRIPTION
## ⚡ Bolt: Optimize AudioWorklet `loadBuffer` Allocation

**💡 What:** Removed manual ArrayBuffer slice copy (`audio.buffer.slice(0)`) in `SingingVoice.ts`'s `loadBuffer` method when sending data to the `RubberBandProcessor` AudioWorklet.

**🎯 Why:** `postMessage` natively uses the structured clone algorithm to handle data passing. By manually calling `slice(0)` on the main thread before passing it, we were creating an entirely redundant copy of the buffer in V8 JavaScript space, which adds unnecessary memory allocation overhead and triggers more frequent garbage collection pauses, especially when loading larger vocal or sample buffers.

**📊 Impact:** Reduces main thread allocation overhead by 1x the size of the loaded buffer on every `loadBuffer` call. This decreases latency during hot sample swaps or dynamic buffer loading.

**🔬 Measurement:** Verified that tests pass. Can be verified via DevTools Memory profiler to observe reduced ArrayBuffer allocation during sampler/TTS loads.

---
*PR created automatically by Jules for task [9129127506853539339](https://jules.google.com/task/9129127506853539339) started by @ford442*