### PR TITLE
⚡ Bolt: Optimize AudioWorklet GC via Direct Setters

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,7 @@
 ## 2024-05-28 - React Memo Comparator Deep Clone Pitfalls
 **Learning:** Using `JSON.stringify(prev.props) !== JSON.stringify(next.props)` inside a `React.memo` custom `areEqual` function for small arrays (like a `loadedBanks` boolean array) forces expensive memory allocation and serialization on *every single render cycle*. Even though it "works" to check array content, it adds unnecessary CPU overhead for components that evaluate frequently.
 **Action:** Replace `JSON.stringify` comparisons inside memo comparators with a simple array shallow equality check: `prev.arr.length !== next.arr.length || prev.arr.some((val, i) => val !== next.arr[i])`. This achieves the exact same value comparison with significantly lower CPU cost and no garbage collection pressure.
+
+## 2024-05-30 - AudioWorklet GC Thrashes via Object Allocation
+**Learning:** Calling `updateConfig({ nested: { value } })` inside an `AudioWorkletProcessor.process()` loop creates new objects every ~3ms (128 samples). This produces intense garbage collection pressure on the audio thread, risking audio dropouts and general CPU bloat, particularly when scaling polyphony or FX instances. Object spreading (`...`) compound this by churning through allocations.
+**Action:** Always implement direct setter methods (`setVibrato(rate, depth)`, `setEnvelope()`, etc.) that directly mutate the inner configuration state in high-frequency contexts like AudioWorklets, avoiding fresh objects and deep merges entirely on the hot path.

--- a/src/audio-worklets/expressive-voice-processor-worklet.ts
+++ b/src/audio-worklets/expressive-voice-processor-worklet.ts
@@ -112,12 +112,11 @@ class ExpressiveVoiceWorkletProcessor extends AudioWorkletProcessor {
         ? globalThis.currentTime
         : (typeof currentFrame === 'number' ? currentFrame / (globalThis.sampleRate || 44100) : 0);
     this.expressiveProcessor.setCurrentTime(now);
-    this.expressiveProcessor.updateConfig({
-      vibrato: { rate: vibratoRate, depth: vibratoDepth, enabled: vibratoDepth > 0 },
-      tremolo: { rate: tremoloRate, depth: tremoloDepth, enabled: tremoloDepth > 0 },
-      breath: { amount: breathAmount, filterCutoff: 2000, enabled: breathAmount > 0 },
-      envelope: { attack, decay, sustain, release },
-    });
+
+    this.expressiveProcessor.setVibrato(vibratoRate, vibratoDepth, vibratoDepth > 0);
+    this.expressiveProcessor.setTremolo(tremoloRate, tremoloDepth, tremoloDepth > 0);
+    this.expressiveProcessor.setBreath(breathAmount, 2000, breathAmount > 0);
+    this.expressiveProcessor.setEnvelope(attack, decay, sustain, release);
 
     this.expressiveProcessor.process(output, output);
     return true;

--- a/src/engines/rubberband/ExpressiveVoiceProcessor.ts
+++ b/src/engines/rubberband/ExpressiveVoiceProcessor.ts
@@ -391,27 +391,53 @@ export class ExpressiveVoiceProcessor {
     
     /**
      * Update configuration parameters dynamically.
+     * Note: Prefer direct setters for high-frequency updates to avoid object allocation.
      */
     updateConfig(newConfig: Partial<ExpressiveConfig>): void {
-        // Deep merge logic simplified for specific nested objects
         if (newConfig.vibrato) {
-            this.config.vibrato = { ...this.config.vibrato, ...newConfig.vibrato };
+            Object.assign(this.config.vibrato, newConfig.vibrato);
         }
         if (newConfig.tremolo) {
-            this.config.tremolo = { ...this.config.tremolo, ...newConfig.tremolo };
+            Object.assign(this.config.tremolo, newConfig.tremolo);
         }
         if (newConfig.breath) {
-            this.config.breath = { ...this.config.breath, ...newConfig.breath };
+            Object.assign(this.config.breath, newConfig.breath);
         }
         if (newConfig.envelope) {
-            this.config.envelope = { ...this.config.envelope, ...newConfig.envelope };
+            Object.assign(this.config.envelope, newConfig.envelope);
         }
         if (newConfig.gate) {
-            this.config.gate = { ...this.config.gate, ...newConfig.gate };
+            Object.assign(this.config.gate, newConfig.gate);
         }
-        if (newConfig.sampleRate) {
+        if (newConfig.sampleRate !== undefined) {
             this.config.sampleRate = newConfig.sampleRate;
         }
+    }
+
+    // Direct setters for AudioWorklet hot-paths to prevent GC thrash from object allocation
+    setVibrato(rate: number, depth: number, enabled: boolean): void {
+        this.config.vibrato.rate = rate;
+        this.config.vibrato.depth = depth;
+        this.config.vibrato.enabled = enabled;
+    }
+
+    setTremolo(rate: number, depth: number, enabled: boolean): void {
+        this.config.tremolo.rate = rate;
+        this.config.tremolo.depth = depth;
+        this.config.tremolo.enabled = enabled;
+    }
+
+    setBreath(amount: number, filterCutoff: number, enabled: boolean): void {
+        this.config.breath.amount = amount;
+        this.config.breath.filterCutoff = filterCutoff;
+        this.config.breath.enabled = enabled;
+    }
+
+    setEnvelope(attack: number, decay: number, sustain: number, release: number): void {
+        this.config.envelope.attack = attack;
+        this.config.envelope.decay = decay;
+        this.config.envelope.sustain = sustain;
+        this.config.envelope.release = release;
     }
     
     /**


### PR DESCRIPTION
The `ExpressiveVoiceProcessor`'s `updateConfig` method was allocating and spreading multiple new configuration objects (`vibrato`, `tremolo`, `breath`, `envelope`) on every single block processed by the audio worklet (~every 3ms). This created significant garbage collection (GC) pressure directly on the audio thread, risking dropouts when pushing polyphony or combining effects.

This PR optimizes the processor by:
1. Adding direct setter methods (`setVibrato`, `setTremolo`, etc.) that mutate the inner `config` state in-place.
2. Updating `expressive-voice-processor-worklet.ts` to utilize these setters rather than passing freshly allocated objects via `updateConfig`.
3. Updating `updateConfig` to use `Object.assign` to prevent allocations for backward compatibility.

---
*PR created automatically by Jules for task [9935361419153838192](https://jules.google.com/task/9935361419153838192) started by @ford442*