### PR TITLE
🎨 Palette: Add proper ARIA attributes to AI Song Import progress bar

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,6 @@
 ## 2026-05-26 - Engine303Selector Keyboard Navigation and Screen Reader Labels
 **Learning:** The Engine303Selector's engine toggle buttons only relied on plain text labels without explicit screen reader context, and lacked focus-visible states for keyboard navigation, making them difficult to use for non-mouse users.
 **Action:** Added `focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2` to make keyboard focus visible, and explicit `aria-label`s ("Select Custom Open303 engine", "Select Authentic JC303 engine") to provide screen readers with better context on what the buttons do.
+## 2026-06-06 - Add Progressbar ARIA Attributes
+**Learning:** Custom UI components that act as progress bars need explicit 'progressbar' role, 'aria-valuenow', 'aria-valuemin', and 'aria-valuemax' attributes for screen reader support. 'aria-label' or 'aria-labelledby' should also be included.
+**Action:** Always verify custom progress indicators implement standard WAI-ARIA progressbar patterns.

--- a/src/components/AISongImportOverlay.tsx
+++ b/src/components/AISongImportOverlay.tsx
@@ -59,7 +59,14 @@ export const AISongImportOverlay = memo(function AISongImportOverlay({
                 </div>
                 
                 {/* Progress Bar */}
-                <div className="relative h-2 bg-gray-800 rounded-full overflow-hidden">
+                <div
+                    className="relative h-2 bg-gray-800 rounded-full overflow-hidden"
+                    role="progressbar"
+                    aria-valuenow={Math.round(aiImportProgress)}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-label="AI Song Import Progress"
+                >
                     <div 
                         className={`absolute top-0 left-0 h-full rounded-full transition-all duration-300 ${
                             aiImportStage === 'error' ? 'bg-red-500' :


### PR DESCRIPTION
* 💡 What: Added `role="progressbar"`, `aria-valuenow`, `aria-valuemin`, `aria-valuemax`, and `aria-label` to the custom progress bar div in `AISongImportOverlay.tsx`.
* 🎯 Why: Custom UI elements that function as progress indicators require explicit ARIA attributes so that assistive technologies (like screen readers) can announce their state and progress value.
* ♿ Accessibility: Significant improvement for non-visual users to track AI song import stages correctly.

---
*PR created automatically by Jules for task [17970660560420686484](https://jules.google.com/task/17970660560420686484) started by @ford442*