### PR TITLE
🎨 Palette: Add accessible focus-visible rings to custom modal close buttons

### DIFF
--- a/src/components/AISongModal.tsx
+++ b/src/components/AISongModal.tsx
@@ -763,7 +763,7 @@ export const AISongModal = React.memo(function AISongModal({ isOpen, onClose, on
           <Tooltip text="Close (Esc)" position="bottom">
             <button 
               onClick={handleClose}
-              className="w-8 h-8 rounded-lg bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-all"
+              className="w-8 h-8 rounded-lg bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1115]"
               aria-label="Close modal"
               title="Close modal"
             ><span aria-hidden="true">✕</span></button>
@@ -785,14 +785,14 @@ export const AISongModal = React.memo(function AISongModal({ isOpen, onClose, on
             <div className="flex gap-2">
               <button
                 onClick={() => setShowCloseConfirm(false)}
-                className="px-2 py-1 text-xs text-gray-400 hover:text-white transition-colors"
+                className="px-2 py-1 text-xs text-gray-400 hover:text-white hover:bg-gray-800 rounded transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1115]"
                 aria-label="Cancel closing modal"
               >
                 Cancel
               </button>
               <button
                 onClick={confirmClose}
-                className="px-2 py-1 text-xs bg-red-600 hover:bg-red-500 text-white rounded transition-colors"
+                className="px-2 py-1 text-xs bg-red-600 hover:bg-red-500 text-white rounded transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1115]"
                 aria-label="Confirm close modal"
               >
                 Close

--- a/src/components/RbsImportModal.tsx
+++ b/src/components/RbsImportModal.tsx
@@ -420,7 +420,7 @@ export const RbsImportModal = React.memo(function RbsImportModal({ isOpen, onClo
           </div>
           <button
             onClick={onClose}
-            className="w-8 h-8 rounded-lg bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-all"
+            className="w-8 h-8 rounded-lg bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1115]"
             title="Close (Esc)"
             aria-label="Close modal"
           ><span aria-hidden="true">✕</span></button>
@@ -965,7 +965,7 @@ export const RbsImportModal = React.memo(function RbsImportModal({ isOpen, onClo
             {importReport ? (
               <button
                 onClick={onClose}
-                className="px-4 py-2 bg-emerald-700 hover:bg-emerald-600 text-white text-xs font-medium rounded transition-all"
+                className="px-4 py-2 bg-emerald-700 hover:bg-emerald-600 text-white text-xs font-medium rounded transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1115]"
                 aria-label="Close Import Modal"
               >
                 ✓ Done
@@ -975,7 +975,7 @@ export const RbsImportModal = React.memo(function RbsImportModal({ isOpen, onClo
                 <button
                   onClick={onClose}
                   disabled={isImporting}
-                  className="px-4 py-2 bg-gray-800 hover:bg-gray-700 text-gray-300 text-xs font-medium rounded transition-all disabled:opacity-50"
+                  className="px-4 py-2 bg-gray-800 hover:bg-gray-700 text-gray-300 text-xs font-medium rounded transition-all disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1115]"
                   aria-label="Cancel Import"
                 >
                   Cancel


### PR DESCRIPTION
Added `focus-visible:ring-2` and `focus-visible:ring-offset-2` with appropriate semantic colors to the close, cancel, and confirm buttons in `AISongModal.tsx` and `RbsImportModal.tsx`. This ensures proper keyboard accessibility by fixing an issue where modals relying on custom buttons or text failed to show focus rings. Updated the `.Jules/palette.md` journal to document this learning. Verified manually in dev mode. Playwright visual verification skipped due to timing flakiness in headless mode with modal initialization.

---
*PR created automatically by Jules for task [9705459546266920425](https://jules.google.com/task/9705459546266920425) started by @ford442*