### PR TITLE
weekly_plan: 2026-06-08 (Fix First — audio engine fallback #720)

### DIFF
--- a/weekly_plan.md
+++ b/weekly_plan.md
@@ -1,27 +1,29 @@
 # web_sequencer — Weekly Plan
 
 ## Today's focus
-**2026-06-01 (Mon) — User Idea mode.** Finish the holographic-knob drift-kill: last week's *plumbing* landed (HardwareModule routes through `KnobGPUContext` singleton, per-knob canvas, ResizeObserver, 2D palette contract — all on `main`, build passing), but the idea's core goal is still open. The two render paths still hardcode **independent palettes** and provably drift:
-- WGSL (`KnobGPUContext.ts`): base `vec3f(0,0.9,1.0)`, arc `mix(vec3(0,0.6,0.5) → vec3(0.2,1.0,0.8))`, ×1.5 bloom, transparent bg.
-- 2D (`HardwareModule.renderWith2D`): ring `#00e5ff`, arc `#00e5ff → #00897b`, solid `#0d0f13` bg, no bloom — comment admits it "approximates" the WGSL look.
+**2026-06-08 (Mon) — Fix First mode.** Diagnose and repair the hybrid audio engine fallback chain (a core active focus area). Issue **#720** (filed by Noah 2026-06-05) reports that **6 of 8 oscillator engines silently fall back to the default JS voice**: Open303, JC303, Rust, Prophecy, Pyodide, and WebGPU all fail to initialize. Only JS (Native) and PCM 303 work. This is a cracked foundation — building new features on top of a degraded engine stack is wasted effort, so the fix outranks any new idea.
 
-**Task:** extract a single `knobMaterial` source-of-truth module (palette stops, ring/arc geometry, 270° sweep angles, bloom factor, background) consumed by **both** the WGSL uniform packing in `KnobGPUContext` *and* `renderWith2D`, so the two paths derive from identical constants and cannot drift. Verify `MagicKnob` (already singleton-ported) inherits the same contract.
+**Task:** Work through #720 engine-by-engine. For each failing engine determine the root cause (WASM load/instantiation failure, AudioWorklet registration error, missing/renamed binary asset, Pyodide bootstrap failure, WebGPU device/adapter unavailability) using the existing `engineTelemetry` + EngineHUD instrumentation. Make each fallback **loud** (console warn/error with the real reason) instead of silent, then fix the initialization path. Expand engine-init test coverage. Last week's knob drift-kill landed clean (see Done) — it is NOT the blocker.
 
 ## Ideas
 - [done — 2026-04-27] **Verify bug-report.md staleness** — confirmed stale: `useAudioEngine.ts` is 938 lines; the try/catch at line 1393 no longer exists. `bug-report.md` can be deleted.
 - [done — 2026-05-25] **Holographic knob GPU context unification** — `KnobGPUContext.ts` singleton fully implemented (shared `GPURenderPipeline`, single batched RAF, per-knob `uniformBuffer`+`bindGroup`, `register`/`unregister` API); `MagicKnob.tsx` fully ported. N-device anti-pattern retired.
-- [in progress — 2026-06-01] Holographic knob WGSL render pass unification — single compute-driven render path so every knob shares lighting/material, kill drift between the 2D fallback and the WebGPU canvas path. (multi-day; depends on perf audit findings)
-  - Plumbing/singleton routing landed 2026-05-25 (see Done). Remaining = shared `knobMaterial` constants module so WGSL + 2D fallback can't visually drift. This is today's focus.
+- [done — 2026-06-08] Holographic knob WGSL render pass unification — single shared-material render path; drift between 2D fallback and WebGPU canvas killed via `knobMaterial.ts` source-of-truth module. Both paths now derive palette/geometry/bloom/sweep from `KNOB_MATERIAL` (KnobGPUContext bakes it into WGSL via string interpolation; HardwareModule.renderWith2D reads it directly). `MagicKnob` inherits the contract through `KnobGPUContext.register()`. Build + all tests pass.
+
+<!-- Ideas list is currently exhausted — all items Done. Add new ideas here during the week. -->
+- [ ]
 
 ## Backlog
-- [ ] **Duplicate Copilot PRs #685 & #686** — both "[WIP] Map Rebirth .rbs data to Hyphon internal models" (open drafts, May 30). Close one to avoid divergence; #685 has the better task checklist.
-- [ ] **PR #693** "feat(tts): add consonantEmphasis control" — open Jules draft (May 31), needs review/merge or feedback.
-- [ ] **GitHub reports 0 OPEN issues** (API, 2026-06-01) — prior backlog refs #330 (live-keyboard CSS grid), #465 (DOCS.md index), #672 (RBS test+docs) appear closed/resolved or were never filed as issues. VERIFY before re-actioning; #672 is cited as a "parser" issue by PRs #685/#686 so likely closed-on-merge.
+- [ ] **Issue #720 — Oscillator fallback audit (CRITICAL, today's focus).** 6/8 engines (Open303, JC303, Rust, Prophecy, Pyodide, WebGPU) silently fall back to JS voice. See Today's focus.
+- [ ] **Overlapping Spectral/Time-Stretch UI PRs #717 & #724** — both add `timeStretchEnvDepth` / `spectralPan*` controls to `NoteSelector.tsx` (#717 also touches SamplerPanel). #717 (2026-06-04, non-draft) vs #724 (2026-06-06, draft). Divergence risk — pick one, close the other. #717 is broader (global + per-step); #724 is per-step group only.
+- [ ] **PR #693** "feat(tts): add consonantEmphasis control" — open Jules draft (May 31, updated 2026-06-06), still needs review/merge or feedback.
+- [ ] **Old #685/#686 (.rbs mapping dupes)** — no longer in open-PR list as of 2026-06-08; treat as closed/merged. Removed from active watch.
 - [ ] **Repo hygiene** — 30+ `*.md` files + dozens of one-off `fix*.py` / `patch*.py` / `update_*.py` scripts at repo root. Candidate: DOCS.md zero-move root index + archive scripts into `tools/`.
 - [ ] Rubberband phoneme-aware time-stretch + `ExpressiveVoiceProcessor.ts` pending per `RUBBERBAND_ENHANCEMENT_PLAN.md`.
 - [ ] RBS import test+docs polish (was issue #672) — expand Vitest coverage for parser/importer/scheduler + document automation architecture. Partly in flight via Copilot PRs #685/#686.
 
 ## Done
+- 2026-06-08 — **Holographic knob drift-kill COMPLETE.** `src/components/knobMaterial.ts` created as single source of truth (`KNOB_MATERIAL`: palette stops, ring/arc/needle geometry as body-radius fractions, −3π/4 sweep start, 3π/2 total, ×1.5 bloom + `rgbToHex`/`rgbToWgsl`/`wgslAngleToCanvas` helpers). `KnobGPUContext.ts` bakes it into the WGSL shader via template-string interpolation (uniform buffer stays 32 bytes, no pipeline recreation); `HardwareModule.renderWith2D()` reads every draw param from it and the start-angle bug (`-0.75π` → correct WGSL→canvas conversion) was fixed so 2D and WebGPU sweeps now match exactly. `MagicKnob` inherits via `KnobGPUContext.register()`. No stray color literals remain in either render path. `tsc -b` + `vite build` + `npm test` (925 passing, 1 skipped) all green. (kimi-cli, see `.swarm-state.md` Iteration 3.)
 - 2026-06-01 — Holographic knob render-pass PLUMBING landed on `main`: `HardwareModule.tsx` routes all knobs through `KnobGPUContext` singleton (per-knob `<canvas>`, `register`/`unregister`, ResizeObserver sizing, ~320 lines of per-component WebGPU init removed), `renderWith2D` extracted as standalone fn with a contracted palette. Build passes. NOTE: visual-drift kill (shared material contract) is NOT done — carried into today's focus.
 - 2026-06-01 — Backlog reconcile: PRs #506 & #507 confirmed CLOSED-unmerged (2026-05-15), removed from backlog. GitHub reports 0 open issues — #330/#465/#672 flagged for verification.
 - 2026-05-25 — Holographic knob GPU context unification: `KnobGPUContext.ts` singleton + `MagicKnob.tsx` fully ported (PR #617 context: WASM memory fix also landed).
@@ -56,8 +58,9 @@
 - 2026-04-12 — AdvancedNoteSelector + ScaleSelector (PR #443).
 
 ## Last run
-Date: 2026-06-01
-Mode: User Idea
-Focus: Finish holographic-knob drift-kill — extract a shared `knobMaterial` constants module (palette/geometry/bloom/bg) consumed by BOTH the WGSL uniform packing in KnobGPUContext AND HardwareModule.renderWith2D, so the WebGPU and 2D-fallback paths derive from identical constants and cannot drift.
+Date: 2026-06-08
+Mode: Fix First
+Focus: Diagnose + repair hybrid audio engine fallback chain (issue #720 — 6/8 oscillator engines silently fall back to JS voice). Make fallbacks loud, fix each init path, expand engine-init test coverage.
 Outcome: (to be filled at end-of-day)
-Prior-run note: 2026-05-25 plumbing/singleton routing landed on main (build passing), but the visual-drift goal was left open — verified 2026-06-01 by diffing WGSL vs renderWith2D palettes (independently hardcoded). Hence continued, not new.
+Prior-run note: 2026-06-01 knob drift-kill landed clean and verified (knobMaterial.ts on main, build + 925 tests green — see Done). That foundation is solid; today pivots to the engine stack because #720 (filed 2026-06-05) reports the audio fallback chain is broken — that outranks new feature work.
+Decoupled track (Copilot/Jules): issue B = Playwright visual-regression harness for the holographic knob to lock in the just-landed drift-kill. Touches test infra + knob testids only — no overlap with kimi-cli's audio-engine files.


### PR DESCRIPTION
Weekly planner run for 2026-06-08.

**Mode: Fix First.** Last week's holographic-knob drift-kill landed clean (`knobMaterial.ts` on main, build + 925 tests green — archived to Done). Today pivots to the hybrid audio engine: issue #720 reports 6/8 oscillator engines (Open303, JC303, Rust, Prophecy, Pyodide, WebGPU) silently fall back to the JS voice. A cracked foundation outranks new feature work.

Changes in this PR (plan file only):
- Today's focus → #720 engine fallback audit
- Knob WGSL render-pass idea marked done; Ideas list now exhausted
- Backlog: added #720 (critical), flagged overlapping Spectral/Time-Stretch PRs #717 & #724, noted #693 still open, retired #685/#686
- Done: archived knob drift-kill completion
- Last run updated

No source changes — dispatch prompts (kimi-cli, Copilot issue, chat models, Claude Code, Jules) delivered in chat.

https://claude.ai/code/session_011JAyJQSNb9zq6NSNGBsZbT

---
_Generated by [Claude Code](https://claude.ai/code/session_011JAyJQSNb9zq6NSNGBsZbT)_