### PR TITLE
🎨 Palette: Add keyboard navigation and focus states to AutomationLaneList

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,6 @@
 ## 2026-06-07 - Consolidate disabled UX states in reusable components
 **Learning:** Hardcoding 'disabled:cursor-not-allowed' inline across the application causes inconsistency and code duplication.
 **Action:** Always place generic interactive visual affordances (like disabled opacity and cursor states) directly into core reusable components like LoadingButton.
+## 2026-06-08 - Keyboard Navigation in Custom List Items
+**Learning:** Custom interactive rows (like `LaneRow` in the Automation lane list) that rely solely on `div` wrappers and `onClick` are unreachable via keyboard. Furthermore, native focus styling on `button` and `select` elements often clashes or is invisible against custom dark backgrounds.
+**Action:** Always add `tabIndex={0}` and map `onKeyDown` ('Enter', ' ') to custom row items. Explicitly apply `focus-visible:ring-2 focus-visible:ring-[color]` with matching `ring-offset` colors across all interactive elements (buttons, selects, rows) in custom lists to ensure unified and visible keyboard navigation.

--- a/src/components/automation/AutomationLaneList.tsx
+++ b/src/components/automation/AutomationLaneList.tsx
@@ -51,15 +51,22 @@ const LaneRow = memo(({
     <div
       role="listitem"
       aria-selected={isSelected}
-      className={`flex items-center gap-2 px-2 py-1 rounded cursor-pointer text-xs ${
+      tabIndex={0}
+      className={`flex items-center gap-2 px-2 py-1 rounded cursor-pointer text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a1d24] ${
         isSelected ? 'bg-cyan-900/40 border border-cyan-500/50' : 'bg-[#1a1d24] hover:bg-[#22262f]'
       }`}
       onClick={() => onSelect(lane.id)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSelect(lane.id);
+        }
+      }}
     >
       {/* Enable/Disable toggle */}
       <button
         aria-label={`${lane.enabled ? 'Disable' : 'Enable'} lane ${lane.name}`}
-        className={`w-4 h-4 rounded-sm border flex-shrink-0 ${
+        className={`w-4 h-4 rounded-sm border flex-shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a1d24] ${
           lane.enabled ? 'bg-cyan-500 border-cyan-400' : 'bg-transparent border-gray-500'
         }`}
         aria-pressed={lane.enabled}
@@ -84,7 +91,7 @@ const LaneRow = memo(({
       {/* Interpolation selector */}
       <select
         aria-label={`Interpolation mode for ${lane.name}`}
-        className="bg-[#2a2d36] text-gray-300 text-[10px] rounded px-1 py-0.5 border border-gray-600"
+        className="bg-[#2a2d36] text-gray-300 text-[10px] rounded px-1 py-0.5 border border-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a1d24]"
         value={lane.interpolation}
         onClick={(e) => e.stopPropagation()}
         onChange={(e) => onInterpolationChange(lane.id, e.target.value as AutomationInterpolation)}
@@ -107,7 +114,7 @@ const LaneRow = memo(({
       {/* Remove button */}
       <button
         aria-label={`Remove lane ${lane.name}`}
-        className="text-gray-500 hover:text-red-400 flex-shrink-0"
+        className="text-gray-500 hover:text-red-400 flex-shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a1d24] rounded"
         onClick={(e) => { e.stopPropagation(); onRemove(lane.id); }}
       >
         ✕

--- a/tests/knob-canvas-smoke.spec.ts
+++ b/tests/knob-canvas-smoke.spec.ts
@@ -27,7 +27,7 @@ test('hardware knob renders on forced Canvas2D fallback', async ({ page }) => {
     await expect
         .poll(
             async () =>
-                knobCanvas.evaluate((canvas, { backgroundRgb, deltaTolerance }) => {
+                knobCanvas.evaluate((canvas, { backgroundRgb, deltaTolerance, PIXEL_SAMPLE_GRID_DIVISOR }) => {
                     const ctx = canvas.getContext('2d');
                     if (!ctx) return 0;
                     let nonBgCount = 0;
@@ -46,7 +46,7 @@ test('hardware knob renders on forced Canvas2D fallback', async ({ page }) => {
                         }
                     }
                     return nonBgCount;
-                }, { backgroundRgb: KNOB_BACKGROUND_RGB, deltaTolerance: NON_BACKGROUND_DELTA_TOLERANCE }),
+                }, { backgroundRgb: KNOB_BACKGROUND_RGB, deltaTolerance: NON_BACKGROUND_DELTA_TOLERANCE, PIXEL_SAMPLE_GRID_DIVISOR }),
             { timeout: 10000 }
         )
         .toBeGreaterThan(0);


### PR DESCRIPTION
💡 What: Added keyboard navigation support (Enter/Space on rows) and visible focus rings to all interactive elements in the `AutomationLaneList` component.
🎯 Why: The automation lane list rows were inaccessible via keyboard since they lacked `tabIndex` and `onKeyDown` handlers. Furthermore, internal controls (enable, delete, interpolation mode) lacked visible focus states on the custom dark background.
📸 Before/After: See the Playwright verification screenshot showing the new focus states.
♿ Accessibility: Ensures full keyboard navigability and WCAG-compliant visible focus for all controls in the lane list.

---
*PR created automatically by Jules for task [6610138103094854346](https://jules.google.com/task/6610138103094854346) started by @ford442*