### PR TITLE
docs: add Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -549,6 +549,55 @@ interface Note {
 
 ---
 
+## Cursor Cloud specific instructions
+
+### One-time toolchain setup (not in the VM update script)
+
+WASM artifacts are gitignored; a fresh checkout needs a one-time native toolchain install before the first dev session:
+
+1. **Emscripten 3.1.51** (matches CI): clone to `$HOME/emsdk`, run `./emsdk install 3.1.51 && ./emsdk activate 3.1.51`, then `source "$HOME/emsdk/emsdk_env.sh"` in each shell that builds WASM.
+2. **Rust wasm32 target**: `rustup target add wasm32-unknown-unknown` (wasm-pack ships via `pnpm`; use `pnpm exec wasm-pack`).
+3. **Git submodule**: `git submodule update --init --recursive` (required for `jc303_wasm`).
+
+### First WASM build per workspace
+
+After `pnpm install`, with Emscripten sourced:
+
+```bash
+pnpm run build:wasm    # AssemblyScript + Rust + JC-303 (~1–2 min)
+pnpm run build:emcc    # hyphon_native.js + Rubberband/Open303 (~30s)
+```
+
+Re-run only after changing `assembly/`, `rust-audio/`, `emscripten/`, or `jc303_wasm/` sources.
+
+### Running the main DAW locally
+
+| Task | Command |
+|------|---------|
+| Dev server (fast restart) | `pnpm exec vite --host 0.0.0.0 --port 5173` |
+| Dev server (rebuilds WASM every start) | `pnpm run dev` |
+| Unit tests | `CI=true pnpm exec vitest run --pool forks` |
+| Lint | `pnpm run lint` |
+| Production build | `pnpm run build` |
+
+Only the **Vite dev server on port 5173** is required for interactive development. The FastAPI cloud API (`app.py`, port 7860) and remote storage are optional.
+
+### Hello-world smoke test
+
+1. Open http://localhost:5173
+2. Click **INITIALIZE SYSTEM** (user gesture required for Web Audio)
+3. Program a kick on step 1 in the sequencer grid
+4. Click **▶ PLAY** — playhead should advance and the kick should trigger
+
+### Gotchas
+
+- **`pnpm run dev` is slow**: it always runs `build:wasm` and `build:emcc` before Vite. Prefer `pnpm exec vite` after WASM is already built.
+- **COOP/COEP headers**: Vite sets these automatically; required for threaded WASM (`SharedArrayBuffer`).
+- **pnpm ignored build scripts**: if `wasm-pack` is missing, use `pnpm exec wasm-pack` (bundled in devDependencies).
+- **Rust audio import warning**: a console warning about `/rust-wasm/rust_audio.js` may appear in dev; core sequencer/audio still works. Use `public/rust-wasm/` paths if debugging the Rust engine.
+
+---
+
 ## Resources
 
 - **Supertonic TTS**: https://github.com/supertone-inc/supertonic


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a **Cursor Cloud specific instructions** section to `AGENTS.md` documenting:

- One-time Emscripten/Rust/submodule setup for WASM builds
- Commands for dev server, tests, and lint
- Hello-world smoke test flow for the DAW
- Gotchas (slow `pnpm run dev`, COOP/COEP, wasm-pack)

This supports Cloud Agent VM environment setup; no application code changes.

## Walkthrough

[hyphon-daw-hello-world-demo.mp4](https://cursor.com/agents/bc-42d4ac9f-7e8a-4f76-aa5c-bcbe9fa60bbc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhyphon-daw-hello-world-demo.mp4)

Environment verified: initialize audio → program kick on step 1 → start playback.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42d4ac9f-7e8a-4f76-aa5c-bcbe9fa60bbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42d4ac9f-7e8a-4f76-aa5c-bcbe9fa60bbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

