### PR TITLE
🎨 Palette: Add tabIndex={-1} to modals and fix useAppState syntax

### DIFF
--- a/src/components/AISongModal.tsx
+++ b/src/components/AISongModal.tsx
@@ -746,6 +746,7 @@ export const AISongModal = React.memo(function AISongModal({ isOpen, onClose, on
         role="dialog"
         aria-modal="true"
         aria-labelledby="ai-song-modal-title" aria-describedby="ai-song-modal-desc"
+        tabIndex={-1}
         className="relative z-10 bg-[#0f1115] border border-emerald-500/30 rounded-xl shadow-[0_0_60px_rgba(16,185,129,0.2)] w-full max-w-3xl max-h-[95vh] sm:max-h-[90vh] flex flex-col animate-in fade-in zoom-in-95 duration-200"
         onDragEnter={handleDragEnter}
         onDragLeave={handleDragLeave}

--- a/src/components/RbsImportModal.tsx
+++ b/src/components/RbsImportModal.tsx
@@ -411,7 +411,7 @@ export const RbsImportModal = React.memo(function RbsImportModal({ isOpen, onClo
         onClick={onClose}
         aria-hidden="true"
       />
-      <div role="dialog" aria-modal="true" aria-labelledby="rbs-import-title" aria-describedby="rbs-import-desc" className="relative z-10 bg-[#0f1115] border border-amber-500/30 rounded-xl shadow-[0_0_60px_rgba(245,158,11,0.2)] w-full max-w-4xl max-h-[90vh] flex flex-col">
+      <div role="dialog" aria-modal="true" aria-labelledby="rbs-import-title" aria-describedby="rbs-import-desc" tabIndex={-1} className="relative z-10 bg-[#0f1115] border border-amber-500/30 rounded-xl shadow-[0_0_60px_rgba(245,158,11,0.2)] w-full max-w-4xl max-h-[90vh] flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-gray-800">
           <div className="flex items-center gap-3">

--- a/src/hooks/useAppState.tsx
+++ b/src/hooks/useAppState.tsx
@@ -1306,42 +1306,6 @@ const handleNotePropertyChange = useCallback((
 
     updateStorageForTrack(trackKey, changedSequence);
     setPattern(newPattern);
-}, [contextMenu, updateStorageForTrack, activeSamplerBankRef]);
-        return newPattern;
-    });
-}, [contextMenu, updateStorageForTrack]);
-
-const prev = patternRef.current;
-
-    const updater = (stepData: any) => {
-        if (!stepData) return stepData;
-        const newStep = { ...stepData };
-
-        if (key === 'reverse' || key === 'formantEnvSync' || key === 'formantLfoSync' || key === 'freezeLfoSync') {
-            if (typeof value === 'boolean') newStep[key] = value;
-        } else if (key === 'reverbType') {
-            if (typeof value === 'string') newStep[key] = value;
-        } else {
-            // numeric params (including new formantEnvAttack/Decay/Amount etc.)
-            if (typeof value === 'number') newStep[key] = value;
-        }
-
-        return newStep;
-    };
-
-    let newPattern;
-    let changedSequence;
-    if (trackKey === 'sampler') {
-        const bankIdx = activeSamplerBankRef.current;
-        newPattern = updateSamplerStep(prev, bankIdx, stepIndex, updater);
-        changedSequence = newPattern.sampler;
-    } else {
-        newPattern = updateTrackStep(prev, trackKey, stepIndex, updater);
-        changedSequence = newPattern[trackKey];
-    }
-
-    updateStorageForTrack(trackKey, changedSequence);
-    setPattern(newPattern);
 }, [contextMenu, updateStorageForTrack, activeSamplerBankRef]); // add activeSamplerBankRef if not already in deps
 
     const handleClearPattern = useCallback(() => {


### PR DESCRIPTION
- Added `tabIndex={-1}` to the `role="dialog"` modal containers in `AISongModal.tsx` and `RbsImportModal.tsx` to enable programmatic focus trapping and accessibility.
- Fixed a malformed and duplicate syntax issue (updater block) in `src/hooks/useAppState.tsx` left over from a previous agent commit.

---
*PR created automatically by Jules for task [9378186427180576013](https://jules.google.com/task/9378186427180576013) started by @ford442*