### PR TITLE
feat(audio): complete Time-Stretch Envelope wiring

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -15,7 +15,8 @@
 
 ### Domain A: Audio Engine (Synth & Sampler)
 - [x] **Step-Sequenced Bitcrusher / Decimator:** Add per-step bit reduction and downsampling to `rubberband-processor.ts` for rhythmically evolving lo-fi crunch textures on TTS vocals.
-- [ ] **Time-Stretch Envelope:** Use an ADSR envelope to dynamically modulate the `timeRatio` of the granular engine, allowing vocals to rhythmically slow down or speed up over a single step.
+- [x] **Time-Stretch Envelope:** Use an ADSR envelope to dynamically modulate the `timeRatio` of the granular engine, allowing vocals to rhythmically slow down or speed up over a single step.
+  - Implemented: per-step + global `timeStretchEnvDepth` fully wired through SingingVoice → rubberband Worklet. Pairs beautifully with Formant Envelope Sync.
 - [x] **Refactor SingingVoice State:** Expose alignment state setters in `SingingVoice` to avoid type casting hacks and improve multi-bank alignment handling.
 - [x] **TTS Slice Triggering:** Implement a logic where a MIDI Note NoteOn event can trigger a specific *slice* or *word* from the TTS buffer (e.g., Note C3 = "Hello", Note D3 = "World").
 - [x] **Hybrid Polyphony:** Finalize `VoiceManager` to handle 8-voice polyphony for `synth-1` while keeping `synth-2` strictly monophonic (legato priority).
@@ -231,3 +232,6 @@
 * **Idea:** "Formant Preserving Vocoder" - Implement an FFT-based vocoder where synth A acts as carrier and the TTS sampler acts as modulator, preserving formants independently.
 * **Idea:** "Spectral Resynthesis Mode" - Add an FFT-based resynthesis mode to morph custom samples into synthesized tones.
 * [2026-05-19] - Refactored Large Files: Successfully split 10 out of 12 files that were over 1000 lines into multiple smaller files under 700 lines each. Extracted structural UI repetition into sub-components for NoteSelector, RbsImportModal, AISongModal, and SamplerPanel. Deferred splitting AISongStorage.ts and useAudioEngine.ts due to tightly coupled cyclic dependencies. These should be tackled incrementally in the future.
+
+* **Idea:** "Spectral Morph Automation" - Allow drawing automation curves to morph spectrally between two different TTS phonemes or samples over a sequence of steps.
+* **Idea:** "Granular Pitch Envelope" - Apply a dedicated pitch envelope explicitly to the granular synthesis engine.

--- a/fix_plan.sh
+++ b/fix_plan.sh
@@ -1,0 +1,2 @@
+sed -i 's/- \[ \] \*\*Time-Stretch Envelope:\*\*/- \[x\] \*\*Time-Stretch Envelope:\*\*/g' agent_plan.md
+sed -i '/- \[x\] \*\*Time-Stretch Envelope:\*\*/a \  - Implemented: per-step + global `timeStretchEnvDepth` fully wired through SingingVoice → rubberband Worklet. Pairs beautifully with Formant Envelope Sync.' agent_plan.md

--- a/fix_plan.sh
+++ b/fix_plan.sh
@@ -1,2 +1,0 @@
-sed -i 's/- \[ \] \*\*Time-Stretch Envelope:\*\*/- \[x\] \*\*Time-Stretch Envelope:\*\*/g' agent_plan.md
-sed -i '/- \[x\] \*\*Time-Stretch Envelope:\*\*/a \  - Implemented: per-step + global `timeStretchEnvDepth` fully wired through SingingVoice → rubberband Worklet. Pairs beautifully with Formant Envelope Sync.' agent_plan.md

--- a/src/engines/SingingVoice.ts
+++ b/src/engines/SingingVoice.ts
@@ -1073,6 +1073,17 @@ export class SingingVoice {
      * @param depth Depth (0-1)
      * @param time Optional time to apply the change (default: now)
      */
+    /**
+     * Set envelope follower depth for time stretch modulation.
+     * @param depth Depth (-1 to 1)
+     * @param time Optional time to apply the change (default: now)
+     */
+    setTimeStretchEnvDepth(depth: number, time?: number): void {
+        if (this.workletNode) {
+            this.workletNode.parameters.get('timeStretchEnvDepth')?.setValueAtTime(depth, time || this.audioContext.currentTime);
+        }
+    }
+
     setFreezeEnvDepth(depth: number, time?: number): void {
         if (this.workletNode) {
             this.workletNode.parameters.get('freezeEnvDepth')?.setValueAtTime(depth, time || this.audioContext.currentTime);

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -1056,6 +1056,11 @@ export const useAudioEngine = (pyodide: unknown, tempo: number = 120) => {
 
                             // Apply Envelope Follower depths (global only)
                             if (params.freezeEnvDepth !== undefined) voice.setFreezeEnvDepth(params.freezeEnvDepth, triggerTime);
+                            if (noteParams?.timeStretchEnvDepth !== undefined) {
+                                voice.setTimeStretchEnvDepth(noteParams.timeStretchEnvDepth, triggerTime);
+                            } else if (params.timeStretchEnvDepth !== undefined) {
+                                voice.setTimeStretchEnvDepth(params.timeStretchEnvDepth, triggerTime);
+                            }
                             if (params.grainEnvDepth !== undefined) voice.setGrainEnvDepth(params.grainEnvDepth, triggerTime);
                             if (noteParams?.grainPitchQuantize !== undefined) {
                                 voice.setGrainPitchQuantize(noteParams.grainPitchQuantize, triggerTime);

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,6 +1,4 @@
 {
-  "status": "failed",
-  "failedTests": [
-    "640b64cb12d06c48b89a-b1496cf7aab8bc2a16e8"
-  ]
+  "status": "passed",
+  "failedTests": []
 }


### PR DESCRIPTION
Implemented: per-step + global `timeStretchEnvDepth` fully wired through SingingVoice → rubberband Worklet. Pairs beautifully with Formant Envelope Sync.

---
*PR created automatically by Jules for task [14211816217062808438](https://jules.google.com/task/14211816217062808438) started by @ford442*