### PR TITLE
fix(types): remove duplicate timeStretchEnvDepth declaration

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -454,7 +454,6 @@ export interface Note {
   pitchDecay?: number;
   pitchAmount?: number;
   vowel?: number;
-  timeStretchEnvDepth?: number;
   /** Prophecy: Portamento rate 0–1 */
   portamento?: number;
   // ... other fields as needed


### PR DESCRIPTION
tsc -b failed with TS2300 (duplicate identifier) — a redundant timeStretchEnvDepth was added in the Prophecy field block during the time-stretch/pitch-envelope merge, duplicating the canonical one. Removing it unblocks tsc -b / npm run build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal note parameters to support enhanced audio synthesis control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->