### PR TITLE
🎨 Palette: Improve ScaleSelector Accessibility & Focus States

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -24,3 +24,6 @@
 ## 2024-06-19 - [Missing interactive element semantics and tooltips on custom buttons]
 **Learning:** Found custom buttons acting as toggles without `type="button"`, `role="switch"`, `aria-checked`, or `title` attributes. This could result in ambiguous screen reader announcements and accidental form submissions. It also limits usability for mouse users relying on hover tooltips.
 **Action:** When creating icon-only toggles and controls (like enabling/disabling lanes), ensure they are fully semantic with `type="button"`, `role="switch"` (where applicable), `aria-checked`, and a helpful `title` tooltip alongside their `aria-label`.
+## 2024-06-20 - [Grouped Parameter Accessibility]
+**Learning:** In complex dropdown or parameter groups like those in the ScaleSelector, grouping related standard `<select>` options in a `<fieldset>` with a visually hidden `<legend>` ensures proper context without requiring multiple repetitive aria labels on every input and unifies their screen reading experience. Applying a unified `focus-visible:ring` provides critical context that regular `focus:ring` lacks.
+**Action:** When creating groupings of closely related controls (e.g. root, scale, tuning system), default to `<fieldset>` and `<legend>` wrapping and strictly use `focus-visible:` classes over `focus:`.

--- a/src/components/ScaleSelector.tsx
+++ b/src/components/ScaleSelector.tsx
@@ -39,7 +39,7 @@ export const ScaleSelector: React.FC<ScaleSelectorProps> = memo(({ currentScale,
         <div className="flex items-center gap-1.5 bg-gray-900/80 border border-gray-700 rounded-lg px-2 py-1">
             <button
                 onClick={handleToggle}
-                className={`px-2 py-0.5 text-[10px] font-bold font-orbitron rounded transition-all ${
+                className={`px-2 py-0.5 text-[10px] font-bold font-orbitron rounded transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1014] focus-visible:ring-cyan-500 ${
                     isActive
                         ? 'bg-amber-500 text-black hover:bg-amber-400'
                         : 'bg-gray-700 text-gray-400 hover:bg-gray-600 hover:text-gray-200'
@@ -52,11 +52,12 @@ export const ScaleSelector: React.FC<ScaleSelectorProps> = memo(({ currentScale,
             </button>
 
             {isActive && (
-                <>
+                <fieldset className="flex items-center gap-1.5">
+                    <legend className="sr-only">Scale Configuration</legend>
                     <select
                         value={currentScale!.root}
                         onChange={handleRootChange}
-                        className="bg-gray-800 text-cyan-400 text-[10px] font-mono border border-gray-600 rounded px-1 py-0.5 focus:outline-none focus:ring-1 focus:ring-cyan-400"
+                        className="bg-gray-800 text-cyan-400 text-[10px] font-mono border border-gray-600 rounded px-1 py-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1014] focus-visible:ring-cyan-500"
                         aria-label="Root note"
                     >
                         {NOTES.map(note => (
@@ -67,7 +68,7 @@ export const ScaleSelector: React.FC<ScaleSelectorProps> = memo(({ currentScale,
                     <select
                         value={currentScale!.scale}
                         onChange={handleScaleChange}
-                        className="bg-gray-800 text-cyan-400 text-[10px] font-mono border border-gray-600 rounded px-1 py-0.5 focus:outline-none focus:ring-1 focus:ring-cyan-400"
+                        className="bg-gray-800 text-cyan-400 text-[10px] font-mono border border-gray-600 rounded px-1 py-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1014] focus-visible:ring-cyan-500"
                         aria-label="Scale type"
                     >
                         {SCALE_NAMES.map(name => (
@@ -78,14 +79,14 @@ export const ScaleSelector: React.FC<ScaleSelectorProps> = memo(({ currentScale,
                     <select
                         value={currentScale!.tuning || '12-TET'}
                         onChange={handleTuningChange}
-                        className="bg-gray-800 text-cyan-400 text-[10px] font-mono border border-gray-600 rounded px-1 py-0.5 focus:outline-none focus:ring-1 focus:ring-cyan-400"
+                        className="bg-gray-800 text-cyan-400 text-[10px] font-mono border border-gray-600 rounded px-1 py-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1014] focus-visible:ring-cyan-500"
                         aria-label="Tuning System"
                     >
                         {TUNING_NAMES.map(tuning => (
                             <option key={tuning} value={tuning}>{tuning}</option>
                         ))}
                     </select>
-                </>
+                </fieldset>
             )}
         </div>
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,7 @@ export interface SamplerBankParams {
   freezeLfoDepth?: number;
   freezeEnvDepth?: number;
   timeStretchEnvDepth?: number;
+  grainPitchEnvDepth?: number;
   grainEnvDepth?: number;
   grainPitchQuantize?: number;
   granularPitchShift?: number;


### PR DESCRIPTION
💡 What:
The UX enhancement groups the root, scale, and tuning `<select>` components inside a `<fieldset>` element with a `<legend className="sr-only">`. It also updates all interactive components in the ScaleSelector, including the Key Lock button and the dropdowns themselves, to use `focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1014] focus-visible:ring-cyan-500` instead of plain `focus:ring-1` or missing focus outlines entirely.

🎯 Why:
Wrapping the grouped `<select>` menus in a `<fieldset>` provides crucial context for screen reader users by implicitly relating the three controls (e.g. telling the user that they are selecting a Root, Scale, and Tuning as part of the overall "Scale Configuration"). Updating the focus styles from `focus:ring` to `focus-visible:ring-2` makes it easier for keyboard users to navigate without forcing focus rings to persist after mouse clicks, and unifies the visual design with other components.

📸 Before/After:
Before: The Scale configuration dropdowns lacked overarching screen reader context and used subtle/inconsistent focus styles that appeared even on mouse click.
After: The dropdowns are semantically grouped and display consistent, clear cyan focus rings offset by a dark background only when navigating via keyboard.

♿ Accessibility:
- Grouped related parameter controls via `<fieldset>` and `<legend>`.
- Standardized focus visibility to `focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1014]`.

---
*PR created automatically by Jules for task [14025734627653171225](https://jules.google.com/task/14025734627653171225) started by @ford442*