### PR TITLE
🎨 Palette: Add type="button" to icon buttons

### DIFF
--- a/src/components/ShortcutsHelp.tsx
+++ b/src/components/ShortcutsHelp.tsx
@@ -77,6 +77,7 @@ export const ShortcutsHelp: React.FC<ShortcutsHelpProps> = React.memo(({ onClose
                         KEYBOARD SHORTCUTS
                     </h2>
                     <button
+                        type="button"
                         onClick={onClose}
                         className="text-gray-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 rounded p-1"
                         aria-label="Close Shortcuts"
@@ -110,6 +111,7 @@ export const ShortcutsHelp: React.FC<ShortcutsHelpProps> = React.memo(({ onClose
                 {/* Footer */}
                 <div className="p-4 border-t border-gray-800 bg-gray-900/50 text-center">
                     <button
+                        type="button"
                         onClick={onClose}
                         className="bg-cyan-900/30 text-cyan-400 border border-cyan-800/50 hover:bg-cyan-900/50 px-6 py-2 rounded font-orbitron text-xs font-bold transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500"
                         aria-label="Acknowledge and close shortcuts"

--- a/src/components/automation/AutomationLaneList.tsx
+++ b/src/components/automation/AutomationLaneList.tsx
@@ -65,6 +65,7 @@ const LaneRow = memo(({
     >
       {/* Enable/Disable toggle */}
       <button
+        type="button"
         aria-label={`${lane.enabled ? 'Disable' : 'Enable'} lane ${lane.name}`}
         className={`w-4 h-4 rounded-sm border flex-shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a1d24] ${
           lane.enabled ? 'bg-cyan-500 border-cyan-400' : 'bg-transparent border-gray-500'
@@ -112,6 +113,7 @@ const LaneRow = memo(({
 
       {/* Remove button */}
       <button
+        type="button"
         aria-label={`Remove lane ${lane.name}`}
         className="text-gray-500 hover:text-red-400 flex-shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a1d24] rounded"
         onClick={(e) => { e.stopPropagation(); onRemove(lane.id); }}


### PR DESCRIPTION
🎨 **Palette: Add type="button" to icon buttons**

💡 **What:** Added missing `type="button"` attributes to the "✕" close/remove `<button>` elements in `AutomationLaneList.tsx` and `ShortcutsHelp.tsx`.
🎯 **Why:** To prevent these buttons from inadvertently triggering form submissions if they are ever wrapped within a `<form>` context. This aligns with accessibility and HTML best practices for interactive UI buttons that are not meant to submit data.
♿ **Accessibility:** Enhances overall UX resilience by explicitly declaring button behavior, which also helps certain screen reader heuristics categorize the interaction type correctly.

---
*PR created automatically by Jules for task [12910355836112068230](https://jules.google.com/task/12910355836112068230) started by @ford442*