### PR TITLE
🎨 Palette: Add keyboard focus-visible rings to custom buttons

### DIFF
--- a/src/components/NoteSelector.tsx
+++ b/src/components/NoteSelector.tsx
@@ -978,7 +978,7 @@ export const NoteSelector: React.FC<NoteSelectorProps> = memo(
                     />
                     <div className="flex items-center gap-2 mt-1">
                       <button
-                        className={`w-5 h-5 rounded flex items-center justify-center border ${currentSlideFormant ? "bg-cyan-500/20 border-cyan-500/50 text-cyan-300" : "bg-zinc-900 border-zinc-700 text-gray-500"} hover:bg-zinc-800 transition-colors`}
+                        className={`w-5 h-5 rounded flex items-center justify-center border ${currentSlideFormant ? "bg-cyan-500/20 border-cyan-500/50 text-cyan-300" : "bg-zinc-900 border-zinc-700 text-gray-500"} hover:bg-zinc-800 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus-visible:ring-cyan-500`}
                         onClick={() =>
                           onPropertyChange("slideFormant", !currentSlideFormant)
                         }
@@ -1680,7 +1680,7 @@ export const NoteSelector: React.FC<NoteSelectorProps> = memo(
                 <button
                   id="note-reverse"
                   onClick={() => onPropertyChange("reverse", !currentReverse)}
-                  className={`w-8 h-4 rounded-full transition-colors flex items-center px-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-1 focus-visible:ring-offset-gray-900 ${currentReverse ? "bg-cyan-500 justify-end shadow-[0_0_8px_rgba(6,182,212,0.4)]" : "bg-gray-700 justify-start border border-gray-600"}`}
+                  className={`w-8 h-4 rounded-full transition-colors flex items-center px-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 ${currentReverse ? "bg-cyan-500 justify-end shadow-[0_0_8px_rgba(6,182,212,0.4)]" : "bg-gray-700 justify-start border border-gray-600"}`}
                   aria-checked={currentReverse}
                   role="switch"
                   aria-label="Play slice in reverse"

--- a/src/components/OscillatorVariantSelector.tsx
+++ b/src/components/OscillatorVariantSelector.tsx
@@ -96,7 +96,7 @@ export const OscillatorVariantSelector: React.FC<OscillatorVariantSelectorProps>
               aria-pressed={active}
               title={`${theme.label} ${label} (${w})`}
               aria-label={`Select ${theme.label} ${label} waveform`}
-              className={`px-1.5 py-0.5 text-[8px] font-bold rounded transition-all border flex-1 min-w-[32px] ${
+              className={`px-1.5 py-0.5 text-[8px] font-bold rounded transition-all border flex-1 min-w-[32px] focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1115] ${accentColor === 'cyan' ? 'focus-visible:ring-cyan-500' : 'focus-visible:ring-pink-500'} ${
                 active ? familyActiveMap[type] : inactiveBase
               }`}
             >

--- a/src/components/phoneme/PhonemeBlock.tsx
+++ b/src/components/phoneme/PhonemeBlock.tsx
@@ -124,7 +124,7 @@ export const PhonemeBlock = memo(({
         {isSelected && (
           <button
             onClick={(e) => { e.stopPropagation(); onDelete(phoneme.id); }}
-            className="absolute -top-2 -right-2 w-5 h-5 rounded-full bg-gradient-to-b from-red-500 to-red-600 hover:from-red-400 hover:to-red-500 text-white text-xs flex items-center justify-center shadow-lg border border-red-400/50 transition-all focus:outline-none focus:ring-2 focus:ring-white"
+            className="absolute -top-2 -right-2 w-5 h-5 rounded-full bg-gradient-to-b from-red-500 to-red-600 hover:from-red-400 hover:to-red-500 text-white text-xs flex items-center justify-center shadow-lg border border-red-400/50 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus-visible:ring-red-400"
             title="Delete phoneme (Delete key)"
             aria-label="Delete phoneme"
             tabIndex={tabIndex}


### PR DESCRIPTION
🎨 Palette: Add keyboard focus-visible rings to custom buttons

💡 What: Added consistent `focus-visible:ring-2` and `focus-visible:ring-offset-2` styling to interactive buttons that were missing them.
- In `OscillatorVariantSelector.tsx`, added focus rings that match the module's accent color (cyan or pink).
- In `phoneme/PhonemeBlock.tsx`, added a red hardware-style focus ring to the custom delete button.
- In `NoteSelector.tsx`, fixed the "Slide Formant" button and updated the "Reverse Sample" button to use correct ring offsets.

🎯 Why: To improve keyboard accessibility. Custom SVG and div-based buttons often lack default browser focus indicators, making it difficult or impossible for keyboard users to see what is focused.

📸 Before/After: N/A
♿ Accessibility: Ensures interactive buttons clearly indicate focus state for keyboard navigation.

---
*PR created automatically by Jules for task [13488779204672490680](https://jules.google.com/task/13488779204672490680) started by @ford442*