### PR TITLE
UX/A11y Enhancements & Syntax Fixes

### DIFF
--- a/src/components/LoadingButton.tsx
+++ b/src/components/LoadingButton.tsx
@@ -21,6 +21,7 @@ export const LoadingButton: React.FC<LoadingButtonProps> = React.memo(({
             {...props}
             disabled={disabled || isLoading}
             aria-busy={isLoading}
+            aria-label={props['aria-label'] || (typeof children === 'string' ? children : loadingText)}
             className={`transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${
                 isLoading ? 'opacity-70 cursor-wait' : disabled ? 'opacity-50 cursor-not-allowed' : ''
             } ${className}`}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -14,11 +14,20 @@ export const Toast: React.FC<ToastProps> = React.memo(({ message, type, onClose 
   }, [onClose]);
 
   return (
-    <div className={`fixed top-4 left-1/2 -translate-x-1/2 z-[100] px-4 py-2 rounded shadow-lg border animate-in slide-in-from-top-2 fade-in duration-300 flex items-center gap-2 ${
+    <div className={`fixed top-4 left-1/2 -translate-x-1/2 z-[100] px-4 py-2 rounded shadow-lg border animate-in slide-in-from-top-2 fade-in duration-300 flex items-center gap-3 ${
       type === 'success' ? 'bg-green-900/90 border-green-500 text-green-100' : 'bg-red-900/90 border-red-500 text-red-100'
-    }`} role="alert">
-      <span>{type === 'success' ? '✓' : '⚠'}</span>
+    }`} role="alert" aria-live="polite">
+      <span aria-hidden="true">{type === 'success' ? '✓' : '⚠'}</span>
       <span className="font-mono text-sm">{message}</span>
+      <button
+        type="button"
+        onClick={onClose}
+        className={`ml-2 hover:opacity-75 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 rounded p-0.5 transition-opacity ${type === 'success' ? 'focus-visible:ring-green-400' : 'focus-visible:ring-red-400'}`}
+        aria-label="Close notification"
+        title="Close notification"
+      >
+        <span aria-hidden="true">✕</span>
+      </button>
     </div>
   );
 });

--- a/src/components/__tests__/SongModeA11y.test.tsx
+++ b/src/components/__tests__/SongModeA11y.test.tsx
@@ -91,10 +91,10 @@ describe('SongMode Accessibility', () => {
         expect(mockOnUpdateStep).toHaveBeenCalledWith(0, 'partA', null);
     });
 
-    it('clamps max value at 7 on ArrowUp', () => {
-        // Test max clamp (7 -> 7)
+    it('clamps max value at 31 on ArrowUp', () => {
+        // Test max clamp (31 -> 31)
         const structureMax = [
-            { ...defaultStructure[0], partA: 7 },
+            { ...defaultStructure[0], partA: 31 },
             defaultStructure[1]
         ];
         render(<SongMode {...defaultProps} songStructure={structureMax} />);
@@ -102,8 +102,8 @@ describe('SongMode Accessibility', () => {
         const maxCell = screen.getByTestId('cell-partA-0');
         fireEvent.keyDown(maxCell, { key: 'ArrowUp' });
 
-        // Should stay at 7
-        expect(mockOnUpdateStep).toHaveBeenCalledWith(0, 'partA', 7);
+        // Should stay at 31
+        expect(mockOnUpdateStep).toHaveBeenCalledWith(0, 'partA', 31);
     });
 
     it('clamps min value at 0 on ArrowDown', () => {

--- a/src/hooks/audioEngine/audioPlayback.ts
+++ b/src/hooks/audioEngine/audioPlayback.ts
@@ -557,6 +557,7 @@ export function createPlayDrum(
                     src.stop(now + hatParams.decay);
                 }
             }
+        };
     };
 
 export function createNoteOnSynth(


### PR DESCRIPTION
- **LoadingButton**: Added fallback `aria-label` logic, using the `aria-label` prop, text children, or `loadingText`.
- **Toast**: Added a dedicated, accessible close button with `focus-visible` styling and set `aria-live="polite"` on the alert to ensure screen readers properly announce toast content.
- **audioPlayback**: Fixed a syntax error (missing closing brace) that was failing the linter.
- **SongModeA11y**: Fixed `ArrowUp` test clamp expectations matching the recent codebase changes from 8 max slots to 32 max pattern slots.

---
*PR created automatically by Jules for task [449916790067844592](https://jules.google.com/task/449916790067844592) started by @ford442*