### PR TITLE
🎨 Palette: Add type="button" to core synth controls

### DIFF
--- a/src/components/Engine303Selector.tsx
+++ b/src/components/Engine303Selector.tsx
@@ -67,7 +67,7 @@ export const Engine303Selector: React.FC<Engine303SelectorProps> = memo(({
             </div>
 
             {/* Custom Open303 button */}
-            <button
+            <button type="button"
                 onClick={() => onChange('open303')}
                 title="Custom Open303 synthesizer — uses the built-in open303_* WASM API in hyphon_native.wasm"
                 aria-pressed={!isJc303}
@@ -80,7 +80,7 @@ export const Engine303Selector: React.FC<Engine303SelectorProps> = memo(({
             </button>
 
             {/* Authentic JC303 button */}
-            <button
+            <button type="button"
                 onClick={() => onChange('jc303')}
                 title="Authentic rosic::Open303 — per-voice JC303 engine from the jc303_wasm submodule (rosic_Open303). Enables the accurate TB-303 DSP introduced in the May 2026 per-voice engine update."
                 aria-pressed={isJc303}

--- a/src/components/OscillatorTypeSelector.tsx
+++ b/src/components/OscillatorTypeSelector.tsx
@@ -77,7 +77,7 @@ export const OscillatorTypeSelector: React.FC<OscillatorTypeSelectorProps> = mem
           };
 
           return (
-            <button
+            <button type="button"
               key={t}
               onClick={() => onChange(t)}
               aria-pressed={isActive}

--- a/src/components/OscillatorVariantSelector.tsx
+++ b/src/components/OscillatorVariantSelector.tsx
@@ -90,7 +90,7 @@ export const OscillatorVariantSelector: React.FC<OscillatorVariantSelectorProps>
           const label = getLabel(w);
           const active = isActive(w);
           return (
-            <button
+            <button type="button"
               key={w}
               onClick={() => onChange(w)}
               aria-pressed={active}


### PR DESCRIPTION
This PR is a targeted UX/accessibility enhancement that adds missing `type="button"` attributes to core synthesizer control components (`OscillatorVariantSelector`, `OscillatorTypeSelector`, `Engine303Selector`).

By default, the `<button>` element behaves as `type="submit"`, which can cause unintended side effects or page reloads if ever wrapped inside a `<form>` element. This defensive fix explicitly sets `type="button"` to ensure robust behavior.

This is the first small, reviewable tranche in a broader hygiene pass, focusing purely on high-frequency synth editing components to minimize diff noise while delivering high ROI usability correctness.

---
*PR created automatically by Jules for task [16174051208872315034](https://jules.google.com/task/16174051208872315034) started by @ford442*