### PR TITLE
fix: enable sign-ext in wasm-opt for native WASM optimization

### DIFF
--- a/tools/optimize.sh
+++ b/tools/optimize.sh
@@ -57,6 +57,7 @@ $WASM_OPT "$PHYSICS_WASM" -o "$PHYSICS_WASM" \
   --enable-simd \
   --enable-threads \
   --enable-bulk-memory \
+  --enable-sign-ext \
   --enable-relaxed-simd \
   --enable-nontrapping-float-to-int
 
@@ -67,6 +68,7 @@ $WASM_OPT "$FREEZER_WASM" -o "$FREEZER_WASM" \
   --strip-debug \
   --enable-simd \
   --enable-bulk-memory \
+  --enable-sign-ext \
   --enable-relaxed-simd \
   --enable-nontrapping-float-to-int
 
@@ -82,6 +84,7 @@ $WASM_OPT "$NATIVE_WASM" -o "$NATIVE_WASM" \
   --strip-debug \
   --enable-simd \
   --enable-threads \
+  --enable-sign-ext \
   --enable-relaxed-simd \
   --enable-bulk-memory \
   --enable-nontrapping-float-to-int


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`pnpm run optimize` fails on `hyphon_native.wasm` with wasm-validator errors like:

```
[wasm-validator error in function 6] unexpected false: all used features should be allowed, on
(i32.extend8_s (local.get $5))
```

## Cause

Emscripten/LLVM emit WebAssembly sign-extension instructions (`i32.extend8_s`, `i32.extend16_s`, etc.). `wasm-opt` validates against an explicit feature set and rejects these ops unless `--enable-sign-ext` is passed.

## Fix

Add `--enable-sign-ext` to all `wasm-opt` invocations in `tools/optimize.sh` (oscillators, track freezer, and native WASM).

## Testing

- Built `hyphon_native.wasm` via `emscripten/build.sh`
- Ran `bash tools/optimize.sh` successfully end-to-end
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-742781b9-8fb6-4ec9-9799-85279dede288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-742781b9-8fb6-4ec9-9799-85279dede288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

