### PR TITLE
fix: remove duplicate vocoder fields blocking TypeScript build

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -465,9 +465,6 @@ export interface Note {
   vocoderAttack?: number;
   vocoderRelease?: number;
   phonemes?: PhonemeData[];
-  vocoderFormantShift?: number;
-  vocoderPreservation?: number;
-  vocoderAttack?: number;
   /** Prophecy: Vowel formant preset 0–4 (A=0, E=1, I=2, O=3, U=4) */
   pitchAttack?: number;
   pitchDecay?: number;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `tsc -b` failures caused by duplicate property declarations on the `Note` interface in `src/types.ts`.

## Problem

After WASM optimization completed, the production build failed during `tsc -b` with:

```
error TS2300: Duplicate identifier 'vocoderFormantShift'.
error TS2300: Duplicate identifier 'vocoderPreservation'.
error TS2300: Duplicate identifier 'vocoderAttack'.
```

The earlier `TS2688` errors for `vite/client`, `@webgpu/types`, and `vitest/globals` were caused by missing `node_modules` (resolved by running `pnpm install --frozen-lockfile`).

## Fix

Removed the duplicate `vocoderFormantShift`, `vocoderPreservation`, and `vocoderAttack` fields from `Note` (lines 468–470). The canonical declarations remain at lines 463–466 alongside `vocoderRelease`.

## Verification

- `npx tsc -b` passes after the change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd46dbb2-f356-4255-b0da-cd05f76ad054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd46dbb2-f356-4255-b0da-cd05f76ad054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

