### PR TITLE
feat: implement Vocal Harmony Envelope

### DIFF
--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -1919,6 +1919,13 @@ const playSamplerVoice = (
                             formantShift: (params.formantShift || 0) + voice.formantShift,
                             fineTune: (params.fineTune || 0) + voice.detuneCents
                         };
+                        const config = harmonizer.getConfig();
+                        if (config.harmonyAttack !== undefined) {
+                            voiceParams.attack = config.harmonyAttack;
+                        }
+                        if (config.harmonyRelease !== undefined) {
+                            voiceParams.release = config.harmonyRelease;
+                        }
 
                         // Play this voice with pitch offset and slight delay for natural ensemble effect
                         const delayMs = voice.index * 5;


### PR DESCRIPTION
This implements the "Vocal Harmony Envelope" feature from the active backlog. It adds `harmonyAttack` and `harmonyRelease` to `HarmonizerConfig` to allow applying a dedicated ADSR envelope to generated harmony voices, so they can slowly fade in/out behind the main lead vocal. 

Includes:
- Additions to `HarmonizerConfig` in `Harmonizer.ts` with updated defaults.
- Updated `HarmonizerPopover.tsx` with Fade In and Fade Out sliders for harmony envelopes.
- Modified `useAudioEngine.ts` to override `voiceParams.attack` and `voiceParams.release` natively when triggering recursive harmony voices during sample playback.
- Updated `agent_plan.md` state.

Note: `useAudioEngine.ts` has a pre-existing bracket/parse issue on `main` which continues to cause linting errors. As advised by the user, the surgical minimal logic was injected despite the file's current compilation status on main.

---
*PR created automatically by Jules for task [13443861150946905586](https://jules.google.com/task/13443861150946905586) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Harmony playback now better respects the current sound settings, applying updated attack and release behavior when harmonies are rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->