### PR TITLE
🎨 Palette: Add keyboard navigation to DrumPads

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -51,3 +51,7 @@
 ## 2026-07-04 - Safely scripting widespread type="button" updates
 **Learning:** Programmatically updating hundreds of missing `type="button"` attributes using regex scripts across a complex React codebase can easily cause duplicates, merge conflict errors, or mistakenly alter the AST if run against recently broken/refactored logic. React builds fail loudly on duplicate attributes (`TS17001`).
 **Action:** When performing sweeping attribute additions, always check for pre-existing occurrences in the target line, avoid touching files currently showing unresolved merge errors, and test via `pnpm lint` and `pnpm build` immediately to catch syntax errors introduced by over-eager regex.
+
+## 2026-07-10 - [Keyboard Accessibility for Playable Audio Triggers]
+**Learning:** When adding keyboard navigation to components that trigger real-time audio (like `DrumPads.tsx`), standard `<button>` click handling is insufficient. The Spacebar key defaults to scrolling the page, and operating system key-repeat rapidly fires `onKeyDown` if the key is held, causing horrible audio stuttering.
+**Action:** Always intercept `' '` (Space) and `'Enter'` keys explicitly via `onKeyDown` and `onKeyUp`. Call `e.preventDefault()` to stop scrolling, and maintain an active state (like a `Set` of active pad IDs) to ensure the audio trigger (`handlePadDown`) only fires once per physical key press, ignoring subsequent auto-repeat events.

--- a/src/components/DrumPads.tsx
+++ b/src/components/DrumPads.tsx
@@ -64,6 +64,20 @@ export const DrumPads = memo(({ onPlayDrum }: DrumPadsProps) => {
               onMouseLeave={() => handlePadUp(pad.id)}
               onTouchStart={(e) => { e.preventDefault(); handlePadDown(pad); }}
               onTouchEnd={(e) => { e.preventDefault(); handlePadUp(pad.id); }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  if (!activePads.has(pad.id)) {
+                    handlePadDown(pad);
+                  }
+                }
+              }}
+              onKeyUp={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  handlePadUp(pad.id);
+                }
+              }}
               className={`
                 relative flex items-center justify-center aspect-square rounded-lg
                 font-bold text-[10px] tracking-wider select-none


### PR DESCRIPTION
💡 **What:** Added keyboard accessibility to the `DrumPads` component. Users can now trigger the drum pads using the 'Enter' and 'Space' keys when they have focus.
🎯 **Why:** To improve accessibility and provide a more tactile, hardware-like interaction pattern for users who prefer keyboard navigation over mouse clicks.
♿ **Accessibility:**
- Ensures `Space` does not scroll the page while playing drums.
- Prevents operating system auto-key-repeat from firing multiple rapid audio triggers when holding down a key.

---
*PR created automatically by Jules for task [7181974740871622972](https://jules.google.com/task/7181974740871622972) started by @ford442*