### PR TITLE
⚡ Bolt: Optimize automation playback loops to reduce GC overhead

### DIFF
--- a/src/hooks/useStepHandler.ts
+++ b/src/hooks/useStepHandler.ts
@@ -20,10 +20,10 @@ import type { AutomationTarget } from '../types';
 
 // ⚡ Bolt: Helper to retrieve the automation store value per lane efficiently without array methods to reduce GC.
 const getAutomationValue = (target: AutomationTarget, param: string, step: number): number | undefined => {
-    const lanes = automationStore.getLanesForParam(target, param);
+    const lanes = automationStore.getState().lanes;
     for (let i = 0; i < lanes.length; i++) {
         const lane = lanes[i];
-        if (lane.enabled) {
+        if (lane.target === target && lane.parameter === param && lane.enabled) {
             const v = automationStore.getValueAtStep(lane, step);
             if (v !== null) return v;
         }
@@ -407,56 +407,34 @@ export const useStepHandler = ({
         // Apply recorded/imported RBS/AI automation lanes with interpolation.
         // High-priority: Voice Designer params (formantShift, drive, attack, decay) via ramping path.
         // This enables full expressive RBS song playback with parameter movement.
-        const playbackEnabled = automationStore.getState().playbackEnabled;
+        const autoState = automationStore.getState();
+        const playbackEnabled = autoState.playbackEnabled;
         if (playbackEnabled && audioEngine) {
             const automationPatternIndex = isSongModeActiveRef.current ? (songMeasureRef.current % 8) : 0;
-            const activeLanes = automationStore.getActiveLanesForPattern(automationPatternIndex);
+            const lanes = autoState.lanes;
             const rampDuration = Math.max(0.01, stepTime * 0.85);
 
             // Collect live values for UI display (keyed "target:parameter")
             const liveValues: Record<string, number> = {};
             let hasLiveValues = false;
 
-            // --- 303 / synth automation via AudioParam-aligned scheduler ---
-            // The AutomationScheduler sends worklet messages timed to the AudioContext
-            // clock, avoiding JS-callback jitter for continuous knob curves.
-            // Master-target PCF lanes are also routed through the scheduler so that
-            // TRAK-event precision is preserved for filter sweeps.
-            if (automationSchedulerRef?.current) {
-                const schedulerLanes = activeLanes.filter(
-                    (l) => l.target === 'synthA' || l.target === 'synthB' || l.target === 'bass2'
-                        || l.target === 'master'
-                );
-                if (schedulerLanes.length > 0) {
-                    automationSchedulerRef.current.scheduleFromLanes(
-                        schedulerLanes,
-                        step,
-                        1,          // schedule one step ahead
-                        stepTime,
-                        time
-                    );
-                    // Collect live values from these lanes for UI indicators.
-                    for (const lane of schedulerLanes) {
-                        if (!lane.enabled) continue;
-                        const normVal = automationStore.getValueAtStep(lane, step);
-                        if (normVal === null) continue;
-                        liveValues[`${lane.target}:${lane.parameter}`] = normVal;
-                        hasLiveValues = true;
-                    }
-                }
-            }
+            const schedulerLanes = [];
 
-            activeLanes.forEach((lane) => {
-                if (!lane.enabled) return;
-                // Skip 303/synth/master lanes already handled by the scheduler above.
-                if (automationSchedulerRef?.current &&
-                    (lane.target === 'synthA' || lane.target === 'synthB' || lane.target === 'bass2'
-                        || lane.target === 'master')) {
-                    return;
+            // First pass: collect scheduler lanes and evaluate active non-scheduler lanes without array methods
+            for (let i = 0; i < lanes.length; i++) {
+                const lane = lanes[i];
+                if (!lane.enabled) continue;
+                if (lane.scope === 'pattern' && lane.patternIndex !== automationPatternIndex) continue;
+
+                const isSchedulerTarget = lane.target === 'synthA' || lane.target === 'synthB' || lane.target === 'bass2' || lane.target === 'master';
+
+                if (automationSchedulerRef?.current && isSchedulerTarget) {
+                    schedulerLanes.push(lane);
+                    continue;
                 }
 
                 const normVal = automationStore.getValueAtStep(lane, step);
-                if (normVal === null) return;
+                if (normVal === null) continue;
 
                 // Track for UI automation indicators
                 liveValues[`${lane.target}:${lane.parameter}`] = normVal;
@@ -486,7 +464,26 @@ export const useStepHandler = ({
                         onParamChange(activeSamplerBankRef.current, lane.parameter as any, realVal, rampDuration);
                     } catch (e) {}
                 }
-            });
+            }
+
+            // --- 303 / synth automation via AudioParam-aligned scheduler ---
+            if (automationSchedulerRef?.current && schedulerLanes.length > 0) {
+                automationSchedulerRef.current.scheduleFromLanes(
+                    schedulerLanes,
+                    step,
+                    1,          // schedule one step ahead
+                    stepTime,
+                    time
+                );
+                // Collect live values from these lanes for UI indicators.
+                for (let i = 0; i < schedulerLanes.length; i++) {
+                    const lane = schedulerLanes[i];
+                    const normVal = automationStore.getValueAtStep(lane, step);
+                    if (normVal === null) continue;
+                    liveValues[`${lane.target}:${lane.parameter}`] = normVal;
+                    hasLiveValues = true;
+                }
+            }
 
             // Notify UI with all live values in a single batched update (one re-render per step)
             if (hasLiveValues) {


### PR DESCRIPTION
💡 What: The optimization replaces `.filter` and `.forEach` calls in the automation playback frame with traditional `for` loops directly over the raw `automationStore.getState().lanes` array.
🎯 Why: In `useStepHandler.ts`, fetching lanes per parameter or for the active pattern repeatedly used `.filter()`. Because this executes on every step interval (often multiple times per bar per track), it creates massive amounts of transient array garbage on the main thread, leading to GC-induced audio frame drops and jitter.
📊 Impact: Expected to significantly reduce main-thread GC thrashing and React re-render pressure during dense playback by avoiding the creation of short-lived arrays and closures inside the hot playback path.
🔬 Measurement: Verify via Chrome DevTools Performance tab: Observe reduced frequency of minor GC events during continuous sequence playback, especially with multiple active automation lanes.

---
*PR created automatically by Jules for task [5869892698869099760](https://jules.google.com/task/5869892698869099760) started by @ford442*