### PR TITLE
Add color-coded expression LEDs to rack instruments

### DIFF
--- a/src/__tests__/expressionLed.test.ts
+++ b/src/__tests__/expressionLed.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { expressionLedStore } from '../stores/expressionLedStore';
+import { pulseExpressionLed } from '../audio/expressionLedPulse';
+import { getNoteColor } from '../utils/noteColors';
+
+describe('expressionLedStore', () => {
+    beforeEach(() => {
+        expressionLedStore.pulse('kick', '#ff0000', 1);
+        expressionLedStore.tick();
+        expressionLedStore.tick();
+        while (expressionLedStore.getChannel('kick')) {
+            expressionLedStore.tick();
+        }
+    });
+
+    it('stores and retrieves a pulse channel', () => {
+        expressionLedStore.pulse('synthA', 'hsl(120, 80%, 50%)', 1);
+        expect(expressionLedStore.getChannel('synthA')).toEqual({
+            noteColor: 'hsl(120, 80%, 50%)',
+            envelope: 1,
+        });
+    });
+
+    it('decays envelope over ticks', () => {
+        expressionLedStore.pulse('snare', '#00ff00', 1);
+        const before = expressionLedStore.getChannel('snare')!.envelope;
+        expressionLedStore.tick();
+        const after = expressionLedStore.getChannel('snare')!.envelope;
+        expect(after).toBeLessThan(before);
+    });
+});
+
+describe('pulseExpressionLed', () => {
+    it('uses sequencer note colors for melodic targets', () => {
+        pulseExpressionLed('synthA', 'C4');
+        expect(expressionLedStore.getChannel('synthA')?.noteColor).toBe(getNoteColor('C4', 'partA'));
+    });
+
+    it('uses track fallback color for drums without a note', () => {
+        pulseExpressionLed('kick');
+        expect(expressionLedStore.getChannel('kick')?.noteColor).toBe('#f97316');
+    });
+});

--- a/src/audio/expressionLedPulse.ts
+++ b/src/audio/expressionLedPulse.ts
@@ -1,0 +1,34 @@
+import { TRACK_COLORS } from '../components/sequencer/constants';
+import { expressionLedStore } from '../stores/expressionLedStore';
+import type { ExpressionLedTarget } from '../types';
+import { getNoteColor } from '../utils/noteColors';
+
+const TARGET_TRACK_KEY: Partial<Record<ExpressionLedTarget, 'partA' | 'partB' | 'bass2'>> = {
+    synthA: 'partA',
+    synthB: 'partB',
+    bass2: 'bass2',
+};
+
+const TARGET_FALLBACK: Record<ExpressionLedTarget, string> = {
+    synthA: TRACK_COLORS.partA,
+    synthB: TRACK_COLORS.partB,
+    bass2: TRACK_COLORS.partB,
+    kick: TRACK_COLORS.kick,
+    snare: TRACK_COLORS.snare,
+    closedHat: TRACK_COLORS.closedHat,
+    openHat: TRACK_COLORS.openHat,
+    sampler: TRACK_COLORS.sampler,
+};
+
+/** Bump the expression LED for an instrument with optional note-colored hue. */
+export function pulseExpressionLed(
+    target: ExpressionLedTarget,
+    note?: string,
+    envelope = 1,
+): void {
+    const trackKey = TARGET_TRACK_KEY[target];
+    const color = note
+        ? getNoteColor(note, trackKey)
+        : TARGET_FALLBACK[target];
+    expressionLedStore.pulse(target, color, envelope);
+}

--- a/src/audio/trackAnalysers.ts
+++ b/src/audio/trackAnalysers.ts
@@ -1,0 +1,23 @@
+// Passive monitor taps for per-instrument expression LEDs.
+// Each tap is a gain bus into the master chain plus a read-only AnalyserNode.
+
+export interface TrackMonitor {
+    bus: GainNode;
+    analyser: AnalyserNode;
+}
+
+export function createTrackMonitor(
+    context: AudioContext,
+    destination: AudioNode,
+): TrackMonitor {
+    const bus = context.createGain();
+    bus.gain.value = 1;
+    bus.connect(destination);
+
+    const analyser = context.createAnalyser();
+    analyser.fftSize = 256;
+    analyser.smoothingTimeConstant = 0.55;
+    bus.connect(analyser);
+
+    return { bus, analyser };
+}

--- a/src/components/ExpressionLed.tsx
+++ b/src/components/ExpressionLed.tsx
@@ -1,0 +1,134 @@
+// ExpressionLed — circular canvas LED that pulses with audio level and note hue.
+//
+// Brightness: RMS from optional per-track AnalyserNode + decaying trigger envelope.
+// Color: note color from the color-coded sequencer (falls back to track accent).
+
+import React, { useRef, useEffect, memo } from 'react';
+import { useLevelMeter, type LevelReading } from '../hooks/useLevelMeter';
+import { expressionLedStore, type ExpressionLedTarget } from '../stores/expressionLedStore';
+
+interface ExpressionLedProps {
+    target: ExpressionLedTarget;
+    analyserNode?: AnalyserNode | null;
+    fallbackColor: string;
+    size?: number;
+    className?: string;
+    'aria-label'?: string;
+}
+
+function clamp01(value: number): number {
+    return Math.max(0, Math.min(1, value));
+}
+
+function drawExpressionLed(
+    canvas: HTMLCanvasElement | null,
+    color: string,
+    brightness: number,
+    size: number,
+): void {
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const px = Math.max(1, Math.floor(size * dpr));
+    if (canvas.width !== px || canvas.height !== px) {
+        canvas.width = px;
+        canvas.height = px;
+    }
+
+    ctx.clearRect(0, 0, px, px);
+    const cx = px / 2;
+    const cy = px / 2;
+    const radius = (px / 2) * 0.82;
+
+    ctx.beginPath();
+    ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+    ctx.fillStyle = '#1a2026';
+    ctx.fill();
+
+    if (brightness < 0.03) return;
+
+    const glowRadius = radius * (0.65 + brightness * 0.55);
+    const gradient = ctx.createRadialGradient(cx, cy, 0, cx, cy, glowRadius);
+    gradient.addColorStop(0, color);
+    gradient.addColorStop(0.45, color);
+    gradient.addColorStop(1, 'rgba(0,0,0,0)');
+
+    ctx.globalAlpha = clamp01(0.25 + brightness * 0.85);
+    ctx.beginPath();
+    ctx.arc(cx, cy, glowRadius, 0, Math.PI * 2);
+    ctx.fillStyle = gradient;
+    ctx.fill();
+
+    ctx.globalAlpha = clamp01(0.4 + brightness * 0.6);
+    ctx.beginPath();
+    ctx.arc(cx, cy, radius * 0.55, 0, Math.PI * 2);
+    ctx.fillStyle = color;
+    ctx.fill();
+
+    ctx.globalAlpha = 1;
+}
+
+function renderFrame(
+    canvas: HTMLCanvasElement | null,
+    target: ExpressionLedTarget,
+    fallbackColor: string,
+    size: number,
+    level: number,
+): void {
+    expressionLedStore.tick();
+    const channel = expressionLedStore.getChannel(target);
+    const color = channel?.noteColor ?? fallbackColor;
+    const envelope = channel?.envelope ?? 0;
+    const brightness = clamp01(level * 2.2 + envelope * 0.75);
+    drawExpressionLed(canvas, color, brightness, size);
+}
+
+export const ExpressionLed: React.FC<ExpressionLedProps> = memo(({
+    target,
+    analyserNode,
+    fallbackColor,
+    size = 10,
+    className = '',
+    'aria-label': ariaLabel,
+}) => {
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+
+    const drawFromReading = (reading: LevelReading) => {
+        renderFrame(canvasRef.current, target, fallbackColor, size, reading.level);
+    };
+
+    useLevelMeter(analyserNode, { onFrame: drawFromReading });
+
+    // Envelope-only fallback when no analyser is wired (drums, 303 voices).
+    useEffect(() => {
+        if (analyserNode) return;
+        let raf = 0;
+        const tick = () => {
+            renderFrame(canvasRef.current, target, fallbackColor, size, 0);
+            raf = requestAnimationFrame(tick);
+        };
+        raf = requestAnimationFrame(tick);
+        return () => cancelAnimationFrame(raf);
+    }, [analyserNode, target, fallbackColor, size]);
+
+    useEffect(() => {
+        drawExpressionLed(canvasRef.current, fallbackColor, 0, size);
+    }, [fallbackColor, size]);
+
+    return (
+        <canvas
+            ref={canvasRef}
+            width={size}
+            height={size}
+            className={`inline-block shrink-0 rounded-full ${className}`}
+            style={{ width: size, height: size }}
+            role={ariaLabel ? 'img' : undefined}
+            aria-label={ariaLabel}
+            aria-hidden={ariaLabel ? undefined : true}
+        />
+    );
+});
+
+ExpressionLed.displayName = 'ExpressionLed';

--- a/src/components/HardwareModule.tsx
+++ b/src/components/HardwareModule.tsx
@@ -16,6 +16,8 @@ import type { KnobAutomationOverlayState } from './knobAutomationOverlay';
 import { buildKnobAutomationSvgPath, knobIndicatorPosition } from './knobAutomationOverlay';
 import { PanelTitleBar } from './ui/PanelChrome';
 import { RackPanelChrome } from './ui/RackPanelChrome';
+import { ExpressionLed } from './ExpressionLed';
+import type { ExpressionLedTarget } from '../types';
 
 const KNOB_TEST_ID_SANITIZE_PATTERN = /[^A-Za-z0-9_-]/g;
 
@@ -70,6 +72,10 @@ interface HardwareModuleProps {
     onAutomationNudge?: (paramId: string, value: number, step: number) => void;
     onAutomationPunchIn?: (paramId: string) => void;
     onAutomationLaneAction?: (action: 'toggle' | 'clear', paramId?: string) => void;
+    /** Color-coded expression LED in the title bar. */
+    expressionLedTarget?: ExpressionLedTarget;
+    expressionLedAnalyser?: AnalyserNode | null;
+    expressionLedFallbackColor?: string;
 }
 
 // PERFORMANCE: Memoized Knob Overlay Component
@@ -287,6 +293,9 @@ export const HardwareModule = memo(
         onAutomationNudge,
         onAutomationPunchIn,
         onAutomationLaneAction,
+        expressionLedTarget,
+        expressionLedAnalyser,
+        expressionLedFallbackColor,
     }: HardwareModuleProps) => {
         const compactLayout = useCompactLayoutOptional();
         const isCompact = compactLayout?.isCompact ?? false;
@@ -781,21 +790,34 @@ export const HardwareModule = memo(
                         title={title}
                         badge={titleBadge}
                         onContextMenu={handleHeaderContextMenu}
-                        actions={automationTarget ? (
-                            <button
-                                type="button"
-                                onClick={(e) => { e.stopPropagation(); automationStore.toggleShowHardwareAutomation(); }}
-                                className={`text-[7px] font-bold uppercase tracking-widest px-1.5 py-0.5 rounded border pointer-events-auto ${
-                                    showAutomationOverlay
-                                        ? 'bg-cyan-900/80 text-cyan-200 border-cyan-500/60'
-                                        : 'bg-gray-900/80 text-gray-500 border-gray-700'
-                                }`}
-                                title="Toggle automation curve overlay on knobs"
-                                aria-pressed={showAutomationOverlay}
-                            >
-                                AUTO
-                            </button>
-                        ) : undefined}
+                        actions={(
+                            <>
+                                {expressionLedTarget && expressionLedFallbackColor && (
+                                    <ExpressionLed
+                                        target={expressionLedTarget}
+                                        analyserNode={expressionLedAnalyser}
+                                        fallbackColor={expressionLedFallbackColor}
+                                        className="pointer-events-auto mr-1"
+                                        aria-label={`${title} activity`}
+                                    />
+                                )}
+                                {automationTarget ? (
+                                    <button
+                                        type="button"
+                                        onClick={(e) => { e.stopPropagation(); automationStore.toggleShowHardwareAutomation(); }}
+                                        className={`text-[7px] font-bold uppercase tracking-widest px-1.5 py-0.5 rounded border pointer-events-auto ${
+                                            showAutomationOverlay
+                                                ? 'bg-cyan-900/80 text-cyan-200 border-cyan-500/60'
+                                                : 'bg-gray-900/80 text-gray-500 border-gray-700'
+                                        }`}
+                                        title="Toggle automation curve overlay on knobs"
+                                        aria-pressed={showAutomationOverlay}
+                                    >
+                                        AUTO
+                                    </button>
+                                ) : undefined}
+                            </>
+                        )}
                     />
 
                     {controls.map((c, i) => (

--- a/src/components/SamplerVoicePanel.tsx
+++ b/src/components/SamplerVoicePanel.tsx
@@ -23,6 +23,9 @@ interface SamplerVoicePanelProps {
     onAutomationNudge?: (paramId: string, value: number, step: number) => void;
     onAutomationPunchIn?: (paramId: string) => void;
     onAutomationLaneAction?: (action: 'toggle' | 'clear', paramId?: string) => void;
+    expressionLedTarget?: import('../types').ExpressionLedTarget;
+    expressionLedAnalyser?: AnalyserNode | null;
+    expressionLedFallbackColor?: string;
     // Sampler-specific props
     rootNote?: number; // 0-96 (C1-C8)
     coarseTune?: number; // -24 to +24
@@ -353,6 +356,9 @@ export const SamplerVoicePanel: React.FC<SamplerVoicePanelProps> = React.memo(({
     onAutomationNudge,
     onAutomationPunchIn,
     onAutomationLaneAction,
+    expressionLedTarget,
+    expressionLedAnalyser,
+    expressionLedFallbackColor,
     rootNote = 60, // C4 default
     coarseTune = 0,
     fineTune = 0,
@@ -511,6 +517,9 @@ export const SamplerVoicePanel: React.FC<SamplerVoicePanelProps> = React.memo(({
                     onAutomationNudge={onAutomationNudge}
                     onAutomationPunchIn={onAutomationPunchIn}
                     onAutomationLaneAction={onAutomationLaneAction}
+                    expressionLedTarget={expressionLedTarget}
+                    expressionLedAnalyser={expressionLedAnalyser}
+                    expressionLedFallbackColor={expressionLedFallbackColor}
                 >
                     {children}
                 </HardwareModule>

--- a/src/components/appParts/RackNode.tsx
+++ b/src/components/appParts/RackNode.tsx
@@ -8,10 +8,26 @@ import { useAutomationStore } from '../../stores/automationStore'
 import { midiMapStore, useMidiMapStore } from '../../stores/midiMapStore'
 import { registerMidiControlTouch, startMidiLearnForControl } from '../../hooks/useMidi'
 import { makeMidiControlId } from '../../types/midi'
-import type { AutomationTarget, AutomationRecordArm, UnifiedAutomationLane } from '../../types'
+import type { AutomationTarget, ExpressionLedTarget, UnifiedAutomationLane, TrackAnalysers } from '../../types'
 import { NUM_STEPS } from '../../constants'
 import { sampleLaneArcValues } from '../../utils/knobAutomationCurve'
 import type { TrackKey } from '../../constants/appDefaults'
+
+function colorHexToCss([r, g, b]: [number, number, number]): string {
+  return `rgb(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)})`;
+}
+
+function makeExpressionLedProps(
+  target: ExpressionLedTarget,
+  fallback: [number, number, number],
+  trackAnalysers?: TrackAnalysers,
+) {
+  return {
+    expressionLedTarget: target,
+    expressionLedAnalyser: trackAnalysers?.[target] ?? null,
+    expressionLedFallbackColor: colorHexToCss(fallback),
+  };
+}
 
 /** Stamp each KnobConfig with isRecording and isAutomated/automatedValue flags from the store. */
 function applyControlFlags(
@@ -160,7 +176,22 @@ export const RackNode = React.memo(() => {
     handleAutomationNudge,
     handleAutomationPunchIn,
     handleAutomationLaneAction,
+    audioEngine,
   } = useAppStateContext()
+
+  const expressionLedProps = React.useMemo(() => {
+    const analysers = audioEngine?.trackAnalysers;
+    return {
+      synthA: makeExpressionLedProps('synthA', COLOR_LEAD, analysers),
+      synthB: makeExpressionLedProps('synthB', COLOR_BASS, analysers),
+      bass2: makeExpressionLedProps('bass2', COLOR_BASS2, analysers),
+      kick: makeExpressionLedProps('kick', COLOR_KICK, analysers),
+      snare: makeExpressionLedProps('snare', COLOR_SNARE, analysers),
+      closedHat: makeExpressionLedProps('closedHat', COLOR_CH, analysers),
+      openHat: makeExpressionLedProps('openHat', COLOR_OH, analysers),
+      sampler: makeExpressionLedProps('sampler', COLOR_SAMPLER, analysers),
+    };
+  }, [audioEngine?.trackAnalysers]);
 
   // Subscribe to record-arm state and live automated values for knob indicators
   const { recordArms, liveAutomatedValues, lanes, showHardwareAutomation } = useAutomationStore()
@@ -265,13 +296,13 @@ export const RackNode = React.memo(() => {
     </span>
   ), [drumKit, updateDrumKit]);
 
-  const rackModulePartA = useMemo(() => <HardwareModule title="SYNTH A // LEAD" colorHex={COLOR_LEAD} controls={armedControlsMap.synthA} onParamChange={onSynthAParamChange} onRecordToggle={onRecordToggleSynthA} is3D={is3DMode} {...makeMidiHandlers('synthA')} {...makeAutomationHandlers('synthA', patternIndexFor('synthA'), handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction)}>{synthAChild}</HardwareModule>, [armedControlsMap.synthA, onSynthAParamChange, onRecordToggleSynthA, is3DMode, synthAChild, patternIndexFor, handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction])
-  const rackModulePartB = useMemo(() => <HardwareModule title="SYNTH B // BASS" colorHex={COLOR_BASS} controls={armedControlsMap.synthB} onParamChange={onSynthBParamChange} onRecordToggle={onRecordToggleSynthB} is3D={is3DMode} titleBadge={synthBTitleBadge} {...makeMidiHandlers('synthB')} {...makeAutomationHandlers('synthB', patternIndexFor('synthB'), handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction)}>{synthBChild}</HardwareModule>, [armedControlsMap.synthB, onSynthBParamChange, onRecordToggleSynthB, is3DMode, synthBChild, synthBTitleBadge, patternIndexFor, handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction])
-  const rackModuleBass2 = useMemo(() => <HardwareModule title="BASS 2 // TB-303" colorHex={COLOR_BASS2} controls={armedControlsMap.bass2} onParamChange={onBass2ParamChange} onRecordToggle={onRecordToggleBass2} is3D={is3DMode} titleBadge={bass2TitleBadge} {...makeMidiHandlers('bass2')} {...makeAutomationHandlers('bass2', patternIndexFor('bass2'), handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction)}>{bass2Child}</HardwareModule>, [armedControlsMap.bass2, onBass2ParamChange, onRecordToggleBass2, is3DMode, bass2Child, bass2TitleBadge, patternIndexFor, handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction])
-  const rackModuleKick = useMemo(() => <HardwareModule title="KICK DRUM" colorHex={COLOR_KICK} controls={armedControlsMap.kick} onParamChange={handleKickChange} onRecordToggle={onRecordToggleKick} is3D={is3DMode} titleBadge={drumKitBadge} {...makeMidiHandlers('kick')} {...makeAutomationHandlers('kick', patternIndexFor('kick'), handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction)} />, [armedControlsMap.kick, handleKickChange, onRecordToggleKick, is3DMode, drumKitBadge, patternIndexFor, handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction])
-  const rackModuleSnare = useMemo(() => <HardwareModule title="SNARE DRUM" colorHex={COLOR_SNARE} controls={armedControlsMap.snare} onParamChange={handleSnareChange} onRecordToggle={onRecordToggleSnare} is3D={is3DMode} {...makeMidiHandlers('snare')} {...makeAutomationHandlers('snare', patternIndexFor('snare'), handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction)} />, [armedControlsMap.snare, handleSnareChange, onRecordToggleSnare, is3DMode, patternIndexFor, handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction])
-  const rackModuleClosedHat = useMemo(() => <HardwareModule title="CLOSED HAT" colorHex={COLOR_CH} controls={armedControlsMap.closedHat} onParamChange={handleClosedHatChange} onRecordToggle={onRecordToggleClosedHat} is3D={is3DMode} {...makeMidiHandlers('closedHat')} {...makeAutomationHandlers('closedHat', patternIndexFor('closedHat'), handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction)} />, [armedControlsMap.closedHat, handleClosedHatChange, onRecordToggleClosedHat, is3DMode, patternIndexFor, handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction])
-  const rackModuleOpenHat = useMemo(() => <HardwareModule title="OPEN HAT" colorHex={COLOR_OH} controls={armedControlsMap.openHat} onParamChange={handleOpenHatChange} onRecordToggle={onRecordToggleOpenHat} is3D={is3DMode} {...makeMidiHandlers('openHat')} {...makeAutomationHandlers('openHat', patternIndexFor('openHat'), handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction)} />, [armedControlsMap.openHat, handleOpenHatChange, onRecordToggleOpenHat, is3DMode, patternIndexFor, handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction])
+  const rackModulePartA = useMemo(() => <HardwareModule title="SYNTH A // LEAD" colorHex={COLOR_LEAD} controls={armedControlsMap.synthA} onParamChange={onSynthAParamChange} onRecordToggle={onRecordToggleSynthA} is3D={is3DMode} {...makeMidiHandlers('synthA')} {...makeAutomationHandlers('synthA', patternIndexFor('synthA'), handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction)} {...expressionLedProps.synthA}>{synthAChild}</HardwareModule>, [armedControlsMap.synthA, onSynthAParamChange, onRecordToggleSynthA, is3DMode, synthAChild, patternIndexFor, handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction, expressionLedProps.synthA])
+  const rackModulePartB = useMemo(() => <HardwareModule title="SYNTH B // BASS" colorHex={COLOR_BASS} controls={armedControlsMap.synthB} onParamChange={onSynthBParamChange} onRecordToggle={onRecordToggleSynthB} is3D={is3DMode} titleBadge={synthBTitleBadge} {...makeMidiHandlers('synthB')} {...makeAutomationHandlers('synthB', patternIndexFor('synthB'), handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction)} {...expressionLedProps.synthB}>{synthBChild}</HardwareModule>, [armedControlsMap.synthB, onSynthBParamChange, onRecordToggleSynthB, is3DMode, synthBChild, synthBTitleBadge, patternIndexFor, handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction, expressionLedProps.synthB])
+  const rackModuleBass2 = useMemo(() => <HardwareModule title="BASS 2 // TB-303" colorHex={COLOR_BASS2} controls={armedControlsMap.bass2} onParamChange={onBass2ParamChange} onRecordToggle={onRecordToggleBass2} is3D={is3DMode} titleBadge={bass2TitleBadge} {...makeMidiHandlers('bass2')} {...makeAutomationHandlers('bass2', patternIndexFor('bass2'), handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction)} {...expressionLedProps.bass2}>{bass2Child}</HardwareModule>, [armedControlsMap.bass2, onBass2ParamChange, onRecordToggleBass2, is3DMode, bass2Child, bass2TitleBadge, patternIndexFor, handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction, expressionLedProps.bass2])
+  const rackModuleKick = useMemo(() => <HardwareModule title="KICK DRUM" colorHex={COLOR_KICK} controls={armedControlsMap.kick} onParamChange={handleKickChange} onRecordToggle={onRecordToggleKick} is3D={is3DMode} titleBadge={drumKitBadge} {...makeMidiHandlers('kick')} {...makeAutomationHandlers('kick', patternIndexFor('kick'), handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction)} {...expressionLedProps.kick} />, [armedControlsMap.kick, handleKickChange, onRecordToggleKick, is3DMode, drumKitBadge, patternIndexFor, handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction, expressionLedProps.kick])
+  const rackModuleSnare = useMemo(() => <HardwareModule title="SNARE DRUM" colorHex={COLOR_SNARE} controls={armedControlsMap.snare} onParamChange={handleSnareChange} onRecordToggle={onRecordToggleSnare} is3D={is3DMode} {...makeMidiHandlers('snare')} {...makeAutomationHandlers('snare', patternIndexFor('snare'), handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction)} {...expressionLedProps.snare} />, [armedControlsMap.snare, handleSnareChange, onRecordToggleSnare, is3DMode, patternIndexFor, handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction, expressionLedProps.snare])
+  const rackModuleClosedHat = useMemo(() => <HardwareModule title="CLOSED HAT" colorHex={COLOR_CH} controls={armedControlsMap.closedHat} onParamChange={handleClosedHatChange} onRecordToggle={onRecordToggleClosedHat} is3D={is3DMode} {...makeMidiHandlers('closedHat')} {...makeAutomationHandlers('closedHat', patternIndexFor('closedHat'), handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction)} {...expressionLedProps.closedHat} />, [armedControlsMap.closedHat, handleClosedHatChange, onRecordToggleClosedHat, is3DMode, patternIndexFor, handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction, expressionLedProps.closedHat])
+  const rackModuleOpenHat = useMemo(() => <HardwareModule title="OPEN HAT" colorHex={COLOR_OH} controls={armedControlsMap.openHat} onParamChange={handleOpenHatChange} onRecordToggle={onRecordToggleOpenHat} is3D={is3DMode} {...makeMidiHandlers('openHat')} {...makeAutomationHandlers('openHat', patternIndexFor('openHat'), handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction)} {...expressionLedProps.openHat} />, [armedControlsMap.openHat, handleOpenHatChange, onRecordToggleOpenHat, is3DMode, patternIndexFor, handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction, expressionLedProps.openHat])
   const rackModuleSampler = useMemo(() => (
     <SamplerVoicePanel
       title={`SAMPLER // BANK ${activeSamplerBank + 1}`}
@@ -282,6 +313,7 @@ export const RackNode = React.memo(() => {
       is3D={is3DMode}
       {...makeMidiHandlers('sampler')}
       {...makeAutomationHandlers('sampler', patternIndexFor('sampler'), handleAutomationNudge, handleAutomationPunchIn, handleAutomationLaneAction)}
+      {...expressionLedProps.sampler}
       {...samplerVoiceParams}
       onSamplerParamChange={handleSamplerVoiceChange}
       harmonizerConfig={harmonizerConfig}
@@ -290,7 +322,7 @@ export const RackNode = React.memo(() => {
     >
       {samplerChild}
     </SamplerVoicePanel>
-  ), [activeSamplerBank, armedControlsMap.sampler, handleSamplerChange, onRecordToggleSampler, is3DMode, samplerVoiceParams, handleSamplerVoiceChange, harmonizerConfig, handleHarmonizerConfigChange, isHarmonizeActive, samplerChild])
+  ), [activeSamplerBank, armedControlsMap.sampler, handleSamplerChange, onRecordToggleSampler, is3DMode, samplerVoiceParams, handleSamplerVoiceChange, harmonizerConfig, handleHarmonizerConfigChange, isHarmonizeActive, samplerChild, expressionLedProps.sampler])
 
   const rackModules = useMemo(() => ({
     partA: rackModulePartA,

--- a/src/hooks/audioEngine/audioPlayback.ts
+++ b/src/hooks/audioEngine/audioPlayback.ts
@@ -21,8 +21,23 @@ import { SingingVoiceManager } from '../../engines/SingingVoiceManager';
 import { DrumKitEngine } from '../../engines/DrumKitEngine';
 import { makeDistortionCurve } from './distortion';
 import { engineTelemetry } from '../../utils/engineTelemetry';
+import { pulseExpressionLed } from '../../audio/expressionLedPulse';
+import type { ExpressionLedTarget } from '../../types';
 
 export type SynthTrack = 'partA' | 'partB' | 'bass2';
+
+const SYNTH_TRACK_TO_LED: Record<SynthTrack, ExpressionLedTarget> = {
+    partA: 'synthA',
+    partB: 'synthB',
+    bass2: 'bass2',
+};
+
+const DRUM_SOUND_TO_LED: Record<DrumSound, ExpressionLedTarget> = {
+    kick: 'kick',
+    snare: 'snare',
+    closedHat: 'closedHat',
+    openHat: 'openHat',
+};
 
 export interface SynthNoteParams {
     vocoderFormantShift?: number;
@@ -166,6 +181,9 @@ export function createPlaySynth(
         const noteStr = Array.isArray(note) ? note[0] : note;
         if (!noteStr) {
             return;
+        }
+        if (track) {
+            pulseExpressionLed(SYNTH_TRACK_TO_LED[track], noteStr);
         }
         const midi = noteToMidi(noteStr);
         const velocity = Math.round((noteParams?.velocity ?? 0.8) * 127);
@@ -414,6 +432,8 @@ export function createPlayDrum(
             return;
         }
 
+        pulseExpressionLed(DRUM_SOUND_TO_LED[sound], noteStr, noteStr ? 1 : 0.9);
+
         // Compute pitch multiplier from note relative to reference C3
         const pitchRatio = noteStr
             ? Math.pow(2, (noteToMidi(noteStr) - DRUM_REF_MIDI) / 12)
@@ -562,6 +582,10 @@ export function createNoteOnSynth(
 ): NoteOnSynthFn {
     return (params, note, time, track) => {
         const now = time || context.currentTime;
+
+        if (track) {
+            pulseExpressionLed(SYNTH_TRACK_TO_LED[track], note);
+        }
 
         if (track === 'bass2') {
             if (refs.open303ManagerRef.current?.isBass2Ready()) {

--- a/src/hooks/audioEngine/engineApiBuilder.ts
+++ b/src/hooks/audioEngine/engineApiBuilder.ts
@@ -1,6 +1,6 @@
 import type { MutableRefObject } from 'react';
 import type { HarmonizerConfig } from '../../engines/Harmonizer';
-import type { AudioEngine, PartSequence, SynthParams } from '../../types';
+import type { AudioEngine, PartSequence, SynthParams, TrackAnalysers } from '../../types';
 import { WebGpuOscillator } from '../../engines/WebGpuOscillator';
 import { WasmOscillator } from '../../engines/WasmOscillator';
 import { Open303Manager } from '../../engines/Open303Manager';
@@ -28,6 +28,8 @@ export interface EngineApiBuilderRefs extends PlaybackRefs {
     masterSaturationRef: MutableRefObject<WaveShaperNode | null>;
     masterPannerRef: MutableRefObject<StereoPannerNode | null>;
     reverbTypeRef: MutableRefObject<'room' | 'plate' | 'hall'>;
+    analyserNodeRef: MutableRefObject<AnalyserNode | null>;
+    trackAnalysersRef: MutableRefObject<TrackAnalysers>;
 }
 
 export interface EngineApiPlaybackFns {
@@ -103,6 +105,8 @@ export function buildAudioEngine(
 
     return {
         context,
+        analyserNode: refs.analyserNodeRef.current,
+        trackAnalysers: refs.trackAnalysersRef.current,
         webGpuEngine: refs.gpuEngineRef.current,
         wasmEngine: refs.wasmEngineRef.current,
         open303Engine: refs.open303ManagerRef.current as any,

--- a/src/hooks/audioEngine/engineLifecycle.ts
+++ b/src/hooks/audioEngine/engineLifecycle.ts
@@ -7,6 +7,8 @@ import { VoiceManager } from '../../engines/VoiceManager';
 import { MultisampleGenerator } from '../../engines/MultisampleGenerator';
 import { PhonemeBufferPool } from '../../services/PhonemeBufferPool';
 import { engineTelemetry } from '../../utils/engineTelemetry';
+import { createTrackMonitor } from '../../audio/trackAnalysers';
+import type { TrackAnalysers } from '../../types';
 import {
     createNoiseBuffer,
     initializeChoirBuses,
@@ -23,6 +25,11 @@ type AudioWindow = Window & typeof globalThis & {
 };
 
 export interface EngineLifecycleRefs {
+    analyserNodeRef: MutableRefObject<AnalyserNode | null>;
+    trackAnalysersRef: MutableRefObject<TrackAnalysers>;
+    synthABusRef: MutableRefObject<GainNode | null>;
+    synthBBusRef: MutableRefObject<GainNode | null>;
+    samplerBusRef: MutableRefObject<GainNode | null>;
     masterGainRef: MutableRefObject<GainNode | null>;
     masterPannerRef: MutableRefObject<StereoPannerNode | null>;
     masterSaturationRef: MutableRefObject<WaveShaperNode | null>;
@@ -91,7 +98,20 @@ export async function initializeAudioContextAndEngines(
         refs.masterCompressorRef,
         refs.sidechainGainRef,
         refs.bassSidechainEQBusRef,
+        refs.analyserNodeRef,
     );
+
+    const synthATap = createTrackMonitor(context, masterBusInput);
+    refs.synthABusRef.current = synthATap.bus;
+    refs.trackAnalysersRef.current.synthA = synthATap.analyser;
+
+    const synthBTap = createTrackMonitor(context, masterBusInput);
+    refs.synthBBusRef.current = synthBTap.bus;
+    refs.trackAnalysersRef.current.synthB = synthBTap.analyser;
+
+    const samplerTap = createTrackMonitor(context, masterBusInput);
+    refs.samplerBusRef.current = samplerTap.bus;
+    refs.trackAnalysersRef.current.sampler = samplerTap.analyser;
 
     // Initialize Reverb Node
     // Initialize Reverb Nodes (Room, Plate, Hall)
@@ -177,9 +197,11 @@ export async function initializeAudioContextAndEngines(
         console.warn('Engine telemetry registration failed for oscillators', e);
     }
 
-    // Initialize Voice Managers
-    refs.voiceManagerARef.current = new VoiceManager(context, refs.masterSaturationRef.current!, 8, false, sawBuf || undefined, sqrBuf || undefined, refs.delayNodeRef.current || undefined);
-    refs.voiceManagerBRef.current = new VoiceManager(context, refs.masterSaturationRef.current!, 1, true, sawBuf || undefined, sqrBuf || undefined, refs.delayNodeRef.current || undefined);
+    // Initialize Voice Managers (routed through per-track monitor buses for expression LEDs)
+    const synthADest = refs.synthABusRef.current ?? refs.masterSaturationRef.current!;
+    const synthBDest = refs.synthBBusRef.current ?? refs.masterSaturationRef.current!;
+    refs.voiceManagerARef.current = new VoiceManager(context, synthADest, 8, false, sawBuf || undefined, sqrBuf || undefined, refs.delayNodeRef.current || undefined);
+    refs.voiceManagerBRef.current = new VoiceManager(context, synthBDest, 1, true, sawBuf || undefined, sqrBuf || undefined, refs.delayNodeRef.current || undefined);
 
     await initializeSustainProcessor(context, urls.sustainProcessorUrl, refs.sustainNodeRef, refs.masterGainRef);
 
@@ -215,8 +237,9 @@ export async function initializeAudioContextAndEngines(
             refs.choirRightPannerRef,
         );
 
+        const samplerDest = refs.samplerBusRef.current ?? refs.masterSaturationRef.current!;
         manager.getAllVoices().forEach(voice => {
-            voice.connectOutput(refs.masterSaturationRef.current!);
+            voice.connectOutput(samplerDest);
         });
 
         // Initialise the phoneme buffer pool and wire it to every voice

--- a/src/hooks/audioEngine/samplerPlayback.ts
+++ b/src/hooks/audioEngine/samplerPlayback.ts
@@ -6,6 +6,7 @@ import { Harmonizer } from '../../engines/Harmonizer';
 import type { MultisampleBank, PhonemeData, SamplerBankParams } from '../../types';
 import { noteToMidi, type ScaleDefinition } from '../../utils/musicTheory';
 import { makeDistortionCurve } from './distortion';
+import { pulseExpressionLed } from '../../audio/expressionLedPulse';
 import { getSyncedLfoHz, getSyncedSeconds, resolveExpressiveness } from './syncUtils';
 
 export interface SamplerNoteParams {
@@ -700,6 +701,11 @@ const playSampler = (
     stepTime: number = 0.2,
     tuning?: ScaleDefinition | null
 ) => {
+    const noteStr = Array.isArray(note) ? note[0] : note;
+    if (noteStr) {
+        pulseExpressionLed('sampler', noteStr);
+    }
+
     // Harmonize support - if harmonizer is active, generate multiple harmony voices
     const harmonizer = harmonizerRef.current;
     if (harmonizer?.getIsActive()) {
@@ -735,6 +741,7 @@ const playSampler = (
 
 const noteOnSampler = (params: SamplerBankParams, note: string, time?: number, tuning?: any): number | null => {
     const now = time || context.currentTime;
+    pulseExpressionLed('sampler', note);
 
     const multisampleBank = multisampleBanksRef.current.get(params.sampleName);
     const legacyBuffer = loadedSampleBuffersRef.current.get(params.sampleName);

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import type {
-    SamplerBankParams, AudioEngine
+    SamplerBankParams, AudioEngine, TrackAnalysers
 } from '../types';
 import { WebGpuOscillator } from '../engines/WebGpuOscillator';
 import { WasmOscillator } from '../engines/WasmOscillator';
@@ -42,6 +42,10 @@ export const useAudioEngine = (pyodide: unknown, tempo: number = 120) => {
     const singingVoiceManagerRef = useRef<SingingVoiceManager | null>(null);
     const drumKitEngineRef = useRef<DrumKitEngine | null>(null);
     const synthABusRef = useRef<GainNode | null>(null);
+    const synthBBusRef = useRef<GainNode | null>(null);
+    const samplerBusRef = useRef<GainNode | null>(null);
+    const analyserNodeRef = useRef<AnalyserNode | null>(null);
+    const trackAnalysersRef = useRef<TrackAnalysers>({});
     const prophecyManagerRef = useRef<ProphecyManager | null>(null);
 
     // Pre-stretched phoneme buffer pool (phoneme-aware time stretching)
@@ -128,6 +132,8 @@ export const useAudioEngine = (pyodide: unknown, tempo: number = 120) => {
         sidechainBusRef,
         drumKitEngineRef,
         synthABusRef,
+        synthBBusRef,
+        samplerBusRef,
         prophecyManagerRef,
     }), []);
 
@@ -141,6 +147,11 @@ export const useAudioEngine = (pyodide: unknown, tempo: number = 120) => {
 
         try {
             const lifecycleRefs: EngineLifecycleRefs = {
+                analyserNodeRef,
+                trackAnalysersRef,
+                synthABusRef,
+                synthBBusRef,
+                samplerBusRef,
                 masterGainRef,
                 masterPannerRef,
                 masterSaturationRef,
@@ -996,6 +1007,8 @@ export const useAudioEngine = (pyodide: unknown, tempo: number = 120) => {
                 masterSaturationRef,
                 masterPannerRef,
                 reverbTypeRef,
+                analyserNodeRef,
+                trackAnalysersRef,
             }, {
                 playSampler,
                 noteOnSampler,

--- a/src/stores/expressionLedStore.ts
+++ b/src/stores/expressionLedStore.ts
@@ -1,0 +1,64 @@
+/**
+ * Expression LED store — per-instrument note color + trigger envelope.
+ *
+ * Brightness is driven by a combination of AnalyserNode RMS (when wired) and
+ * a decaying envelope bumped on each note/drum trigger.
+ */
+
+import type { ExpressionLedTarget } from '../types';
+
+export type { ExpressionLedTarget };
+
+export interface ExpressionLedChannel {
+    noteColor: string;
+    envelope: number;
+}
+
+type Listener = () => void;
+
+const DECAY_PER_FRAME = 0.88;
+const MIN_ENVELOPE = 0.02;
+
+class ExpressionLedStore {
+    private channels = new Map<ExpressionLedTarget, ExpressionLedChannel>();
+    private listeners = new Set<Listener>();
+
+    pulse(target: ExpressionLedTarget, noteColor: string, envelope = 1): void {
+        this.channels.set(target, {
+            noteColor,
+            envelope: Math.max(0, Math.min(1, envelope)),
+        });
+        this.notify();
+    }
+
+    /** Decay envelopes — call once per animation frame. */
+    tick(): void {
+        let changed = false;
+        for (const [target, channel] of this.channels) {
+            const next = channel.envelope * DECAY_PER_FRAME;
+            if (next < MIN_ENVELOPE) {
+                this.channels.delete(target);
+                changed = true;
+            } else if (next !== channel.envelope) {
+                channel.envelope = next;
+                changed = true;
+            }
+        }
+        if (changed) this.notify();
+    }
+
+    getChannel(target: ExpressionLedTarget): ExpressionLedChannel | undefined {
+        return this.channels.get(target);
+    }
+
+    subscribe(listener: Listener): () => void {
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    }
+
+    private notify(): void {
+        for (const listener of this.listeners) listener();
+    }
+}
+
+export const expressionLedStore = new ExpressionLedStore();

--- a/src/types.ts
+++ b/src/types.ts
@@ -495,10 +495,20 @@ export interface Pattern {
   sampler: PartSequence[]; // Array of banks
 }
 
+/** Instruments that expose a color-coded expression LED in the rack UI. */
+export type ExpressionLedTarget =
+  | 'synthA' | 'synthB' | 'bass2'
+  | 'kick' | 'snare' | 'closedHat' | 'openHat'
+  | 'sampler';
+
+export type TrackAnalysers = Partial<Record<ExpressionLedTarget, AnalyserNode>>;
+
 export interface AudioEngine {
   context: AudioContext;
   /** Passive monitor tap on the master output — use for level meters and visualisers. */
   analyserNode?: AnalyserNode | null;
+  /** Per-instrument monitor taps for expression LEDs (when routed through a track bus). */
+  trackAnalysers?: TrackAnalysers;
   webGpuEngine?: WebGpuOscillator | null;
   wasmEngine?: WasmOscillator | null;
   open303Engine?: Open303Oscillator | Open303Manager | null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds hardware-style **expression LEDs** to every rack module (synths, drums, sampler). Each LED:

- **Brightens with loudness** — RMS from a per-track `AnalyserNode` when available, plus a decaying trigger envelope
- **Shows note color** — flashes the same hue as the color-coded sequencer when a note/step fires

## Implementation

| Piece | Role |
|-------|------|
| `ExpressionLed` | Canvas 2D circular LED with glow; driven by `useLevelMeter` + store |
| `expressionLedStore` | Per-instrument note color + decaying envelope on trigger |
| `pulseExpressionLed` | Called from `playSynth`, `playDrum`, `playSampler`, and live `noteOn` paths |
| Track monitor buses | Synth A, Synth B, and Sampler routed through passive analyser taps |
| `HardwareModule` | Renders LED in title bar next to AUTO button |

## Behavior by instrument

- **Synth A / B / Sampler** — real-time RMS from dedicated track bus + note hue on trigger
- **Bass 2 / Drums** — envelope + note hue (no separate bus yet; 303/drum one-shots are short)

Also wires the **master analyser** that `LevelMeter` expected but was never connected.

## Tests

- `src/__tests__/expressionLed.test.ts` — store decay + note color mapping

## Follow-ups (not in this PR)

- Effect-aware shader signatures (reverb wobble, delay trails, etc.)
- User toggle for LED mappings / monochrome accessibility mode
- Per-drum and Open303 bass analysers if we split those buses
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46093db6-e353-4efb-904e-e60f0c83bdc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46093db6-e353-4efb-904e-e60f0c83bdc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added animated expression LEDs to instrument panels, with colors reflecting played notes and instrument activity.
  * LEDs now respond to synthesizer, drum, and sampler playback in real time.
  * Added audio-level monitoring for smoother, track-specific LED animations.
  * Added accessible labels for expression LED indicators.

* **Tests**
  * Added coverage for LED pulsing, color selection, and envelope decay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->