### PR TITLE
🎨 Palette: Improve keyboard focus rings in MIDI Map and Engine Status

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -61,3 +61,6 @@
 ## 2026-07-14 - SongMode accessibility roving tabindex
 **Learning:** The ESLint/TypeScript parse error (e.g., `',' expected` or `Expression expected`) often reported around line 214 of `src/hooks/useAudioEngine.ts` is a known environmental false positive regarding valid destructuring (from `createSampleLibraryControls`). It shouldn't block unrelated scopes.
 **Action:** Ignore it or note it in the PR description, and do not attempt to fix this syntax if it surfaces during unrelated feature work.
+## 2024-07-16 - Handling blocked frontend verification
+**Learning:** If widespread, pre-existing syntax errors in unrelated files (e.g., `SamplerPanel.tsx`) prevent the local dev server from starting or the build from passing, it is impossible to run Playwright UI verification scripts.
+**Action:** When the build is fundamentally broken by external factors, document the issue, skip frontend Playwright verification (video/screenshots), and proceed directly to code review and submission, staying strictly scoped to the assigned accessibility task.

--- a/src/components/EngineStatusPill.tsx
+++ b/src/components/EngineStatusPill.tsx
@@ -78,7 +78,7 @@ export const EngineStatusPill: React.FC<EngineStatusPillProps> = memo(({
                     disabled={!d.retryable || d.status === 'recovering'}
                     title={`${d.message}: ${d.reason}`}
                     aria-label={`${d.subsystem} degraded: ${d.reason}. Click to retry.`}
-                    className="text-[7px] font-bold uppercase tracking-widest px-1.5 py-0.5 rounded-full border bg-amber-950/90 text-amber-300 border-amber-500/60 hover:bg-amber-900/90 disabled:opacity-60 touch-manipulation"
+                    className="text-[7px] font-bold uppercase tracking-widest px-1.5 py-0.5 rounded-full border bg-amber-950/90 text-amber-300 border-amber-500/60 hover:bg-amber-900/90 disabled:opacity-60 touch-manipulation focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus-visible:ring-amber-500"
                 >
                     {d.status === 'recovering' ? '…' : '!'} {d.subsystem}:{d.activeBackend}
                 </button>

--- a/src/components/MidiMapPanel.tsx
+++ b/src/components/MidiMapPanel.tsx
@@ -29,7 +29,7 @@ export const MidiMapPanel = memo(function MidiMapPanel({ onClose }: MidiMapPanel
           <button
             type="button"
             onClick={onClose}
-            className="text-gray-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 rounded p-1"
+            className="text-gray-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus-visible:ring-purple-500 rounded p-1"
             aria-label="Close MIDI Map"
           >
             <span aria-hidden="true">✕</span>
@@ -51,7 +51,7 @@ export const MidiMapPanel = memo(function MidiMapPanel({ onClose }: MidiMapPanel
               type="button"
               onClick={() => midiMapStore.toggleLearnMode()}
               aria-pressed={learnMode}
-              className={`px-3 py-1 text-[10px] font-bold font-orbitron rounded border transition-all ${
+              className={`px-3 py-1 text-[10px] font-bold font-orbitron rounded border transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus-visible:ring-purple-500 ${
                 learnMode
                   ? 'bg-purple-600 text-white border-purple-400 animate-pulse'
                   : 'bg-zinc-900 text-purple-400 border-purple-900/50 hover:bg-purple-950/40'
@@ -88,7 +88,7 @@ export const MidiMapPanel = memo(function MidiMapPanel({ onClose }: MidiMapPanel
                     <button
                       type="button"
                       onClick={() => midiMapStore.removeBinding(m.key, m.deviceId)}
-                      className="text-[10px] text-red-400 hover:text-red-300 shrink-0 px-2 py-0.5 border border-red-900/40 rounded"
+                      className="text-[10px] text-red-400 hover:text-red-300 shrink-0 px-2 py-0.5 border border-red-900/40 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus-visible:ring-red-500"
                       aria-label={`Remove mapping for ${m.controlId}`}
                     >
                       CLEAR
@@ -105,7 +105,7 @@ export const MidiMapPanel = memo(function MidiMapPanel({ onClose }: MidiMapPanel
               onClick={() => {
                 if (window.confirm('Clear all MIDI mappings?')) midiMapStore.clearAllBindings();
               }}
-              className="w-full text-[10px] font-bold text-red-400 border border-red-900/40 rounded py-2 hover:bg-red-950/30"
+              className="w-full text-[10px] font-bold text-red-400 border border-red-900/40 rounded py-2 hover:bg-red-950/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus-visible:ring-red-500"
             >
               CLEAR ALL MAPPINGS
             </button>


### PR DESCRIPTION
Added comprehensive `focus-visible` states to buttons in `MidiMapPanel` and `EngineStatusPill` for better keyboard accessibility.

- `MidiMapPanel.tsx`: Added `focus-visible:ring-offset-2` styling to the close button, MIDI learn toggle, individual clear buttons, and clear all mappings button.
- `EngineStatusPill.tsx`: Added `focus-visible:ring-offset-2` styling to the degradation retry button.

*Note on verification: The local dev server and build are currently failing due to massive pre-existing syntax errors in `SamplerPanel.tsx` and other unrelated files, which blocked Playwright video/screenshot verification. The changes submitted are isolated Tailwind string additions.*

---
*PR created automatically by Jules for task [10621475887547898618](https://jules.google.com/task/10621475887547898618) started by @ford442*