### PR TITLE
🎨 Palette: UX and Accessibility Improvements

### DIFF
--- a/src/components/LyricTrack.tsx
+++ b/src/components/LyricTrack.tsx
@@ -41,7 +41,7 @@ export const LyricTrack: React.FC<LyricTrackProps> = React.memo(({
                     }
                 }}
             />
-            <button
+            <button type="button"
                 onClick={() => onApply(text)}
                 disabled={isGenerating || !text.trim()}
                 aria-busy={isGenerating}
@@ -49,7 +49,7 @@ export const LyricTrack: React.FC<LyricTrackProps> = React.memo(({
             >
                 {isGenerating ? 'GENERATING...' : 'APPLY TO TRACK'}
             </button>
-            <button
+            <button type="button"
                 onClick={onClose}
                 className="px-2 py-1.5 text-gray-500 hover:text-white"
                 aria-label="Close Lyric Track"

--- a/src/components/WaveformDisplay.tsx
+++ b/src/components/WaveformDisplay.tsx
@@ -692,7 +692,7 @@ export const WaveformDisplay: React.FC<WaveformDisplayProps> = memo(({ buffer, a
                             />
                         </div>
                     )}
-                    <button
+                    <button type="button"
                         onClick={(e) => {
                             e.stopPropagation();
                             onAutoSlice();

--- a/src/components/WaveformSelector.tsx
+++ b/src/components/WaveformSelector.tsx
@@ -188,7 +188,7 @@ export const WaveformSelector: React.FC<WaveformSelectorProps> = React.memo(({ s
   return (
     <div className="relative inline-block" ref={containerRef}>
       {/* Compact trigger button - always visible */}
-      <button
+      <button type="button"
         ref={triggerRef}
         onClick={() => setIsExpanded(!isExpanded)}
         aria-label={`Waveform selector: ${selected}. Click to ${isExpanded ? 'collapse' : 'expand'} options. Click to cycle, Shift+click for reverse.`}
@@ -215,7 +215,7 @@ export const WaveformSelector: React.FC<WaveformSelectorProps> = React.memo(({ s
             {/* Left side: Current waveform display and cycle button */}
             <div className="flex flex-col gap-2 border-r border-gray-700 pr-2">
               <div className="text-xs font-bold uppercase tracking-wider text-gray-400 text-center">Current</div>
-              <button
+              <button type="button"
                 onClick={handleWaveformClick}
                 aria-label={`Current waveform: ${selected}. Click to cycle, Shift+click to cycle back.`}
                 title={`Current: ${selected}. Click to cycle, Shift+click for reverse.`}
@@ -236,7 +236,7 @@ export const WaveformSelector: React.FC<WaveformSelectorProps> = React.memo(({ s
                   {/* Waveform buttons in a row */}
                   <div className="flex flex-wrap gap-1 px-2">
                     {group.items.map((wave) => (
-                      <button
+                      <button type="button"
                         key={wave}
                         onClick={() => { onChange(wave); }}
                         aria-pressed={selected === wave}

--- a/src/components/automation/CurveEditor.tsx
+++ b/src/components/automation/CurveEditor.tsx
@@ -221,7 +221,7 @@ export const CurveEditor = memo(({
   }
 
   return (
-    <svg aria-hidden="true"
+    <svg
       ref={svgRef}
       width={width}
       height={height}


### PR DESCRIPTION
This PR adds `type="button"` to the remaining `<button>` tags that were missing it in `LyricTrack`, `WaveformDisplay`, and `WaveformSelector`.

It also fixes an accessibility issue in `CurveEditor`, where the root `<svg>` had `aria-hidden="true"`, causing screen readers to completely ignore it and its `aria-label`.

---
*PR created automatically by Jules for task [8577377655232326456](https://jules.google.com/task/8577377655232326456) started by @ford442*