### PR TITLE
🎨 Palette: Add tooltips to SongMode measure control buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -64,3 +64,6 @@
 ## 2024-07-16 - Handling blocked frontend verification
 **Learning:** If widespread, pre-existing syntax errors in unrelated files (e.g., `SamplerPanel.tsx`) prevent the local dev server from starting or the build from passing, it is impossible to run Playwright UI verification scripts.
 **Action:** When the build is fundamentally broken by external factors, document the issue, skip frontend Playwright verification (video/screenshots), and proceed directly to code review and submission, staying strictly scoped to the assigned accessibility task.
+## 2026-07-20 - SongMode Add/Remove Measure Button Tooltips
+**Learning:** Quick-action control buttons in interactive sequence builders (like adding/removing measures in `SongMode.tsx`) often lack `title` tooltips, even when they have an `aria-label`. While `aria-label` provides screen reader support, visual users without screen readers rely on hover tooltips to clarify the meaning of small or abbreviated buttons (like `- BAR` or `+ BAR`).
+**Action:** When auditing quick-action panels, explicitly verify that all control buttons include a `title` tooltip alongside their `aria-label` to provide context for both sighted mouse users and assistive technology users.

--- a/src/components/SongMode.tsx
+++ b/src/components/SongMode.tsx
@@ -364,8 +364,8 @@ export const SongMode = memo(forwardRef<SongModeHandle, SongModeProps & { is3D?:
                 <div className="h-14 bg-gradient-to-r from-[#0b0d10] to-[#0d0f12] border-b-2 border-cyan-900/30 flex items-center justify-between px-6 shrink-0 relative">
                      <h2 className="font-orbitron font-bold text-cyan-400 tracking-widest">SONG ARRANGER</h2>
                      <div className="flex gap-3 items-center">
-                        <button type="button" onClick={onRemoveMeasure} aria-label="Remove Measure" className="px-3 py-1.5 bg-gray-800 text-gray-300 text-xs rounded-lg border border-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500">- BAR</button>
-                        <button type="button" onClick={onAddMeasure} aria-label="Add Measure" className="px-3 py-1.5 bg-gray-800 text-cyan-300 text-xs rounded-lg border border-cyan-900/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500">+ BAR</button>
+                        <button type="button" onClick={onRemoveMeasure} aria-label="Remove Measure" title="Remove Measure" className="px-3 py-1.5 bg-gray-800 text-gray-300 text-xs rounded-lg border border-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500">- BAR</button>
+                        <button type="button" onClick={onAddMeasure} aria-label="Add Measure" title="Add Measure" className="px-3 py-1.5 bg-gray-800 text-cyan-300 text-xs rounded-lg border border-cyan-900/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500">+ BAR</button>
                         <button type="button"
                             onClick={() => onSetIsSongModeActive(!isSongModeActive)}
                             aria-pressed={isSongModeActive}
@@ -475,8 +475,8 @@ export const SongMode = memo(forwardRef<SongModeHandle, SongModeProps & { is3D?:
                             ><span aria-hidden="true">✕</span></button>
                         )}
                     </div>
-                    <button type="button" onClick={onRemoveMeasure} aria-label="Remove Measure" className="px-3 py-1.5 bg-gradient-to-r from-gray-800 to-gray-700 text-gray-300 text-xs rounded-lg hover:from-gray-700 hover:to-gray-600 border border-gray-600 shadow-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500">- BAR</button>
-                    <button type="button" onClick={onAddMeasure} aria-label="Add Measure" className="px-3 py-1.5 bg-gradient-to-r from-gray-800 to-gray-700 text-cyan-300 text-xs rounded-lg hover:from-gray-700 hover:to-gray-600 border border-cyan-900/50 shadow-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500">+ BAR</button>
+                    <button type="button" onClick={onRemoveMeasure} aria-label="Remove Measure" title="Remove Measure" className="px-3 py-1.5 bg-gradient-to-r from-gray-800 to-gray-700 text-gray-300 text-xs rounded-lg hover:from-gray-700 hover:to-gray-600 border border-gray-600 shadow-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500">- BAR</button>
+                    <button type="button" onClick={onAddMeasure} aria-label="Add Measure" title="Add Measure" className="px-3 py-1.5 bg-gradient-to-r from-gray-800 to-gray-700 text-cyan-300 text-xs rounded-lg hover:from-gray-700 hover:to-gray-600 border border-cyan-900/50 shadow-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500">+ BAR</button>
                     <button type="button"
                         onClick={() => onSetIsSongModeActive(!isSongModeActive)}
                         aria-pressed={isSongModeActive}


### PR DESCRIPTION
💡 **What:** Added missing `title` tooltips to the Add/Remove measure buttons (`+ BAR` and `- BAR`) in `SongMode.tsx`.
🎯 **Why:** To provide immediate visual context for sighted mouse users hovering over the abbreviated buttons, ensuring parity with the existing `aria-label` for screen reader users.
♿ **Accessibility:** Enhances overall usability by surfacing the hidden `aria-label` context to standard visual hover interactions.

---
*PR created automatically by Jules for task [15879187185769013403](https://jules.google.com/task/15879187185769013403) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the “− BAR” and “+ BAR” measure controls with gradient backgrounds, hover transitions, shadows, and smoother visual transitions.
  - Preserved visible focus indicators for keyboard navigation across display modes.

- **Accessibility**
  - Documented that measure control buttons should provide visible tooltips alongside accessible labels, helping users understand each action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->