### PR TITLE
🎨 Palette: Add tooltips to SongModeToolbar buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -67,3 +67,6 @@
 ## 2026-07-20 - SongMode Add/Remove Measure Button Tooltips
 **Learning:** Quick-action control buttons in interactive sequence builders (like adding/removing measures in `SongMode.tsx`) often lack `title` tooltips, even when they have an `aria-label`. While `aria-label` provides screen reader support, visual users without screen readers rely on hover tooltips to clarify the meaning of small or abbreviated buttons (like `- BAR` or `+ BAR`).
 **Action:** When auditing quick-action panels, explicitly verify that all control buttons include a `title` tooltip alongside their `aria-label` to provide context for both sighted mouse users and assistive technology users.
+## 2026-07-24 - SongModeToolbar Title Attributes
+**Learning:** Toolbar buttons with abbreviated text labels (like "Pat+", "Ins", "Dup") rely heavily on `aria-label` for screen readers, but sighted users without assistive tech also need context to understand them. Adding `title` tooltips bridges this gap.
+**Action:** When implementing or auditing toolbars with icon-only or heavily abbreviated buttons, ensure that every button has a `title` attribute that matches its `aria-label`.

--- a/src/components/songMode/SongModeToolbar.tsx
+++ b/src/components/songMode/SongModeToolbar.tsx
@@ -1,104 +1,152 @@
-import React, { memo } from 'react';
+import React, { memo } from "react";
 
 interface SongModeToolbarProps {
-    selectionCount: number;
-    canUndo: boolean;
-    canRedo: boolean;
-    onClear: () => void;
-    onCycleUp: () => void;
-    onCycleDown: () => void;
-    onCopy: () => void;
-    onPaste: () => void;
-    onUndo: () => void;
-    onRedo: () => void;
-    onDuplicateMeasure: () => void;
-    onInsertMeasure: () => void;
-    onRemoveMeasureAt: () => void;
-    compact?: boolean;
+  selectionCount: number;
+  canUndo: boolean;
+  canRedo: boolean;
+  onClear: () => void;
+  onCycleUp: () => void;
+  onCycleDown: () => void;
+  onCopy: () => void;
+  onPaste: () => void;
+  onUndo: () => void;
+  onRedo: () => void;
+  onDuplicateMeasure: () => void;
+  onInsertMeasure: () => void;
+  onRemoveMeasureAt: () => void;
+  compact?: boolean;
 }
 
 export const SongModeToolbar = memo(function SongModeToolbar({
-    selectionCount,
-    canUndo,
-    canRedo,
-    onClear,
-    onCycleUp,
-    onCycleDown,
-    onCopy,
-    onPaste,
-    onUndo,
-    onRedo,
-    onDuplicateMeasure,
-    onInsertMeasure,
-    onRemoveMeasureAt,
-    compact = false,
+  selectionCount,
+  canUndo,
+  canRedo,
+  onClear,
+  onCycleUp,
+  onCycleDown,
+  onCopy,
+  onPaste,
+  onUndo,
+  onRedo,
+  onDuplicateMeasure,
+  onInsertMeasure,
+  onRemoveMeasureAt,
+  compact = false,
 }: SongModeToolbarProps) {
-    const btn =
-        'px-2 py-1 text-[10px] rounded border font-mono transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 disabled:opacity-40 disabled:cursor-not-allowed';
-    const activeBtn = `${btn} bg-gray-800 text-cyan-300 border-cyan-900/50 hover:bg-gray-700`;
-    const mutedBtn = `${btn} bg-gray-900/60 text-gray-400 border-gray-700 hover:bg-gray-800`;
+  const btn =
+    "px-2 py-1 text-[10px] rounded border font-mono transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 disabled:opacity-40 disabled:cursor-not-allowed";
+  const activeBtn = `${btn} bg-gray-800 text-cyan-300 border-cyan-900/50 hover:bg-gray-700`;
+  const mutedBtn = `${btn} bg-gray-900/60 text-gray-400 border-gray-700 hover:bg-gray-800`;
 
-    return (
-        <div
-            className={`flex flex-wrap items-center gap-1 ${compact ? 'px-2 py-1' : 'px-3 py-1.5'} bg-gray-900/40 border border-gray-800 rounded-lg`}
-            role="toolbar"
-            aria-label="Song arrangement editing tools"
-        >
-            <button type="button" className={mutedBtn} onClick={onUndo} disabled={!canUndo} aria-label="Undo song edit">
-                Undo
-            </button>
-            <button type="button" className={mutedBtn} onClick={onRedo} disabled={!canRedo} aria-label="Redo song edit">
-                Redo
-            </button>
-            <span className="w-px h-4 bg-gray-700 mx-1" aria-hidden />
-            <button
-                type="button"
-                className={activeBtn}
-                onClick={onClear}
-                disabled={selectionCount === 0}
-                aria-label="Clear selected cells"
-            >
-                Clear
-            </button>
-            <button
-                type="button"
-                className={activeBtn}
-                onClick={onCycleUp}
-                disabled={selectionCount === 0}
-                aria-label="Cycle pattern up in selection"
-            >
-                Pat+
-            </button>
-            <button
-                type="button"
-                className={activeBtn}
-                onClick={onCycleDown}
-                disabled={selectionCount === 0}
-                aria-label="Cycle pattern down in selection"
-            >
-                Pat−
-            </button>
-            <button type="button" className={activeBtn} onClick={onCopy} disabled={selectionCount === 0} aria-label="Copy selection">
-                Copy
-            </button>
-            <button type="button" className={activeBtn} onClick={onPaste} aria-label="Paste at selection anchor">
-                Paste
-            </button>
-            <span className="w-px h-4 bg-gray-700 mx-1" aria-hidden />
-            <button type="button" className={mutedBtn} onClick={onInsertMeasure} aria-label="Insert measure after selection">
-                Ins
-            </button>
-            <button type="button" className={mutedBtn} onClick={onDuplicateMeasure} aria-label="Duplicate measure at selection">
-                Dup
-            </button>
-            <button type="button" className={mutedBtn} onClick={onRemoveMeasureAt} aria-label="Remove measure at selection">
-                Del
-            </button>
-            {selectionCount > 0 && (
-                <span className="text-[10px] text-gray-500 ml-1" aria-live="polite">
-                    {selectionCount} sel
-                </span>
-            )}
-        </div>
-    );
+  return (
+    <div
+      className={`flex flex-wrap items-center gap-1 ${compact ? "px-2 py-1" : "px-3 py-1.5"} bg-gray-900/40 border border-gray-800 rounded-lg`}
+      role="toolbar"
+      aria-label="Song arrangement editing tools"
+    >
+      <button
+        type="button"
+        className={mutedBtn}
+        onClick={onUndo}
+        disabled={!canUndo}
+        aria-label="Undo song edit"
+        title="Undo song edit"
+      >
+        Undo
+      </button>
+      <button
+        type="button"
+        className={mutedBtn}
+        onClick={onRedo}
+        disabled={!canRedo}
+        aria-label="Redo song edit"
+        title="Redo song edit"
+      >
+        Redo
+      </button>
+      <span className="w-px h-4 bg-gray-700 mx-1" aria-hidden />
+      <button
+        type="button"
+        className={activeBtn}
+        onClick={onClear}
+        disabled={selectionCount === 0}
+        aria-label="Clear selected cells"
+        title="Clear selected cells"
+      >
+        Clear
+      </button>
+      <button
+        type="button"
+        className={activeBtn}
+        onClick={onCycleUp}
+        disabled={selectionCount === 0}
+        aria-label="Cycle pattern up in selection"
+        title="Cycle pattern up in selection"
+      >
+        Pat+
+      </button>
+      <button
+        type="button"
+        className={activeBtn}
+        onClick={onCycleDown}
+        disabled={selectionCount === 0}
+        aria-label="Cycle pattern down in selection"
+        title="Cycle pattern down in selection"
+      >
+        Pat−
+      </button>
+      <button
+        type="button"
+        className={activeBtn}
+        onClick={onCopy}
+        disabled={selectionCount === 0}
+        aria-label="Copy selection"
+        title="Copy selection"
+      >
+        Copy
+      </button>
+      <button
+        type="button"
+        className={activeBtn}
+        onClick={onPaste}
+        aria-label="Paste at selection anchor"
+        title="Paste at selection anchor"
+      >
+        Paste
+      </button>
+      <span className="w-px h-4 bg-gray-700 mx-1" aria-hidden />
+      <button
+        type="button"
+        className={mutedBtn}
+        onClick={onInsertMeasure}
+        aria-label="Insert measure after selection"
+        title="Insert measure after selection"
+      >
+        Ins
+      </button>
+      <button
+        type="button"
+        className={mutedBtn}
+        onClick={onDuplicateMeasure}
+        aria-label="Duplicate measure at selection"
+        title="Duplicate measure at selection"
+      >
+        Dup
+      </button>
+      <button
+        type="button"
+        className={mutedBtn}
+        onClick={onRemoveMeasureAt}
+        aria-label="Remove measure at selection"
+        title="Remove measure at selection"
+      >
+        Del
+      </button>
+      {selectionCount > 0 && (
+        <span className="text-[10px] text-gray-500 ml-1" aria-live="polite">
+          {selectionCount} sel
+        </span>
+      )}
+    </div>
+  );
 });


### PR DESCRIPTION
💡 **What:** Added `title` attributes matching the existing `aria-label`s to all buttons in the `SongModeToolbar` component.

🎯 **Why:** The buttons in this toolbar use extreme abbreviations ("Pat+", "Pat-", "Ins", "Dup", "Del") or generic text ("Undo", "Clear") to fit in a compact space. While screen readers had context via `aria-label`, sighted users had to guess their function. Adding tooltips makes the interface instantly intuitive without cluttering the UI.

📸 **Before/After:** No layout changes. Hovering over a button now shows a native browser tooltip (e.g. hovering "Pat+" shows "Cycle pattern up in selection").

♿ **Accessibility:** Improves cognitive accessibility by providing clarifying context on hover for users who may struggle with abstract abbreviations.

---
*PR created automatically by Jules for task [18120432305633724354](https://jules.google.com/task/18120432305633724354) started by @ford442*