### PR TITLE
Fix TypeScript syntax errors in HarmonizerPopover and useAudioEngine

### DIFF
--- a/src/components/sampler/HarmonizerPopover.tsx
+++ b/src/components/sampler/HarmonizerPopover.tsx
@@ -57,6 +57,8 @@ export const HarmonizerPopover: React.FC<HarmonizerPopoverProps> = React.memo(({
 
     const handleHarmonyReleaseChange = (value: number) => {
         setLocalConfig(prev => ({ ...prev, harmonyRelease: value }));
+    };
+
     const handleEnvAttackChange = (value: number) => {
         setLocalConfig(prev => ({ ...prev, envAttack: value }));
     };
@@ -580,69 +582,6 @@ export const HarmonizerPopover: React.FC<HarmonizerPopoverProps> = React.memo(({
                             </div>
                         </div>
                     </div>
-{/* Harmony Attack - Styled slider */}
-<div className="space-y-2">
-    <div className="flex justify-between items-center">
-        <label htmlFor="harmonizer-attack" className="text-[9px] font-mono text-gray-400 uppercase tracking-wider">Attack</label>
-        <span className="text-[9px] font-mono font-bold px-1.5 py-0.5 rounded bg-zinc-950 border border-zinc-800" style={{ color, textShadow: `0 0 8px ${color}40` }}>
-            {(localConfig.harmonyAttack ?? 0.1).toFixed(2)}s
-        </span>
-    </div>
-    <div className="relative h-5 bg-zinc-900 rounded-md border border-zinc-700 overflow-hidden shadow-[inset_0_2px_4px_rgba(0,0,0,0.5)]">
-        <div
-            className="absolute inset-y-0.5 left-0.5 rounded-sm transition-all"
-            style={{
-                width: `${((localConfig.harmonyAttack ?? 0.1) / 2.0) * 100}%`,
-                background: `linear-gradient(90deg, ${color}40 0%, ${color} 100%)`,
-                boxShadow: `0 0 10px ${color}40`
-            }}
-        />
-        <input
-            type="range"
-            min="0"
-            max="2"
-            step="0.01"
-            value={localConfig.harmonyAttack ?? 0.1}
-            onChange={(e) => handleHarmonyAttackChange(parseFloat(e.target.value))}
-            id="harmonizer-attack"
-            className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
-            aria-label="Harmony Attack Time"
-            aria-valuetext={`${(localConfig.harmonyAttack ?? 0.1).toFixed(2)} seconds`}
-        />
-    </div>
-</div>
-
-{/* Harmony Release - Styled slider */}
-<div className="space-y-2">
-    <div className="flex justify-between items-center">
-        <label htmlFor="harmonizer-release" className="text-[9px] font-mono text-gray-400 uppercase tracking-wider">Release</label>
-        <span className="text-[9px] font-mono font-bold px-1.5 py-0.5 rounded bg-zinc-950 border border-zinc-800" style={{ color, textShadow: `0 0 8px ${color}40` }}>
-            {(localConfig.harmonyRelease ?? 0.3).toFixed(2)}s
-        </span>
-    </div>
-    <div className="relative h-5 bg-zinc-900 rounded-md border border-zinc-700 overflow-hidden shadow-[inset_0_2px_4px_rgba(0,0,0,0.5)]">
-        <div
-            className="absolute inset-y-0.5 left-0.5 rounded-sm transition-all"
-            style={{
-                width: `${((localConfig.harmonyRelease ?? 0.3) / 2.0) * 100}%`,
-                background: `linear-gradient(90deg, ${color}40 0%, ${color} 100%)`,
-                boxShadow: `0 0 10px ${color}40`
-            }}
-        />
-        <input
-            type="range"
-            min="0"
-            max="2"
-            step="0.01"
-            value={localConfig.harmonyRelease ?? 0.3}
-            onChange={(e) => handleHarmonyReleaseChange(parseFloat(e.target.value))}
-            id="harmonizer-release"
-            className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
-            aria-label="Harmony Release Time"
-            aria-valuetext={`${(localConfig.harmonyRelease ?? 0.3).toFixed(2)} seconds`}
-        />
-    </div>
-</div>
 
                     {/* Presets - Hardware button style */}
                     <div className="pt-2 border-t border-zinc-800/50">

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -36,8 +36,6 @@ import {
 } from './audioEngine/initialization';
 import { engineTelemetry } from '../utils/engineTelemetry';
 import { initializeAudioContextAndEngines, type EngineLifecycleRefs } from './audioEngine/engineLifecycle';
-import { createPhonemeAlignmentWrappers } from './audioEngine/phonemePoolWarming';
-import { createSamplerPlayback } from './audioEngine/samplerPlayback';
 import { buildAudioEngine } from './audioEngine/engineApiBuilder';
 
 export { getSyncedSeconds, getSyncedLfoHz } from './audioEngine/syncUtils';
@@ -1222,46 +1220,6 @@ export const useAudioEngine = (pyodide: unknown, tempo: number = 120) => {
             const setHarmonizerConfig = (config: HarmonizerConfig, isActive: boolean) => applyHarmonizerConfig(harmonizerRef, config, isActive);
             const updateSamplerVoiceParams = (_bankIdx: number, _key: string, _value: number | string | boolean) => {};
 
-            // Re-assign to state
-            setAudioEngine({
-                context,
-                webGpuEngine: gpuEngineRef.current,
-                wasmEngine: wasmEngineRef.current,
-                open303Engine: open303ManagerRef.current as any,
-                singingVoice: undefined,
-                playSynth,
-                playDrum,
-            const { prepareVocal, setAlignment } = createPhonemeAlignmentWrappers(
-                {
-                    phonemeBufferPoolRef,
-                    vocalAlignmentsRef,
-                    multisampleBanksRef,
-                    loadedSampleBuffersRef,
-                },
-                prepareVocalBase,
-                setAlignmentBase,
-            );
-
-            const { playSampler, noteOnSampler, noteOffSampler } = createSamplerPlayback(
-                context,
-                {
-                    masterSaturationRef,
-                    singingVoiceManagerRef,
-                    vocalAlignmentsRef,
-                    loadedSampleBuffersRef,
-                    multisampleBanksRef,
-                    choirLeftGainRef,
-                    choirRightGainRef,
-                    reverbNodesRef,
-                    reverbTypeRef,
-                    delayNodeRef,
-                    harmonizerRef,
-                    nextSamplerNoteId,
-                    activeSamplerNotes,
-                },
-                tempo,
-            );
-
             setAudioEngine(buildAudioEngine(context, {
                 ...playbackRefs,
                 gpuEngineRef,
@@ -1279,18 +1237,6 @@ export const useAudioEngine = (pyodide: unknown, tempo: number = 120) => {
                 noteOnSampler,
                 noteOffSampler,
                 loadSampleToEngine,
-                renderSynthPartToBuffer,
-                playBufferedPart,
-                playAmbiance,
-                stopAmbiance,
-                setAmbianceVolume,
-                setMasterVolume,
-                setMasterSaturation,
-                setGlobalPan,
-                setReverbType,
-                detectSamplePitch,
-                processSinging,
-                processSpoon,
                 prepareVocal,
                 getAlignment,
                 setAlignment,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the 11 TypeScript syntax errors reported during `tsc -b`:

- **`HarmonizerPopover.tsx`**: `handleHarmonyReleaseChange` was missing a closing `};`, which broke parsing of the component and caused the `',' expected` error at the `React.memo` closing `});`. Also removed a duplicate harmony attack/release slider block that had been pasted outside the JSX tree.
- **`useAudioEngine.ts`**: Removed a broken partial refactor where a new `setAudioEngine({ ...` object literal was started inside `initializeAudio` but never closed, with `const` declarations nested inside it. Restored the intended `setAudioEngine(buildAudioEngine(...))` call and trimmed the playback-fn payload to match `EngineApiPlaybackFns`.

The `vite.config.ts` module-resolution errors are environment-related (missing `node_modules` / devDependencies) and were not reproducible once dependencies were installed.

## Test plan

- [x] `npx tsc -b` — no more `TS1005` errors in the three reported files
- [ ] `pnpm run dev` — app loads and audio initializes
- [ ] Open harmonizer popover in sampler — UI renders without console errors
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f6814ee-4e36-4162-bd02-f8deca87f690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f6814ee-4e36-4162-bd02-f8deca87f690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

