### PR TITLE
fix(ci): restore green lint gate and add pre-push guardrail

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+pnpm install --frozen-lockfile && pnpm exec tsc -b && pnpm lint

--- a/.swarm-state.md
+++ b/.swarm-state.md
@@ -1,103 +1,23 @@
-# CI gate hardening + useAudioEngine type cleanup — FINAL
+# Swarm State — CI gate restore (2026-07-20)
 
-Session: 2026-07-07
+**Status: DONE — all 5 gate steps green**
 
-## Objective
-Make `src/hooks/useAudioEngine.ts` compile cleanly with no `as any` casts, close the CI gaps that let a non-parsing file ship, and remove an unused dependency.
+## Gate results
+1. `pnpm install --frozen-lockfile` — pass
+2. `pnpm run build:wasm` — pass
+3. `pnpm exec tsc -b` — pass
+4. `pnpm lint` — pass (0 errors)
+5. `pnpm test` — pass (1280 tests)
 
-## Task board
+## Fixed this pass
+- `src/engines/SingingVoice.ts` — already had scoped eslint-disable for mixin merge (no change needed)
+- `src/hooks/useAudioEngine.ts` — removed all 13 `as any` casts; used existing `Note`/`SamplerBankParams` props
+- `.husky/pre-push` — runs `pnpm install --frozen-lockfile && pnpm exec tsc -b && pnpm lint`
+- `package.json` — added `prepare: husky`, `husky@^9.1.7` devDep
+- Pre-push hook verified: blocks on tsc/lint failure (exit 2), passes when clean (exit 0)
 
-| # | Task | Status |
-|---|------|--------|
-| 1 | Confirm parse fix and document it | DONE |
-| 2 | Strip `as any` casts and add missing `Note` properties | DONE |
-| 3 | Add `tsc` gate and un-mask lint in `ci.yml` | DONE |
-| 4 | Delete redundant `debug_build.yml` | DONE |
-| 5 | Remove `@babel/helper-plugin-utils` and regenerate lockfile | DONE |
-| 6 | Run full verification suite | DONE |
-
-## Parse fix
-
-- **Command:** `npx esbuild src/hooks/useAudioEngine.ts --loader:.ts=ts --log-level=warning >/dev/null`
-- **Result:** exit 0 ✅
-- **Root cause (main):** `origin/main` had an unbalanced parenthesis inside the inline `playSamplerVoice`/`triggerVoice`/`runVoices`/`playBufferSource` sampler-voice block (roughly lines 900–1013). The parser reached the `};` closing the arrow function at line 1013 while still inside an unclosed call argument list.
-- **Fix in this branch:** commit `247789f` replaced that inline block with the hoisted `SamplerVoiceContext` / `triggerVoice` / `playBufferSource` refactor, restoring syntactic balance. No additional structural change was required.
-
-## `as any` cleanup
-
-### Typing changes in `src/hooks/useAudioEngine.ts`
-- Imported `Note` from `'../types'`.
-- Typed `SamplerVoiceContext.noteParams` as `Note | undefined` (was `any`).
-- Typed `SamplerVoiceContext.morphTarget` as `NonNullable<SamplerBankParams['morphTarget']>` (was `string`).
-- Typed `playSampler` and `playSamplerVoice` `noteParams` parameters as `Note | undefined` instead of a hand-rolled inline object.
-- Typed `SamplerVoiceContext.spectralPanDepth` as `number | undefined` to match its runtime defaulting.
-- Replaced the harmony-voice object spread with an explicit `Note` construction so the per-step type's required `note` field is satisfied.
-
-### Casts removed (all 19 occurrences)
-| Old line | Cast | Replacement |
-|---|---|---|
-| 439 | `ctx.morphTarget as any` | direct `ctx.morphTarget` |
-| 542 | `(ctx.noteParams as any)?.pitchAttack` | `ctx.noteParams?.pitchAttack` |
-| 548–549 | `(voice as any).setPitchAmount` | direct `voice.setPitchAmount` guard/call |
-| 1364 | `createPlayDrum(...) as any` | direct assignment |
-| 1494–1497 | `(noteParams as any)?.vocoderFormantShift` etc. | direct access |
-| 1500–1501 | `(params as any).spectralPanRate` / `.spectralPanDepth` | direct access |
-| 1506 | `(noteParams as any)?.reverbType` | direct access |
-| 1560–1561 | `(noteParams as any)?.grainPitchEnvDepth` / `.grainJitter` | direct access |
-| 1591–1592 | `(noteParams as any)?.pitchDecay` / `.pitchAmount` | direct access |
-| 1919 | `open303ManagerRef.current as any` | direct assignment |
-
-`grep -c "as any" src/hooks/useAudioEngine.ts` → **0**.
-
-### Properties added to `Note` in `src/types.ts`
-These were genuinely missing from the per-step type and are now read without casts:
-```ts
-slideFromMidi?: number;
-slideFromFormant?: number;
-slideType?: 'linear' | 'exponential';
-characterMorph?: number;
-isHarmonyVoice?: boolean;
-grainPitchQuantize?: number;
-formantLfoShape?: number[];
-customLfoShape?: number[];
+## Resume commands (if needed)
+```bash
+git checkout cursor/restore-ci-lint-guardrail-75c5
+pnpm install --frozen-lockfile && pnpm run build:wasm && pnpm exec tsc -b && pnpm lint && pnpm test
 ```
-
-## CI changes
-
-### `.github/workflows/ci.yml`
-- Added `Type-check (tsc)` step immediately after `Build WASM artifacts`.
-- Removed `continue-on-error: true` from the Lint step because `pnpm run lint` is now clean.
-
-### `.github/workflows/debug_build.yml`
-- **Deleted.** It was invalid YAML (Setup Rust step nested under `setup-node.with`), used `--no-frozen-lockfile`, and was fully superseded by `ci.yml` (WASM + tests) and `playwright-e2e.yml` (full Vite build + E2E).
-
-## Dependency change
-
-- Removed direct devDependency `@babel/helper-plugin-utils` from `package.json`.
-- Regenerated `pnpm-lock.yaml` with `pnpm install`.
-- Verified `pnpm install --frozen-lockfile` passes.
-
-## Final verification status
-
-| Command | Status | Notes |
-|---------|--------|-------|
-| `npx esbuild src/hooks/useAudioEngine.ts --loader:.ts=ts --log-level=warning >/dev/null` | ✅ PASS | exit 0 |
-| `pnpm exec tsc -b` | ✅ PASS | 0 errors |
-| `pnpm run lint` | ✅ PASS | clean |
-| `pnpm run build:wasm && pnpm test` | ✅ PASS | 1183 passed, 2 skipped |
-| `pnpm run build` | ✅ PASS | `dist/` produced |
-| `pnpm install --frozen-lockfile` | ✅ PASS | lockfile consistent |
-| Workflow YAML parse | ✅ PASS | `ci.yml` + `playwright-e2e.yml` valid |
-| `grep -c "as any" src/hooks/useAudioEngine.ts` | ✅ PASS | 0 |
-
-## Commits
-
-- `fix(types): remove as any casts from useAudioEngine and add missing Note properties`
-- `ci: add tsc gate, remove lint continue-on-error, delete redundant debug_build.yml`
-- `chore(deps): remove unused @babel/helper-plugin-utils and regenerate lockfile`
-- `docs(swarm-state): record final gate state`
-
-## Notes
-
-- Generated WASM artifacts (`public/hyphon_wasm_export_map.json`, `src/wasm/*.wasm`, etc.) were rebuilt by the verification commands but were not committed; they are produced by CI/build scripts.
-- `debug_build.yml`'s artifact-upload behavior is covered by `playwright-e2e.yml`'s full build; if a standalone artifact upload is needed later, add the upload step to `playwright-e2e.yml` rather than reviving the broken workflow.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "hyphon-daw",
-  "workspaces": ["."],
+  "workspaces": [
+    "."
+  ],
   "version": "1.0.0",
   "private": true,
   "description": "Sequencer-driven Web Audio workstation inspired by the Korg Electribe EA-1 ER-1.",
@@ -22,6 +24,7 @@
     "lint": "eslint .",
     "typecheck": "tsc -b",
     "test": "vitest run",
+    "prepare": "husky",
     "deploy": "python deploy.py",
     "demo": "start svg-demo.html"
   },
@@ -62,6 +65,7 @@
     "fast-check": "^4.8.0",
     "globals": "^16.5.0",
     "happy-dom": "^15.11.7",
+    "husky": "^9.1.7",
     "tailwindcss": "^3.4.6",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       happy-dom:
         specifier: ^15.11.7
         version: 15.11.7
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       tailwindcss:
         specifier: ^3.4.6
         version: 3.4.19
@@ -1390,6 +1393,11 @@ packages:
 
   hls.js@1.6.15:
     resolution: {integrity: sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -3360,6 +3368,8 @@ snapshots:
       hermes-estree: 0.25.1
 
   hls.js@1.6.15: {}
+
+  husky@9.1.7: {}
 
   ieee754@1.2.1: {}
 

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -317,13 +317,13 @@ export const useAudioEngine = (pyodide: unknown, tempo: number = 120) => {
                 const pVocoderRelease = noteParams?.vocoderRelease ?? 0.05;
 
                 // Spectral Panning
-                const spectralPanRate = noteParams?.spectralPanRate !== undefined ? noteParams.spectralPanRate : (params as any).spectralPanRate;
-                const spectralPanDepth = noteParams?.spectralPanDepth !== undefined ? noteParams.spectralPanDepth : (params as any).spectralPanDepth;
+                const spectralPanRate = noteParams?.spectralPanRate !== undefined ? noteParams.spectralPanRate : params.spectralPanRate;
+                const spectralPanDepth = noteParams?.spectralPanDepth !== undefined ? noteParams.spectralPanDepth : params.spectralPanDepth;
                 const spectralPanLfoRate = (spectralPanRate || 1) * (tempo / 60);
 
                 // Reverb
                 const reverbSendAmount = noteParams?.reverbSend !== undefined ? noteParams.reverbSend : 0;
-                const currentReverbType = (noteParams as any)?.reverbType || reverbTypeRef.current;
+                const currentReverbType = noteParams?.reverbType || reverbTypeRef.current;
                 const targetReverbNode = reverbNodesRef.current[currentReverbType] || reverbNodesRef.current['plate'];
 
                 const baseShift = params.formantShift || 0;
@@ -379,8 +379,8 @@ export const useAudioEngine = (pyodide: unknown, tempo: number = 120) => {
                 const pFreezeEnvDepth = noteParams?.freezeEnvDepth !== undefined ? noteParams.freezeEnvDepth : params.freezeEnvDepth;
                 const pTimeStretchEnvDepth = noteParams?.timeStretchEnvDepth !== undefined ? noteParams.timeStretchEnvDepth : params.timeStretchEnvDepth;
                 const pGrainEnvDepth = noteParams?.grainEnvDepth !== undefined ? noteParams.grainEnvDepth : params.grainEnvDepth;
-                const pGrainPitchEnvDepth = (noteParams as any)?.grainPitchEnvDepth !== undefined ? (noteParams as any).grainPitchEnvDepth : params.grainPitchEnvDepth;
-                const pGrainJitter = (noteParams as any)?.grainJitter !== undefined ? (noteParams as any).grainJitter : params.grainJitter;
+                const pGrainPitchEnvDepth = noteParams?.grainPitchEnvDepth !== undefined ? noteParams.grainPitchEnvDepth : params.grainPitchEnvDepth;
+                const pGrainJitter = noteParams?.grainJitter !== undefined ? noteParams.grainJitter : params.grainJitter;
                 const pGrainPitchQuantize = noteParams?.grainPitchQuantize !== undefined ? noteParams.grainPitchQuantize : params.grainPitchQuantize;
 
                 // Effects
@@ -410,9 +410,9 @@ export const useAudioEngine = (pyodide: unknown, tempo: number = 120) => {
                     pEnvDecay = getSyncedSeconds(pEnvDecay as number, tempo);
                 }
 
-                const pPitchAttack = (noteParams as any)?.pitchAttack ?? params.pitchAttack ?? 0;
-                const pPitchDecay = (noteParams as any)?.pitchDecay ?? params.pitchDecay ?? 0;
-                const pPitchAmount = (noteParams as any)?.pitchAmount ?? params.pitchAmount ?? 0;
+                const pPitchAttack = noteParams?.pitchAttack ?? params.pitchAttack ?? 0;
+                const pPitchDecay = noteParams?.pitchDecay ?? params.pitchDecay ?? 0;
+                const pPitchAmount = noteParams?.pitchAmount ?? params.pitchAmount ?? 0;
 
                 const pFilterCutoff = noteParams?.filterCutoff !== undefined
                     ? Math.max(20, noteParams.filterCutoff * 20000)
@@ -472,7 +472,7 @@ export const useAudioEngine = (pyodide: unknown, tempo: number = 120) => {
 
                             // Setup Reverb Send
                             const reverbSendAmount = noteParams?.reverbSend !== undefined ? noteParams.reverbSend : 0;
-                            const currentReverbType = (noteParams as any)?.reverbType || reverbTypeRef.current;
+                            const currentReverbType = noteParams?.reverbType || reverbTypeRef.current;
                             const targetReverbNode = reverbNodesRef.current[currentReverbType] || reverbNodesRef.current['plate'];
                             if (reverbSendAmount > 0 && targetReverbNode) {
                                 const reverbGain = context.createGain();
@@ -504,7 +504,7 @@ export const useAudioEngine = (pyodide: unknown, tempo: number = 120) => {
                             // Apply Character Morphing
                             const morphAmount = noteParams?.characterMorph !== undefined ? noteParams.characterMorph : (params.characterMorph ?? 0);
                             const morphTarget = params.morphTarget || 'female';
-                            voice.setCharacterMorph(morphAmount, morphTarget as any, 0.05); // Use short ramp time
+                            voice.setCharacterMorph(morphAmount, morphTarget, 0.05); // Use short ramp time
 
                             // Sync other params
                             if (noteParams?.vibratoDepth !== undefined) {
@@ -591,7 +591,7 @@ export const useAudioEngine = (pyodide: unknown, tempo: number = 120) => {
                             }
 
                             // Apply Character Morphing
-                            voice.setCharacterMorph(characterMorph, morphTarget as any, 0.05); // Use short ramp time
+                            voice.setCharacterMorph(characterMorph, morphTarget, 0.05); // Use short ramp time
 
                             // Sync other params
                             if (pVibratoDepth !== undefined) voice.setVibratoDepth(pVibratoDepth, triggerTime);
@@ -701,8 +701,8 @@ export const useAudioEngine = (pyodide: unknown, tempo: number = 120) => {
                             if (voice.setPitchDecay) {
                                 voice.setPitchDecay(pPitchDecay, triggerTime);
                             }
-                            if ((voice as any).setPitchAmount) {
-                                (voice as any).setPitchAmount(pPitchAmount, triggerTime);
+                            if (voice.setPitchAmount) {
+                                voice.setPitchAmount(pPitchAmount, triggerTime);
                             }
 
                             voice.play(undefined, undefined, 1.0, noteParams?.reverse);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores a green CI gate on `main` and adds a pre-push guardrail so install/typecheck/lint failures cannot silently land on `main` again.

## Changes

- **`src/hooks/useAudioEngine.ts`**: Removed all 13 `as any` casts by using existing `Note` and `SamplerBankParams` properties (`spectralPanRate`, `reverbType`, `grainPitchEnvDepth`, `pitchAttack`, `morphTarget`, etc.). No new types were needed.
- **`src/engines/SingingVoice.ts`**: Already had scoped ESLint disables for the intentional mixin interface/class merge — no change required.
- **`.husky/pre-push`**: Runs `pnpm install --frozen-lockfile && pnpm exec tsc -b && pnpm lint` before every push.
- **`package.json`**: Added `prepare: husky` and `husky@^9.1.7` devDependency.

## Verification

All five CI gate steps pass locally:

1. `pnpm install --frozen-lockfile`
2. `pnpm run build:wasm`
3. `pnpm exec tsc -b`
4. `pnpm lint` (0 errors)
5. `pnpm test` (1280 passed)

Pre-push hook verified:
- Blocks push on deliberate tsc/lint failure (exit 2)
- Passes when tree is clean (ran successfully on this branch push)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de5f7d87-da42-43df-8055-3d8d345075c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de5f7d87-da42-43df-8055-3d8d345075c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

