### PR TITLE
feat(audio): Phase 1 declarative AudioGraph model

### DIFF
--- a/src/audio/graph/__tests__/compileGraph.test.ts
+++ b/src/audio/graph/__tests__/compileGraph.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+import {
+    CLASSIC_ELECTRIBE_GRAPH,
+    MASTER_CHAIN_CONNECTIONS,
+    MASTER_CHAIN_ORDER,
+    compileAudioGraph,
+    extractMasterChainConnections,
+} from '../index';
+
+interface TrackedNode {
+    id: string;
+    connect: (dest: TrackedNode | AudioDestinationNode) => void;
+}
+
+function createTrackingContext(): {
+    context: AudioContext;
+    nodes: Map<string, TrackedNode>;
+    connections: Array<{ from: string; to: string }>;
+    nodeId: (node: TrackedNode) => string;
+} {
+    const nodes = new Map<string, TrackedNode>();
+    const connections: Array<{ from: string; to: string }> = [];
+    let counter = 0;
+
+    const makeNode = (factory: string): TrackedNode => {
+        const id = `${factory}_${counter++}`;
+        const node: TrackedNode = {
+            id,
+            connect(dest: TrackedNode | AudioDestinationNode) {
+                const toId = 'id' in dest ? dest.id : 'destination';
+                connections.push({ from: id, to: toId });
+            },
+        };
+        nodes.set(id, node);
+        return node;
+    };
+
+    const context = {
+        currentTime: 0,
+        sampleRate: 48000,
+        destination: { id: 'destination' } as AudioDestinationNode & { id: string },
+        createGain: () => {
+            const node = makeNode('gain');
+            return Object.assign(node, {
+                gain: { value: 1, setValueAtTime: () => {} },
+            });
+        },
+        createWaveShaper: () => makeNode('waveShaper'),
+        createBiquadFilter: () => {
+            const node = makeNode('biquad');
+            return Object.assign(node, {
+                type: 'lowpass',
+                frequency: { setValueAtTime: () => {} },
+                Q: { setValueAtTime: () => {} },
+                gain: { setValueAtTime: () => {} },
+            });
+        },
+        createDynamicsCompressor: () =>
+            Object.assign(makeNode('compressor'), {
+                threshold: { setValueAtTime: () => {} },
+                knee: { setValueAtTime: () => {} },
+                ratio: { setValueAtTime: () => {} },
+                attack: { setValueAtTime: () => {} },
+                release: { setValueAtTime: () => {} },
+            }),
+        createStereoPanner: () =>
+            Object.assign(makeNode('panner'), {
+                pan: { setValueAtTime: () => {} },
+            }),
+        createAnalyser: () =>
+            Object.assign(makeNode('analyser'), {
+                fftSize: 256,
+                smoothingTimeConstant: 0.5,
+            }),
+        createConvolver: () => makeNode('convolver'),
+        createDelay: () =>
+            Object.assign(makeNode('delay'), {
+                delayTime: { value: 0 },
+            }),
+        createBuffer: (channels: number, length: number, sampleRate: number) => ({
+            numberOfChannels: channels,
+            length,
+            sampleRate,
+            getChannelData: () => new Float32Array(length),
+        }),
+    } as unknown as AudioContext;
+
+    const nodeId = (node: TrackedNode) => node.id;
+
+    return { context, nodes, connections, nodeId };
+}
+
+describe('CLASSIC_ELECTRIBE_GRAPH config', () => {
+    it('declares the expected master chain node ids', () => {
+        const nodeIds = CLASSIC_ELECTRIBE_GRAPH.nodes.map((n) => n.id);
+        for (const id of MASTER_CHAIN_ORDER) {
+            expect(nodeIds).toContain(id);
+        }
+    });
+
+    it('declares master chain edges in series order', () => {
+        expect(MASTER_CHAIN_CONNECTIONS).toEqual([
+            ['masterSaturation', 'bassSidechainEQ'],
+            ['bassSidechainEQ', 'sidechainGain'],
+            ['sidechainGain', 'masterCompressor'],
+            ['masterCompressor', 'masterGain'],
+            ['masterGain', 'masterPanner'],
+            ['masterPanner', 'destination'],
+        ]);
+    });
+
+    it('routes track buses and aux returns to masterFxInput', () => {
+        const fxInputEdges = CLASSIC_ELECTRIBE_GRAPH.edges.filter((e) => e.to === 'masterSaturation');
+        const sources = fxInputEdges.map((e) => e.from).sort();
+        expect(sources).toEqual([
+            'delay',
+            'reverbHall',
+            'reverbPlate',
+            'reverbRoom',
+            'samplerBus',
+            'synthABus',
+            'synthBBus',
+        ]);
+    });
+
+    it('routes choir buses to masterDryInput (masterGain)', () => {
+        const dryEdges = CLASSIC_ELECTRIBE_GRAPH.edges.filter((e) => e.to === 'masterGain');
+        const sources = dryEdges.map((e) => e.from).sort();
+        expect(sources).toEqual(['choirLeftPanner', 'choirRightPanner', 'masterCompressor']);
+    });
+});
+
+describe('compileAudioGraph', () => {
+    it('connects master chain nodes in declarative edge order', () => {
+        const graph = compileAudioGraph(
+            new AudioContext(),
+            {
+                id: 'test-master',
+                name: 'Test Master',
+                nodes: CLASSIC_ELECTRIBE_GRAPH.nodes.filter((n) =>
+                    MASTER_CHAIN_ORDER.includes(n.id) || n.id === 'masterAnalyser',
+                ),
+                edges: CLASSIC_ELECTRIBE_GRAPH.edges.filter(
+                    (e) =>
+                        MASTER_CHAIN_ORDER.includes(e.from) ||
+                        e.from === 'masterGain' && e.to === 'masterAnalyser',
+                ),
+            },
+        );
+
+        const masterConnections = extractMasterChainConnections(graph.connectionLog);
+        expect(masterConnections.map((c) => [c.from, c.to])).toEqual(
+            MASTER_CHAIN_CONNECTIONS.map(([from, to]) => [from, to]),
+        );
+    });
+
+    it('records connection log with monotonic order indices', () => {
+        const graph = compileAudioGraph(new AudioContext(), CLASSIC_ELECTRIBE_GRAPH);
+        const orders = graph.connectionLog.map((c) => c.order);
+        expect(orders).toEqual([...orders].sort((a, b) => a - b));
+        expect(new Set(orders).size).toBe(orders.length);
+    });
+
+    it('assigns masterFxInput and masterDryInput roles', () => {
+        const graph = compileAudioGraph(new AudioContext(), CLASSIC_ELECTRIBE_GRAPH);
+        expect(graph.getRoleNode('masterFxInput')).toBe(graph.getNode('masterSaturation'));
+        expect(graph.getRoleNode('masterDryInput')).toBe(graph.getNode('masterGain'));
+    });
+
+    it('creates track monitor analysers for each track bus', () => {
+        const graph = compileAudioGraph(new AudioContext(), CLASSIC_ELECTRIBE_GRAPH);
+        expect(graph.analysers.has('synthABus')).toBe(true);
+        expect(graph.analysers.has('synthBBus')).toBe(true);
+        expect(graph.analysers.has('samplerBus')).toBe(true);
+    });
+
+    it('wires delay feedback loop before delay return to master', () => {
+        const graph = compileAudioGraph(new AudioContext(), CLASSIC_ELECTRIBE_GRAPH);
+        const delayEdges = graph.connectionLog.filter((c) => c.from === 'delay' || c.to === 'delay');
+        const feedbackIdx = delayEdges.findIndex(
+            (c) => c.from === 'delay' && c.to === 'delayFeedback',
+        );
+        const returnIdx = delayEdges.findIndex(
+            (c) => c.from === 'delay' && c.to === 'masterSaturation',
+        );
+        expect(feedbackIdx).toBeGreaterThanOrEqual(0);
+        expect(returnIdx).toBeGreaterThan(feedbackIdx);
+    });
+
+    it('compiles full classic graph with tracking context in correct order', () => {
+        const { context } = createTrackingContext();
+        const impulse = context.createBuffer(2, 100, 48000);
+
+        const graph = compileAudioGraph(context, CLASSIC_ELECTRIBE_GRAPH, {
+            createReverbImpulse: () => impulse,
+        });
+        const masterPairs = extractMasterChainConnections(graph.connectionLog);
+        expect(masterPairs).toHaveLength(MASTER_CHAIN_CONNECTIONS.length);
+        expect(graph.connectionLog.length).toBe(CLASSIC_ELECTRIBE_GRAPH.edges.length);
+    });
+});
+
+describe('extractMasterChainConnections', () => {
+    it('filters non-master edges from the connection log', () => {
+        const log = [
+            { from: 'masterSaturation', to: 'bassSidechainEQ', order: 0 },
+            { from: 'synthABus', to: 'masterSaturation', order: 1 },
+            { from: 'bassSidechainEQ', to: 'sidechainGain', order: 2 },
+        ];
+        expect(extractMasterChainConnections(log)).toEqual([
+            { from: 'masterSaturation', to: 'bassSidechainEQ' },
+            { from: 'bassSidechainEQ', to: 'sidechainGain' },
+        ]);
+    });
+});

--- a/src/audio/graph/compileGraph.ts
+++ b/src/audio/graph/compileGraph.ts
@@ -1,0 +1,272 @@
+import { makeDistortionCurve } from '../../hooks/audioEngine/distortion';
+import { createReverbImpulseResponse } from '../impulseResponses';
+import type {
+    AnalyserConfig,
+    AudioGraphConfig,
+    BiquadFilterConfig,
+    CompiledAudioGraph,
+    ConvolverConfig,
+    DelayConfig,
+    DynamicsCompressorConfig,
+    GainConfig,
+    GraphConnectionRecord,
+    GraphNodeFactory,
+    GraphNodeId,
+    GraphNodeRole,
+    GraphNodeSpec,
+    StereoPannerConfig,
+    TrackMonitorConfig,
+    WaveShaperConfig,
+} from './types';
+
+export interface CompileGraphOptions {
+    /** When false, skip masterPanner and connect masterGain → destination directly. */
+    useStereoPanner?: boolean;
+    createReverbImpulse?: (context: AudioContext, preset: 'room' | 'plate' | 'hall') => AudioBuffer;
+}
+
+const DEFAULT_OPTIONS: Required<CompileGraphOptions> = {
+    useStereoPanner: true,
+    createReverbImpulse: (context, preset) => {
+        switch (preset) {
+            case 'room':
+                return createReverbImpulseResponse(context, 0.5, 1.0);
+            case 'plate':
+                return createReverbImpulseResponse(context, 1.5, 2.0);
+            case 'hall':
+                return createReverbImpulseResponse(context, 3.5, 3.0);
+        }
+    },
+};
+
+function asConfig<T>(config: GraphNodeSpec['config']): T {
+    return (config ?? {}) as T;
+}
+
+function createNode(
+    context: AudioContext,
+    spec: GraphNodeSpec,
+    options: Required<CompileGraphOptions>,
+    analysers: Map<GraphNodeId, AnalyserNode>,
+): AudioNode | null {
+    const { factory, id, config } = spec;
+
+    switch (factory as GraphNodeFactory) {
+        case 'waveShaper': {
+            const cfg = asConfig<WaveShaperConfig>(config);
+            const node = context.createWaveShaper();
+            node.curve = makeDistortionCurve(cfg.drive ?? 0);
+            node.oversample = cfg.oversample ?? '4x';
+            return node;
+        }
+        case 'biquadFilter': {
+            const cfg = asConfig<BiquadFilterConfig>(config);
+            const node = context.createBiquadFilter();
+            node.type = cfg.type;
+            const t = context.currentTime;
+            if (cfg.frequency !== undefined) {
+                node.frequency.setValueAtTime(cfg.frequency, t);
+            }
+            if (cfg.Q !== undefined) {
+                node.Q.setValueAtTime(cfg.Q, t);
+            }
+            if (cfg.gain !== undefined) {
+                node.gain.setValueAtTime(cfg.gain, t);
+            }
+            return node;
+        }
+        case 'dynamicsCompressor': {
+            const cfg = asConfig<DynamicsCompressorConfig>(config);
+            const node = context.createDynamicsCompressor();
+            const t = context.currentTime;
+            if (cfg.threshold !== undefined) node.threshold.setValueAtTime(cfg.threshold, t);
+            if (cfg.knee !== undefined) node.knee.setValueAtTime(cfg.knee, t);
+            if (cfg.ratio !== undefined) node.ratio.setValueAtTime(cfg.ratio, t);
+            if (cfg.attack !== undefined) node.attack.setValueAtTime(cfg.attack, t);
+            if (cfg.release !== undefined) node.release.setValueAtTime(cfg.release, t);
+            return node;
+        }
+        case 'gain': {
+            const cfg = asConfig<GainConfig>(config);
+            const node = context.createGain();
+            node.gain.setValueAtTime(cfg.gain ?? 1, 0);
+            return node;
+        }
+        case 'stereoPanner': {
+            const cfg = asConfig<StereoPannerConfig>(config);
+            if (!options.useStereoPanner || !context.createStereoPanner) {
+                return null;
+            }
+            const node = context.createStereoPanner();
+            node.pan.setValueAtTime(cfg.pan ?? 0, 0);
+            return node;
+        }
+        case 'analyser': {
+            const cfg = asConfig<AnalyserConfig>(config);
+            const node = context.createAnalyser();
+            if (cfg.fftSize !== undefined) node.fftSize = cfg.fftSize;
+            if (cfg.smoothingTimeConstant !== undefined) {
+                node.smoothingTimeConstant = cfg.smoothingTimeConstant;
+            }
+            return node;
+        }
+        case 'convolver': {
+            const cfg = asConfig<ConvolverConfig>(config);
+            const node = context.createConvolver();
+            if (cfg.reverbPreset) {
+                node.buffer = options.createReverbImpulse(context, cfg.reverbPreset);
+            }
+            return node;
+        }
+        case 'delay': {
+            const cfg = asConfig<DelayConfig>(config);
+            const node = context.createDelay(cfg.maxDelayTime ?? 2.0);
+            node.delayTime.value = cfg.delayTime ?? 0.375;
+            return node;
+        }
+        case 'trackMonitor': {
+            const cfg = asConfig<TrackMonitorConfig>(config);
+            const bus = context.createGain();
+            bus.gain.value = cfg.busGain ?? 1;
+            const analyser = context.createAnalyser();
+            analyser.fftSize = cfg.analyserFftSize ?? 256;
+            analyser.smoothingTimeConstant = cfg.analyserSmoothing ?? 0.55;
+            bus.connect(analyser);
+            analysers.set(id, analyser);
+            return bus;
+        }
+        case 'destination':
+            return context.destination;
+        default:
+            throw new Error(`Unknown graph node factory: ${factory}`);
+    }
+}
+
+function registerRole(
+    roles: Map<GraphNodeRole, GraphNodeId | GraphNodeId[]>,
+    role: GraphNodeRole,
+    nodeId: GraphNodeId,
+): void {
+    const existing = roles.get(role);
+    if (existing === undefined) {
+        roles.set(role, nodeId);
+        return;
+    }
+    if (Array.isArray(existing)) {
+        existing.push(nodeId);
+        return;
+    }
+    roles.set(role, [existing, nodeId]);
+}
+
+/**
+ * Compile a declarative AudioGraphConfig into live Web Audio nodes and connections.
+ * Connection order follows the edges array — deterministic for testing.
+ */
+export function compileAudioGraph(
+    context: AudioContext,
+    config: AudioGraphConfig,
+    options: CompileGraphOptions = {},
+): CompiledAudioGraph {
+    const resolved = { ...DEFAULT_OPTIONS, ...options };
+    const nodes = new Map<GraphNodeId, AudioNode>();
+    const analysers = new Map<GraphNodeId, AnalyserNode>();
+    const roles = new Map<GraphNodeRole, GraphNodeId | GraphNodeId[]>();
+    const connectionLog: GraphConnectionRecord[] = [];
+
+    for (const spec of config.nodes) {
+        const node = createNode(context, spec, resolved, analysers);
+        if (node) {
+            nodes.set(spec.id, node);
+            if (spec.role) {
+                registerRole(roles, spec.role, spec.id);
+            }
+        }
+    }
+
+    // When stereo panner node was not created, reroute masterGain → destination
+    const hasStereoPanner = nodes.has('masterPanner');
+    const edges = config.edges.filter((edge) => {
+        if (hasStereoPanner) return true;
+        if (edge.from === 'masterGain' && edge.to === 'masterPanner') return false;
+        if (edge.from === 'masterPanner') return false;
+        return true;
+    });
+
+    if (!hasStereoPanner) {
+        const masterGain = nodes.get('masterGain');
+        if (masterGain) {
+            masterGain.connect(context.destination);
+            connectionLog.push({
+                from: 'masterGain',
+                to: 'destination',
+                order: connectionLog.length,
+            });
+        }
+    }
+
+    for (const edge of edges) {
+        const fromNode = nodes.get(edge.from);
+        const toNode = nodes.get(edge.to) ?? (edge.to === 'destination' ? context.destination : undefined);
+        if (!fromNode || !toNode) {
+            if (!hasStereoPanner && (edge.to === 'masterPanner' || edge.from === 'masterPanner')) {
+                continue;
+            }
+            throw new Error(
+                `AudioGraph compile failed: missing node for edge ${edge.from} → ${edge.to}`,
+            );
+        }
+        fromNode.connect(toNode);
+        connectionLog.push({
+            from: edge.from,
+            to: edge.to,
+            order: connectionLog.length,
+        });
+    }
+
+    return {
+        configId: config.id,
+        configName: config.name,
+        nodes,
+        analysers,
+        roles,
+        connectionLog,
+        getNode<T extends AudioNode = AudioNode>(id: GraphNodeId): T {
+            const node = nodes.get(id);
+            if (!node) {
+                throw new Error(`AudioGraph node not found: ${id}`);
+            }
+            return node as T;
+        },
+        getRoleNode(role: GraphNodeRole): AudioNode | undefined {
+            const entry = roles.get(role);
+            if (!entry) return undefined;
+            const id = Array.isArray(entry) ? entry[0] : entry;
+            return nodes.get(id);
+        },
+        getRoleNodes(role: GraphNodeRole): AudioNode[] {
+            const entry = roles.get(role);
+            if (!entry) return [];
+            const ids = Array.isArray(entry) ? entry : [entry];
+            return ids.map((nodeId) => nodes.get(nodeId)).filter((n): n is AudioNode => n !== undefined);
+        },
+    };
+}
+
+/** Extract in-series master chain connections from a compiled graph log. */
+export function extractMasterChainConnections(
+    log: readonly GraphConnectionRecord[],
+): Array<{ from: string; to: string }> {
+    const masterIds = new Set([
+        'masterSaturation',
+        'bassSidechainEQ',
+        'sidechainGain',
+        'masterCompressor',
+        'masterGain',
+        'masterPanner',
+        'destination',
+    ]);
+    return log
+        .filter((c) => masterIds.has(c.from) && masterIds.has(c.to))
+        .map(({ from, to }) => ({ from, to }));
+}

--- a/src/audio/graph/defaultElectribeGraph.ts
+++ b/src/audio/graph/defaultElectribeGraph.ts
@@ -1,0 +1,179 @@
+import type { AudioGraphConfig } from './types';
+
+/**
+ * Classic Electribe master routing topology.
+ *
+ * Two intentional entry points:
+ * - masterFxInput (saturation): synths, sampler, Open303, reverb/delay returns
+ * - masterDryInput (master gain): drums, ambiance, sustain, choir — bypasses FX chain
+ */
+export const CLASSIC_ELECTRIBE_GRAPH: AudioGraphConfig = {
+    id: 'classic-electribe',
+    name: 'Classic Electribe',
+    nodes: [
+        // --- Master FX chain (series) ---
+        {
+            id: 'masterSaturation',
+            factory: 'waveShaper',
+            role: 'masterFxInput',
+            config: { drive: 0, oversample: '4x' },
+        },
+        {
+            id: 'bassSidechainEQ',
+            factory: 'biquadFilter',
+            config: { type: 'peaking', frequency: 250, Q: 1.0, gain: 0 },
+        },
+        {
+            id: 'sidechainGain',
+            factory: 'biquadFilter',
+            config: { type: 'lowshelf', frequency: 250, gain: 0 },
+        },
+        {
+            id: 'masterCompressor',
+            factory: 'dynamicsCompressor',
+            config: { threshold: -15, knee: 30, ratio: 4, attack: 0.03, release: 0.25 },
+        },
+        {
+            id: 'masterGain',
+            factory: 'gain',
+            role: 'masterDryInput',
+            config: { gain: 0.8 },
+        },
+        {
+            id: 'masterPanner',
+            factory: 'stereoPanner',
+            role: 'masterOutput',
+            config: { pan: 0 },
+        },
+        { id: 'destination', factory: 'destination' },
+        {
+            id: 'masterAnalyser',
+            factory: 'analyser',
+            config: { fftSize: 1024, smoothingTimeConstant: 0.6 },
+        },
+
+        // --- Per-track monitor buses ---
+        {
+            id: 'synthABus',
+            factory: 'trackMonitor',
+            role: 'trackBus',
+            config: { busGain: 1, analyserFftSize: 256, analyserSmoothing: 0.55 },
+        },
+        {
+            id: 'synthBBus',
+            factory: 'trackMonitor',
+            role: 'trackBus',
+            config: { busGain: 1, analyserFftSize: 256, analyserSmoothing: 0.55 },
+        },
+        {
+            id: 'samplerBus',
+            factory: 'trackMonitor',
+            role: 'trackBus',
+            config: { busGain: 1, analyserFftSize: 256, analyserSmoothing: 0.55 },
+        },
+
+        // --- Parallel aux returns ---
+        {
+            id: 'reverbRoom',
+            factory: 'convolver',
+            role: 'auxReturn',
+            config: { reverbPreset: 'room' },
+        },
+        {
+            id: 'reverbPlate',
+            factory: 'convolver',
+            role: 'auxReturn',
+            config: { reverbPreset: 'plate' },
+        },
+        {
+            id: 'reverbHall',
+            factory: 'convolver',
+            role: 'auxReturn',
+            config: { reverbPreset: 'hall' },
+        },
+        {
+            id: 'delay',
+            factory: 'delay',
+            config: { maxDelayTime: 2.0, delayTime: 0.375 },
+        },
+        { id: 'delayFeedback', factory: 'gain', config: { gain: 0.4 } },
+
+        // --- Choir widening (bypass master FX) ---
+        {
+            id: 'choirLeftGain',
+            factory: 'gain',
+            role: 'choirBus',
+            config: { gain: 0 },
+        },
+        {
+            id: 'choirLeftPanner',
+            factory: 'stereoPanner',
+            config: { pan: -0.6 },
+        },
+        {
+            id: 'choirRightGain',
+            factory: 'gain',
+            role: 'choirBus',
+            config: { gain: 0 },
+        },
+        {
+            id: 'choirRightPanner',
+            factory: 'stereoPanner',
+            config: { pan: 0.6 },
+        },
+    ],
+    edges: [
+        // Master FX chain (in-series)
+        { from: 'masterSaturation', to: 'bassSidechainEQ' },
+        { from: 'bassSidechainEQ', to: 'sidechainGain' },
+        { from: 'sidechainGain', to: 'masterCompressor' },
+        { from: 'masterCompressor', to: 'masterGain' },
+        { from: 'masterGain', to: 'masterPanner' },
+        { from: 'masterPanner', to: 'destination' },
+
+        // Passive master analyser tap (read-only)
+        { from: 'masterGain', to: 'masterAnalyser' },
+
+        // Track buses → master FX input
+        { from: 'synthABus', to: 'masterSaturation' },
+        { from: 'synthBBus', to: 'masterSaturation' },
+        { from: 'samplerBus', to: 'masterSaturation' },
+
+        // Reverb returns → master FX input
+        { from: 'reverbRoom', to: 'masterSaturation' },
+        { from: 'reverbPlate', to: 'masterSaturation' },
+        { from: 'reverbHall', to: 'masterSaturation' },
+
+        // Global delay with feedback loop
+        { from: 'delay', to: 'delayFeedback' },
+        { from: 'delayFeedback', to: 'delay' },
+        { from: 'delay', to: 'masterSaturation' },
+
+        // Choir buses → master dry input (post-compressor)
+        { from: 'choirLeftGain', to: 'choirLeftPanner' },
+        { from: 'choirLeftPanner', to: 'masterGain' },
+        { from: 'choirRightGain', to: 'choirRightPanner' },
+        { from: 'choirRightPanner', to: 'masterGain' },
+    ],
+};
+
+/** Ordered master-chain node ids for test assertions. */
+export const MASTER_CHAIN_ORDER: readonly string[] = [
+    'masterSaturation',
+    'bassSidechainEQ',
+    'sidechainGain',
+    'masterCompressor',
+    'masterGain',
+    'masterPanner',
+    'destination',
+];
+
+/** Expected compile-time connection order for the in-series master chain. */
+export const MASTER_CHAIN_CONNECTIONS: readonly [string, string][] = [
+    ['masterSaturation', 'bassSidechainEQ'],
+    ['bassSidechainEQ', 'sidechainGain'],
+    ['sidechainGain', 'masterCompressor'],
+    ['masterCompressor', 'masterGain'],
+    ['masterGain', 'masterPanner'],
+    ['masterPanner', 'destination'],
+];

--- a/src/audio/graph/index.ts
+++ b/src/audio/graph/index.ts
@@ -1,0 +1,112 @@
+import type { MutableRefObject } from 'react';
+import type { TrackAnalysers } from '../../types';
+import { compileAudioGraph } from './compileGraph';
+import { CLASSIC_ELECTRIBE_GRAPH } from './defaultElectribeGraph';
+import type { CompiledAudioGraph } from './types';
+
+export interface MasterChainRefs {
+    masterGainRef: MutableRefObject<GainNode | null>;
+    masterPannerRef: MutableRefObject<StereoPannerNode | null>;
+    masterSaturationRef: MutableRefObject<WaveShaperNode | null>;
+    masterCompressorRef: MutableRefObject<DynamicsCompressorNode | null>;
+    sidechainGainRef: MutableRefObject<BiquadFilterNode | null>;
+    bassSidechainEQBusRef: MutableRefObject<BiquadFilterNode | null>;
+    analyserNodeRef?: MutableRefObject<AnalyserNode | null>;
+}
+
+export interface TrackBusRefs {
+    synthABusRef: MutableRefObject<GainNode | null>;
+    synthBBusRef: MutableRefObject<GainNode | null>;
+    samplerBusRef: MutableRefObject<GainNode | null>;
+    trackAnalysersRef: MutableRefObject<TrackAnalysers>;
+}
+
+export interface AuxSendRefs {
+    reverbNodesRef: MutableRefObject<Record<string, ConvolverNode>>;
+    reverbNodeRef: MutableRefObject<ConvolverNode | null>;
+    delayNodeRef: MutableRefObject<DelayNode | null>;
+    delayFeedbackRef: MutableRefObject<GainNode | null>;
+}
+
+export interface ChoirBusRefs {
+    choirLeftGainRef: MutableRefObject<GainNode | null>;
+    choirRightGainRef: MutableRefObject<GainNode | null>;
+    choirLeftPannerRef: MutableRefObject<StereoPannerNode | null>;
+    choirRightPannerRef: MutableRefObject<StereoPannerNode | null>;
+}
+
+export interface ElectribeGraphRefs extends MasterChainRefs, TrackBusRefs, AuxSendRefs, ChoirBusRefs {}
+
+function assignMasterChainRefs(graph: CompiledAudioGraph, refs: MasterChainRefs): WaveShaperNode {
+    refs.masterSaturationRef.current = graph.getNode<WaveShaperNode>('masterSaturation');
+    refs.bassSidechainEQBusRef.current = graph.getNode<BiquadFilterNode>('bassSidechainEQ');
+    refs.sidechainGainRef.current = graph.getNode<BiquadFilterNode>('sidechainGain');
+    refs.masterCompressorRef.current = graph.getNode<DynamicsCompressorNode>('masterCompressor');
+    refs.masterGainRef.current = graph.getNode<GainNode>('masterGain');
+
+    const panner = graph.nodes.get('masterPanner');
+    refs.masterPannerRef.current = (panner as StereoPannerNode | undefined) ?? null;
+
+    if (refs.analyserNodeRef) {
+        refs.analyserNodeRef.current = graph.getNode<AnalyserNode>('masterAnalyser');
+    }
+
+    return refs.masterSaturationRef.current;
+}
+
+function assignTrackBusRefs(graph: CompiledAudioGraph, refs: TrackBusRefs): void {
+    refs.synthABusRef.current = graph.getNode<GainNode>('synthABus');
+    refs.synthBBusRef.current = graph.getNode<GainNode>('synthBBus');
+    refs.samplerBusRef.current = graph.getNode<GainNode>('samplerBus');
+
+    refs.trackAnalysersRef.current.synthA = graph.analysers.get('synthABus');
+    refs.trackAnalysersRef.current.synthB = graph.analysers.get('synthBBus');
+    refs.trackAnalysersRef.current.sampler = graph.analysers.get('samplerBus');
+}
+
+function assignAuxSendRefs(graph: CompiledAudioGraph, refs: AuxSendRefs): void {
+    const room = graph.getNode<ConvolverNode>('reverbRoom');
+    const plate = graph.getNode<ConvolverNode>('reverbPlate');
+    const hall = graph.getNode<ConvolverNode>('reverbHall');
+    refs.reverbNodesRef.current = { room, plate, hall };
+    refs.reverbNodeRef.current = plate;
+    refs.delayNodeRef.current = graph.getNode<DelayNode>('delay');
+    refs.delayFeedbackRef.current = graph.getNode<GainNode>('delayFeedback');
+}
+
+function assignChoirBusRefs(graph: CompiledAudioGraph, refs: ChoirBusRefs): void {
+    refs.choirLeftGainRef.current = graph.getNode<GainNode>('choirLeftGain');
+    refs.choirRightGainRef.current = graph.getNode<GainNode>('choirRightGain');
+    refs.choirLeftPannerRef.current = graph.getNode<StereoPannerNode>('choirLeftPanner');
+    refs.choirRightPannerRef.current = graph.getNode<StereoPannerNode>('choirRightPanner');
+}
+
+export interface BuildElectribeGraphResult {
+    graph: CompiledAudioGraph;
+    masterBusInput: WaveShaperNode;
+}
+
+/**
+ * Build the default Classic Electribe routing graph and populate engine refs.
+ */
+export function buildClassicElectribeGraph(
+    context: AudioContext,
+    refs: ElectribeGraphRefs,
+): BuildElectribeGraphResult {
+    const graph = compileAudioGraph(context, CLASSIC_ELECTRIBE_GRAPH);
+    const masterBusInput = assignMasterChainRefs(graph, refs);
+    assignTrackBusRefs(graph, refs);
+    assignAuxSendRefs(graph, refs);
+    assignChoirBusRefs(graph, refs);
+    return { graph, masterBusInput };
+}
+
+export { CLASSIC_ELECTRIBE_GRAPH, MASTER_CHAIN_ORDER, MASTER_CHAIN_CONNECTIONS } from './defaultElectribeGraph';
+export { compileAudioGraph, extractMasterChainConnections } from './compileGraph';
+export type {
+    AudioGraphConfig,
+    CompiledAudioGraph,
+    GraphConnectionRecord,
+    GraphNodeId,
+    GraphNodeRole,
+} from './types';

--- a/src/audio/graph/types.ts
+++ b/src/audio/graph/types.ts
@@ -1,0 +1,128 @@
+/**
+ * Declarative AudioGraph model (Phase 1).
+ * Describes node topology and roles without UI — compiled into Web Audio connections.
+ */
+
+export type GraphNodeId = string;
+
+/** Semantic roles used by playback code to find entry/exit points. */
+export type GraphNodeRole =
+    | 'masterFxInput'
+    | 'masterDryInput'
+    | 'masterOutput'
+    | 'trackBus'
+    | 'trackAnalyser'
+    | 'auxReturn'
+    | 'choirBus'
+    | 'internal';
+
+export type GraphNodeFactory =
+    | 'waveShaper'
+    | 'biquadFilter'
+    | 'dynamicsCompressor'
+    | 'gain'
+    | 'stereoPanner'
+    | 'analyser'
+    | 'convolver'
+    | 'delay'
+    | 'trackMonitor'
+    | 'destination';
+
+export interface BiquadFilterConfig {
+    type: BiquadFilterType;
+    frequency?: number;
+    Q?: number;
+    gain?: number;
+}
+
+export interface DynamicsCompressorConfig {
+    threshold?: number;
+    knee?: number;
+    ratio?: number;
+    attack?: number;
+    release?: number;
+}
+
+export interface WaveShaperConfig {
+    drive?: number;
+    oversample?: OverSampleType;
+}
+
+export interface GainConfig {
+    gain?: number;
+}
+
+export interface StereoPannerConfig {
+    pan?: number;
+}
+
+export interface AnalyserConfig {
+    fftSize?: number;
+    smoothingTimeConstant?: number;
+}
+
+export interface ConvolverConfig {
+    /** Reverb preset key — resolved at compile time via impulse factory. */
+    reverbPreset?: 'room' | 'plate' | 'hall';
+}
+
+export interface DelayConfig {
+    maxDelayTime?: number;
+    delayTime?: number;
+}
+
+export interface TrackMonitorConfig {
+    busGain?: number;
+    analyserFftSize?: number;
+    analyserSmoothing?: number;
+}
+
+export type GraphNodeConfig =
+    | BiquadFilterConfig
+    | DynamicsCompressorConfig
+    | WaveShaperConfig
+    | GainConfig
+    | StereoPannerConfig
+    | AnalyserConfig
+    | ConvolverConfig
+    | DelayConfig
+    | TrackMonitorConfig
+    | Record<string, never>;
+
+export interface GraphNodeSpec {
+    id: GraphNodeId;
+    factory: GraphNodeFactory;
+    role?: GraphNodeRole;
+    config?: GraphNodeConfig;
+}
+
+export interface GraphEdgeSpec {
+    from: GraphNodeId;
+    to: GraphNodeId;
+}
+
+export interface AudioGraphConfig {
+    id: string;
+    name: string;
+    nodes: GraphNodeSpec[];
+    edges: GraphEdgeSpec[];
+}
+
+export interface GraphConnectionRecord {
+    from: GraphNodeId;
+    to: GraphNodeId;
+    order: number;
+}
+
+export interface CompiledAudioGraph {
+    configId: string;
+    configName: string;
+    nodes: ReadonlyMap<GraphNodeId, AudioNode>;
+    /** Passive analyser taps keyed by graph node id (trackMonitor nodes). */
+    analysers: ReadonlyMap<GraphNodeId, AnalyserNode>;
+    roles: ReadonlyMap<GraphNodeRole, GraphNodeId | GraphNodeId[]>;
+    connectionLog: readonly GraphConnectionRecord[];
+    getNode<T extends AudioNode = AudioNode>(id: GraphNodeId): T;
+    getRoleNode(role: GraphNodeRole): AudioNode | undefined;
+    getRoleNodes(role: GraphNodeRole): AudioNode[];
+}

--- a/src/audio/impulseResponses.ts
+++ b/src/audio/impulseResponses.ts
@@ -1,0 +1,20 @@
+export function createReverbImpulseResponse(
+    context: AudioContext,
+    duration: number = 2.0,
+    decay: number = 2.0,
+): AudioBuffer {
+    const sampleRate = context.sampleRate;
+    const length = sampleRate * duration;
+    const impulse = context.createBuffer(2, length, sampleRate);
+    const left = impulse.getChannelData(0);
+    const right = impulse.getChannelData(1);
+
+    for (let i = 0; i < length; i++) {
+        const n = i / sampleRate;
+        const e = Math.pow(1 - n / duration, decay);
+        left[i] = (Math.random() * 2 - 1) * e;
+        right[i] = (Math.random() * 2 - 1) * e;
+    }
+
+    return impulse;
+}

--- a/src/hooks/audioEngine/engineLifecycle.ts
+++ b/src/hooks/audioEngine/engineLifecycle.ts
@@ -7,16 +7,13 @@ import { VoiceManager } from '../../engines/VoiceManager';
 import { MultisampleGenerator } from '../../engines/MultisampleGenerator';
 import { PhonemeBufferPool } from '../../services/PhonemeBufferPool';
 import { engineTelemetry } from '../../utils/engineTelemetry';
-import { createTrackMonitor } from '../../audio/trackAnalysers';
+import { buildClassicElectribeGraph } from '../../audio/graph';
 import type { TrackAnalysers } from '../../types';
 import {
     createNoiseBuffer,
-    initializeChoirBuses,
     initializeHarmonizer,
-    initializeMasterOutput,
     initializeSustainProcessor,
     loadWavBuffer,
-    createReverbImpulseResponse,
 } from './initialization';
 
 type AudioWindow = Window & typeof globalThis & {
@@ -90,56 +87,7 @@ export async function initializeAudioContextAndEngines(
         console.log("AudioContext resumed");
     }
 
-    const masterBusInput = initializeMasterOutput(
-        context,
-        refs.masterGainRef,
-        refs.masterPannerRef,
-        refs.masterSaturationRef,
-        refs.masterCompressorRef,
-        refs.sidechainGainRef,
-        refs.bassSidechainEQBusRef,
-        refs.analyserNodeRef,
-    );
-
-    const synthATap = createTrackMonitor(context, masterBusInput);
-    refs.synthABusRef.current = synthATap.bus;
-    refs.trackAnalysersRef.current.synthA = synthATap.analyser;
-
-    const synthBTap = createTrackMonitor(context, masterBusInput);
-    refs.synthBBusRef.current = synthBTap.bus;
-    refs.trackAnalysersRef.current.synthB = synthBTap.analyser;
-
-    const samplerTap = createTrackMonitor(context, masterBusInput);
-    refs.samplerBusRef.current = samplerTap.bus;
-    refs.trackAnalysersRef.current.sampler = samplerTap.analyser;
-
-    // Initialize Reverb Node
-    // Initialize Reverb Nodes (Room, Plate, Hall)
-    const roomNode = context.createConvolver();
-    roomNode.buffer = createReverbImpulseResponse(context, 0.5, 1.0);
-    roomNode.connect(masterBusInput);
-
-    const plateNode = context.createConvolver();
-    plateNode.buffer = createReverbImpulseResponse(context, 1.5, 2.0);
-    plateNode.connect(masterBusInput);
-
-    const hallNode = context.createConvolver();
-    hallNode.buffer = createReverbImpulseResponse(context, 3.5, 3.0);
-    hallNode.connect(masterBusInput);
-
-    refs.reverbNodesRef.current = { room: roomNode, plate: plateNode, hall: hallNode };
-    refs.reverbNodeRef.current = plateNode; // Fallback
-
-    // Initialize Global Delay Node
-    const delayNode = context.createDelay(2.0);
-    delayNode.delayTime.value = 0.375; // ~1/8th note at typical tempo
-    const delayFeedback = context.createGain();
-    delayFeedback.gain.value = 0.4;
-    delayNode.connect(delayFeedback);
-    delayFeedback.connect(delayNode);
-    delayNode.connect(masterBusInput);
-    refs.delayNodeRef.current = delayNode;
-    refs.delayFeedbackRef.current = delayFeedback;
+    const { masterBusInput } = buildClassicElectribeGraph(context, refs);
 
     // Initialize Engines
     const gpuEngine = new WebGpuOscillator();
@@ -227,15 +175,6 @@ export async function initializeAudioContextAndEngines(
         await manager.init(wasmBinary);
         refs.singingVoiceManagerRef.current = manager;
         try { engineTelemetry.registerResolution('singingVoice','wasm','loaded'); } catch (e) { /* noop */ }
-
-        initializeChoirBuses(
-            context,
-            refs.masterGainRef,
-            refs.choirLeftGainRef,
-            refs.choirRightGainRef,
-            refs.choirLeftPannerRef,
-            refs.choirRightPannerRef,
-        );
 
         const samplerDest = refs.samplerBusRef.current ?? refs.masterSaturationRef.current!;
         manager.getAllVoices().forEach(voice => {

--- a/src/hooks/audioEngine/initialization.ts
+++ b/src/hooks/audioEngine/initialization.ts
@@ -1,7 +1,39 @@
 import type { MutableRefObject } from 'react';
 import { Harmonizer } from '../../engines/Harmonizer';
+import { compileAudioGraph } from '../../audio/graph/compileGraph';
+import { CLASSIC_ELECTRIBE_GRAPH } from '../../audio/graph/defaultElectribeGraph';
+import type { MasterChainRefs } from '../../audio/graph';
 
-import { makeDistortionCurve } from './distortion';
+const MASTER_CHAIN_NODE_IDS = new Set([
+    'masterSaturation',
+    'bassSidechainEQ',
+    'sidechainGain',
+    'masterCompressor',
+    'masterGain',
+    'masterPanner',
+    'destination',
+    'masterAnalyser',
+]);
+
+function assignMasterChainRefs(
+    graph: ReturnType<typeof compileAudioGraph>,
+    refs: MasterChainRefs,
+): WaveShaperNode {
+    refs.masterSaturationRef.current = graph.getNode<WaveShaperNode>('masterSaturation');
+    refs.bassSidechainEQBusRef.current = graph.getNode<BiquadFilterNode>('bassSidechainEQ');
+    refs.sidechainGainRef.current = graph.getNode<BiquadFilterNode>('sidechainGain');
+    refs.masterCompressorRef.current = graph.getNode<DynamicsCompressorNode>('masterCompressor');
+    refs.masterGainRef.current = graph.getNode<GainNode>('masterGain');
+
+    const panner = graph.nodes.get('masterPanner');
+    refs.masterPannerRef.current = (panner as StereoPannerNode | undefined) ?? null;
+
+    if (refs.analyserNodeRef) {
+        refs.analyserNodeRef.current = graph.getNode<AnalyserNode>('masterAnalyser');
+    }
+
+    return refs.masterSaturationRef.current;
+}
 
 export function initializeMasterOutput(
     context: AudioContext,
@@ -13,65 +45,26 @@ export function initializeMasterOutput(
     bassSidechainEQBusRef: MutableRefObject<BiquadFilterNode | null>,
     analyserNodeRef?: MutableRefObject<AnalyserNode | null>,
 ): WaveShaperNode {
-    const masterSaturation = context.createWaveShaper();
-    masterSaturation.curve = makeDistortionCurve(0);
-    masterSaturation.oversample = '4x';
-    masterSaturationRef.current = masterSaturation;
+    const masterConfig = {
+        ...CLASSIC_ELECTRIBE_GRAPH,
+        id: 'classic-electribe-master',
+        name: 'Classic Electribe (master chain)',
+        nodes: CLASSIC_ELECTRIBE_GRAPH.nodes.filter((n) => MASTER_CHAIN_NODE_IDS.has(n.id)),
+        edges: CLASSIC_ELECTRIBE_GRAPH.edges.filter(
+            (e) => MASTER_CHAIN_NODE_IDS.has(e.from) && MASTER_CHAIN_NODE_IDS.has(e.to),
+        ),
+    };
 
-    const masterCompressor = context.createDynamicsCompressor();
-    masterCompressor.threshold.setValueAtTime(-15, context.currentTime);
-    masterCompressor.knee.setValueAtTime(30, context.currentTime);
-    masterCompressor.ratio.setValueAtTime(4, context.currentTime);
-    masterCompressor.attack.setValueAtTime(0.03, context.currentTime);
-    masterCompressor.release.setValueAtTime(0.25, context.currentTime);
-    masterCompressorRef.current = masterCompressor;
-
-    const masterGain = context.createGain();
-    masterGain.gain.setValueAtTime(0.8, 0);
-    masterGainRef.current = masterGain;
-
-    // AI Auto-EQ Bus: ducks conflicting frequencies (e.g., 250Hz) when Bass plays
-    const bassSidechainEQBus = context.createBiquadFilter();
-    bassSidechainEQBus.type = 'peaking';
-    bassSidechainEQBus.frequency.setValueAtTime(250, context.currentTime);
-    bassSidechainEQBus.Q.setValueAtTime(1.0, context.currentTime);
-    bassSidechainEQBus.gain.setValueAtTime(0.0, context.currentTime);
-    bassSidechainEQBusRef.current = bassSidechainEQBus;
-
-    // Use a low-shelf filter for sidechaining instead of a broadband gain duck.
-    // This ducks only the low frequencies, leaving the highs intact (Spectral Sidechaining).
-    const sidechainBus = context.createBiquadFilter();
-    sidechainBus.type = 'lowshelf';
-    sidechainBus.frequency.setValueAtTime(250, context.currentTime);
-    sidechainBus.gain.setValueAtTime(0.0, context.currentTime); // 0 dB initially
-    sidechainGainRef.current = sidechainBus;
-
-    masterSaturation.connect(bassSidechainEQBus);
-    bassSidechainEQBus.connect(sidechainBus);
-    sidechainBus.connect(masterCompressor);
-    masterCompressor.connect(masterGain);
-
-    if (context.createStereoPanner) {
-        const masterPanner = context.createStereoPanner();
-        masterPanner.pan.setValueAtTime(0, 0);
-        masterPannerRef.current = masterPanner;
-        masterGain.connect(masterPanner);
-        masterPanner.connect(context.destination);
-    } else {
-        masterGain.connect(context.destination);
-    }
-
-    // Passive analyser tap: connects after masterGain so it monitors the full
-    // output mix. The analyser is not connected to destination — it only reads.
-    if (analyserNodeRef) {
-        const analyser = context.createAnalyser();
-        analyser.fftSize = 1024;
-        analyser.smoothingTimeConstant = 0.6;
-        masterGain.connect(analyser);
-        analyserNodeRef.current = analyser;
-    }
-
-    return masterSaturation;
+    const graph = compileAudioGraph(context, masterConfig);
+    return assignMasterChainRefs(graph, {
+        masterGainRef,
+        masterPannerRef,
+        masterSaturationRef,
+        masterCompressorRef,
+        sidechainGainRef,
+        bassSidechainEQBusRef,
+        analyserNodeRef,
+    });
 }
 
 export function initializeHarmonyBus(
@@ -188,22 +181,7 @@ export function createNoiseBuffer(context: AudioContext): AudioBuffer {
     return buffer;
 }
 
-export function createReverbImpulseResponse(context: AudioContext, duration: number = 2.0, decay: number = 2.0): AudioBuffer {
-    const sampleRate = context.sampleRate;
-    const length = sampleRate * duration;
-    const impulse = context.createBuffer(2, length, sampleRate);
-    const left = impulse.getChannelData(0);
-    const right = impulse.getChannelData(1);
-
-    for (let i = 0; i < length; i++) {
-        const n = i / sampleRate;
-        const e = Math.pow(1 - n / duration, decay);
-        left[i] = (Math.random() * 2 - 1) * e;
-        right[i] = (Math.random() * 2 - 1) * e;
-    }
-
-    return impulse;
-}
+export { createReverbImpulseResponse } from '../../audio/impulseResponses';
 
 export function initializeHarmonizer(harmonizerRef: MutableRefObject<Harmonizer | null>): void {
     try {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -41,16 +41,17 @@ if (typeof window !== 'undefined') {
     }),
     createDynamicsCompressor: vi.fn().mockReturnValue({
       connect: vi.fn(),
-      threshold: { value: 0 },
-      knee: { value: 0 },
-      ratio: { value: 0 },
-      attack: { value: 0 },
-      release: { value: 0 },
+      threshold: { value: 0, setValueAtTime: vi.fn() },
+      knee: { value: 0, setValueAtTime: vi.fn() },
+      ratio: { value: 0, setValueAtTime: vi.fn() },
+      attack: { value: 0, setValueAtTime: vi.fn() },
+      release: { value: 0, setValueAtTime: vi.fn() },
     }),
     createBiquadFilter: vi.fn().mockReturnValue({
         connect: vi.fn(),
         frequency: { value: 0, setValueAtTime: vi.fn() },
         Q: { value: 0, setValueAtTime: vi.fn() },
+        gain: { value: 0, setValueAtTime: vi.fn() },
         type: 'lowpass'
     }),
     createAnalyser: vi.fn().mockReturnValue({
@@ -97,6 +98,10 @@ if (typeof window !== 'undefined') {
         connect: vi.fn(),
         curve: null,
         oversample: 'none'
+    }),
+    createConvolver: vi.fn().mockReturnValue({
+        connect: vi.fn(),
+        buffer: null,
     }),
     sampleRate: 44100,
     audioWorklet: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase 1** of the modular patch bay vision: an internal declarative `AudioGraph` model with no UI. The default Classic Electribe routing is now described as config and compiled into Web Audio connections.

## Changes

- **`src/audio/graph/`** — new module:
  - `types.ts` — graph node/edge specs, roles (`masterFxInput`, `masterDryInput`, etc.)
  - `defaultElectribeGraph.ts` — `CLASSIC_ELECTRIBE_GRAPH` declarative topology
  - `compileGraph.ts` — compiles config → nodes + deterministic connection log
  - `index.ts` — `buildClassicElectribeGraph()` populates engine refs
- **`src/audio/impulseResponses.ts`** — extracted reverb impulse helper (breaks circular import)
- **`engineLifecycle.ts`** — uses `buildClassicElectribeGraph()` instead of imperative wiring for master chain, track buses, reverb/delay aux, and choir buses
- **`initialization.ts`** — `initializeMasterOutput()` compiles master-chain subset from the same graph config

## Topology preserved

Two intentional entry points remain explicit in the graph:

| Role | Node | Sources |
|------|------|---------|
| `masterFxInput` | `masterSaturation` | Synth A/B buses, sampler bus, Open303, reverb/delay returns |
| `masterDryInput` | `masterGain` | Drums, ambiance, sustain, choir (bypass FX chain) |

Master FX chain order: `saturation → bass EQ duck → sidechain shelf → compressor → gain → panner → destination`

## Acceptance (Phase 1)

- [x] Declarative graph produces identical routing to current default
- [x] Unit tests for graph compile → node connect order (`src/audio/graph/__tests__/compileGraph.test.ts`)

## Next phases (not in this PR)

- Phase 2: Read-only graph visualizer (debug)
- Phase 3: Editable patch bay with loop validation
- Phase 4: Presets ("Classic Electribe", "Vocal Production", "Acid Only")

## Test plan

- [x] `pnpm exec vitest run src/audio/graph/__tests__/compileGraph.test.ts`
- [x] `npx tsc -b`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93db91d7-daa1-4746-8878-7ceb35e43f60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93db91d7-daa1-4746-8878-7ceb35e43f60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

