### PR TITLE
feat(audio): 303 Voices architecture — selectable TB-303 model registry

### DIFF
--- a/docs/audio-engine/303-voices.md
+++ b/docs/audio-engine/303-voices.md
@@ -1,0 +1,135 @@
+# 303 Voices — selectable TB-303 models
+
+The dual-engine switch (`open303` / `jc303`) has grown into a **selectable,
+extensible list of TB-303 "voices"** (models). Each of the three 303 tracks —
+**SYNTH A (lead303)**, **SYNTH B (bass1)** and **BASS 2 (bass2)** — picks its
+voice independently, so you can A/B stock vs. experimental characters per
+track without touching the others.
+
+## Concepts
+
+| Term | Meaning |
+|------|---------|
+| **Engine family** | One of the two DSP implementations compiled into `hyphon_native.wasm`: `open303` (custom synth, `emscripten/open303_wrapper.cpp`) or `jc303` (authentic `rosic::Open303`, `emscripten/jc303_wrapper.cpp`). |
+| **Voice / model** | A named sound character with a stable string id (e.g. `stock-open303`, `experimental-01`). Voices in the `open303` family are *coefficient profiles* applied to the shared DSP topology; `jc303`-family voices run on the rosic engine. |
+
+## Current catalog
+
+| Id | Family | Status | Character |
+|----|--------|--------|-----------|
+| `stock-open303` | open303 | ✅ shipped | Pristine default — bit-identical to the pre-voices custom engine. |
+| `jc303` | jc303 | ✅ shipped | Authentic rosic::Open303 — identical to the old "Authentic JC303" engine setting. |
+| `1ink303-v1` | open303 | ✅ shipped | In-house: warmer filter base (26 Hz), rounder accent, slower slides, gentle saw shaping. |
+| `experimental-01` | open303 | ✅ shipped | Scratchpad: hotter resonance feedback (4.15), snappier envelope, harder accent punch, heavier square drive. |
+| `rebirth-338-1.5` | jc303 | 🚧 catalogued | ReBirth 1.5 filter/env/accent profile. |
+| `rebirth-2.0` | jc303 | 🚧 catalogued | ReBirth 2.0 profile. |
+| `mb33-mkii` | open303 | 🚧 catalogued | MAM MB33 mkII profile. |
+| `raveolution` | open303 | 🚧 catalogued | Quasimidi Raveolution 309 profile. |
+
+Catalogued-but-unshipped voices are hidden from the UI and normalize to the
+stock voice of their family when loaded from a song.
+
+## Architecture
+
+### C++ (`emscripten/open303_wrapper.cpp`)
+
+The registry is a static table of `Open303ModelProfile` rows (`k303Models[]`)
+holding the id, label, engine family, and the coefficient profile:
+
+- filter cutoff curve (`cutoffBaseHz`, `cutoffRangeMul`) and resonance
+  feedback gain (`resFeedback`, ≈4 approaches self-oscillation)
+- accent filter/VCA boost depths
+- envelope decay range, slide/portamento range
+- square overdrive depth and optional saw waveshaping drive
+
+WASM exports (also embind-bound where types allow):
+
+```
+open303_get_model_count()          → number of registry entries
+open303_get_model_id(i)            → const char* stable id
+open303_get_model_label(i)         → const char* label
+open303_get_model_engine(i)        → 0 = open303 family, 1 = jc303 family
+open303_set_model(handle, i)       → apply profile to an instance (1 = ok)
+open303_get_model(handle)          → currently applied model index
+getAvailable303Models()            → JSON list (embind, main-thread module)
+```
+
+`stock-open303` is row 0 and its coefficients are exactly the constants the
+engine used before the registry existed, so the default sound is unchanged.
+The `sawDrive = 0` fast path skips the waveshaper entirely — stock saw output
+is bit-identical.
+
+### TypeScript
+
+`src/engines/TB303Models.ts` mirrors the C++ table (`TB303_MODELS`) and is the
+single source the UI and persistence layers read:
+
+- `TB303ModelId` — union of all voice ids (persisted in songs; never rename).
+- `getAvailableTB303Models()` — what the UI selector lists.
+- `normalizeTB303Model(model303?, engine303?)` — resolves any persisted
+  model/engine pair (including legacy songs and unknown future ids) to a
+  valid, available model.
+- `tb303ModelFamily(id)` / `stockModelForFamily(family)` — family helpers.
+
+Plumbing:
+
+- `Open303Oscillator.setModel303(model)` posts `set-303-model`
+  (`{ model, engine }`) to the worklet; the legacy `setEngine303()` still
+  works and maps to the family's stock voice.
+- `Open303Manager.setBass1Model / setBass2Model / setLead303Model` and
+  `syncModel303Settings({ lead, bass1, bass2 })` (applied after audio init /
+  song load in `useAppState`).
+- The worklet (`open303-processor.ts`) discovers the native registry at init
+  by reading the `open303_get_model_*` exports. On a `set-303-model` message
+  it switches the engine family (clearing held notes) and applies the
+  coefficient profile via `open303_set_model`.
+
+### Graceful degradation
+
+Every step feature-detects:
+
+- **Old WASM, new TS** — if `hyphon_native.wasm` predates the registry, the
+  worklet falls back to the `engine` hint included in the `set-303-model`
+  message, so both stock voices keep working; non-stock voices simply sound
+  stock until the WASM is rebuilt (`pnpm run build:emcc`).
+- **New WASM, old song** — `normalizeTB303Model` maps `engine303:'jc303'` →
+  `jc303` and everything else → `stock-open303`.
+- **Old build, new song** — the UI mirrors each `model303` change into the
+  legacy `engine303` field on save, so older builds load the closest stock
+  voice.
+
+### UI
+
+`src/components/Voice303Selector.tsx` renders the "303 Voice" list on the
+SYNTH A / SYNTH B / BASS 2 rack panels (`useHardwarePanels.tsx`). It is
+populated from `getAvailableTB303Models()` with the model description as the
+tooltip — new registry entries appear automatically. The old two-way
+`Engine303Selector` is deprecated but kept for compatibility.
+
+## Adding a new voice
+
+1. Add a profile row to `k303Models[]` in `emscripten/open303_wrapper.cpp`
+   (for an `open303`-family coefficient voice — bigger topology changes get a
+   separate DSP class behind the same instance API).
+2. Rebuild the WASM: `pnpm run build:emcc`.
+3. Add the matching entry to `TB303_MODELS` in `src/engines/TB303Models.ts`
+   with `available: true`.
+
+That's it — the selector, worklet routing, persistence and normalization all
+read the registry.
+
+## Out of scope for v1
+
+- Per-pattern model automation
+- Model-specific default knob positions
+- Live A/B compare mode (two synced instances)
+- Export/import of model tweaks as JSON
+
+## Tests
+
+- `src/__tests__/TB303Models.test.ts` — registry integrity, normalization,
+  legacy-song compatibility, oscillator/manager model plumbing.
+- `src/components/__tests__/Voice303Selector.test.tsx` — dynamic UI list,
+  selection callbacks, tooltips, a11y.
+- `src/__tests__/Open303EngineSelect.test.ts` /
+  `engine303-roundtrip.test.ts` — legacy engine switch behaviour still intact.

--- a/emscripten/build.sh
+++ b/emscripten/build.sh
@@ -62,6 +62,12 @@ EXPORTS="[ \
     '_open303_all_notes_off', \
     '_open303_set_param', \
     '_open303_process', \
+    '_open303_get_model_count', \
+    '_open303_get_model_id', \
+    '_open303_get_model_label', \
+    '_open303_get_model_engine', \
+    '_open303_set_model', \
+    '_open303_get_model', \
     '_jc303_create', \
     '_jc303_destroy', \
     '_jc303_init_handle', \

--- a/emscripten/open303_wrapper.cpp
+++ b/emscripten/open303_wrapper.cpp
@@ -43,6 +43,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <memory>
+#include <string>
 #include <unordered_map>
 
 using namespace emscripten;
@@ -93,6 +94,62 @@ static inline float fastTanh(float x)
 /** Velocity threshold above which a noteOn triggers the accent path. */
 static constexpr float ACCENT_VELOCITY_THRESHOLD = 100.0f;
 
+// ─────────────────────────────────────────────────────────────────────────────
+// 303 model registry ("303 Voices")
+//
+// A model is a named sound character. Models in the ENGINE_OPEN303 family are
+// coefficient profiles applied to the Open303Instance DSP below; models in the
+// ENGINE_JC303 family run on the rosic::Open303 engine (jc303_wrapper.cpp) and
+// are selected by the AudioWorklet via the jc303_* multi-instance API.
+//
+// This table is mirrored by TB303_MODELS in src/engines/TB303Models.ts —
+// keep ids in sync. Model ids are persisted in saved songs; never rename.
+//
+// Adding a new open303-family voice = adding one row here (plus the TS mirror
+// entry) and rebuilding with `pnpm run build:emcc`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+enum TB303EngineKind : int {
+    ENGINE_OPEN303 = 0,
+    ENGINE_JC303   = 1,
+};
+
+struct Open303ModelProfile {
+    const char* id;           // stable identifier (persisted in songs)
+    const char* label;        // human-readable name
+    int         engine;       // TB303EngineKind
+
+    // Coefficient profile (ENGINE_OPEN303 family; ignored for ENGINE_JC303):
+    float cutoffBaseHz;      // filter frequency at fcNorm = 0        (stock 20)
+    float cutoffRangeMul;    // exponential range multiplier          (stock 400 → 8 kHz at 1)
+    float resFeedback;       // resonance→feedback gain, ≈4 self-osc  (stock 3.9)
+    float accentFilterBoost; // accent cutoff boost depth             (stock 0.4)
+    float accentGainBoost;   // accent VCA boost depth                (stock 0.3)
+    float decayMinS;         // envelope decay at decay = 0           (stock 0.05)
+    float decayRangeS;       // envelope decay span                   (stock 1.95)
+    float slideMinS;         // portamento time at slideTime = 0      (stock 0.01)
+    float slideRangeS;       // portamento time span                  (stock 0.49)
+    float squareDriveMul;    // square overdrive depth                (stock 3.0)
+    float sawDrive;          // saw waveshaping drive, 0 = pristine   (stock 0.0)
+};
+
+static const Open303ModelProfile k303Models[] = {
+    // id                label               engine          cutBase range  resFb accFlt accGain decMin decRng sldMin sldRng sqDrv sawDrv
+    { "stock-open303",   "Stock Open303",    ENGINE_OPEN303, 20.0f, 400.0f, 3.9f, 0.40f, 0.30f,  0.05f, 1.95f, 0.01f, 0.49f, 3.0f, 0.0f },
+    { "jc303",           "Authentic JC303",  ENGINE_JC303,   20.0f, 400.0f, 3.9f, 0.40f, 0.30f,  0.05f, 1.95f, 0.01f, 0.49f, 3.0f, 0.0f },
+    // In-house: warmer filter base, rounder accent, slower slides.
+    { "1ink303-v1",      "1ink303 v1",       ENGINE_OPEN303, 26.0f, 340.0f, 4.0f, 0.35f, 0.38f,  0.04f, 1.60f, 0.02f, 0.60f, 2.4f, 0.35f },
+    // Scratchpad: hotter resonance feedback, snappier envelope, harder accent.
+    { "experimental-01", "Experimental 01",  ENGINE_OPEN303, 20.0f, 420.0f, 4.15f, 0.55f, 0.45f, 0.03f, 1.20f, 0.008f, 0.40f, 4.5f, 0.0f },
+};
+
+static constexpr int k303ModelCount = static_cast<int>(sizeof(k303Models) / sizeof(k303Models[0]));
+
+static const Open303ModelProfile* find303Model(int index)
+{
+    return (index >= 0 && index < k303ModelCount) ? &k303Models[index] : nullptr;
+}
+
 
 
 struct MoogFilter {
@@ -101,20 +158,17 @@ struct MoogFilter {
     /**
      * Process one sample.
      * @param input      dry sample (±1.0 range)
-     * @param fcNorm     normalised cutoff frequency [0..1]
-     *                   maps exponentially to ~20 Hz … ~8 kHz
-     * @param res        resonance [0..1] (1.0 approaches self-oscillation)
+     * @param freqHz     cutoff frequency in Hz (already curve-mapped by the
+     *                   caller from the active model profile)
+     * @param k          resonance feedback gain (0..≈4, ≈4 self-oscillates)
      * @param sampleRate sample rate in Hz
      */
-    float process(float input, float fcNorm, float res, float sampleRate)
+    float process(float input, float freqHz, float k, float sampleRate)
     {
-        // Exponential frequency mapping: 20 Hz at 0, 8000 Hz at 1
-        float freqHz = 20.0f * std::pow(400.0f, fcNorm);
         freqHz = std::min(freqHz, sampleRate * 0.49f);
 
         const float g  = TWO_PI_F * freqHz / sampleRate;
         const float gp = g / (1.0f + g);       // one-pole coefficient
-        const float k  = res * 3.9f;            // feedback gain (0..≈4)
 
         // Feedback from the last stage
         const float fb   = k * s[3];
@@ -170,6 +224,10 @@ struct Open303Instance {
 
     // ── Filter ───────────────────────────────────────────────────────────────
     MoogFilter filter;
+
+    // ── Active model profile (index into k303Models; 0 = stock-open303) ──────
+    int modelIndex = 0;
+    Open303ModelProfile profile = k303Models[0];
 
     // ── Output buffer (owned, allocated once in init) ────────────────────────
     float* outBuf  = nullptr;
@@ -228,11 +286,25 @@ struct Open303Instance {
 
     void updateDecayRate()
     {
-        // Map [0..1] → [50 ms .. 2 s] decay time
-        float timeS = 0.05f + decay * 1.95f;
+        // Map [0..1] → decay time range from the active model profile
+        // (stock: 50 ms .. 2 s)
+        float timeS = profile.decayMinS + decay * profile.decayRangeS;
         // Accent shortens the decay further
         if (accented) timeS *= (0.05f + accentDecay * 0.95f);
         envDecayRate = std::exp(-1.0f / (sampleRate * timeS));
+    }
+
+    /** Apply a model coefficient profile ("303 voice"). Returns 1 on success.
+     *  Only ENGINE_OPEN303-family models apply here; ENGINE_JC303 models are
+     *  routed to the rosic engine by the AudioWorklet. */
+    int setModel(int index)
+    {
+        const Open303ModelProfile* m = find303Model(index);
+        if (!m || m->engine != ENGINE_OPEN303) return 0;
+        modelIndex = index;
+        profile    = *m;
+        updateDecayRate();
+        return 1;
     }
 
     // ── Note control ─────────────────────────────────────────────────────────
@@ -244,7 +316,7 @@ struct Open303Instance {
 
         if (gateOpen && slideTime > 0.0f && currentFreq > 0.0f) {
             // Portamento: compute per-sample exponential glide coefficient
-            const float slideSeconds = 0.01f + slideTime * 0.49f;
+            const float slideSeconds = profile.slideMinS + slideTime * profile.slideRangeS;
             const float ratio = targetFreq / currentFreq;
             if (ratio > 0.0f && ratio != 1.0f) {
                 slideCoeff = std::pow(ratio, 1.0f / (slideSeconds * sampleRate));
@@ -305,10 +377,15 @@ struct Open303Instance {
             float osc;
             if (waveform < 0.5f) {
                 osc = 2.0f * phase - 1.0f;   // sawtooth
+                // Optional model waveshaping (sawDrive = 0 keeps the stock
+                // path bit-identical — no tanh applied at all)
+                if (profile.sawDrive > 0.0f) {
+                    osc = fastTanh(osc * (1.0f + profile.sawDrive));
+                }
             } else {
                 // Square with soft overdrive controlled by squareDrv
                 const float sq    = (phase < 0.5f) ? 1.0f : -1.0f;
-                const float drive = 1.0f + squareDrv * 3.0f;
+                const float drive = 1.0f + squareDrv * profile.squareDriveMul;
                 osc = fastTanh(sq * drive);
             }
 
@@ -317,15 +394,17 @@ struct Open303Instance {
             if (envLevel < 1.0e-6f) envLevel = 0.0f;
 
             // --- Filter cutoff with envelope modulation ---
-            const float accentBoost = accented ? (accent * 0.4f * envLevel) : 0.0f;
+            const float accentBoost = accented ? (accent * profile.accentFilterBoost * envLevel) : 0.0f;
             const float totalCutoff = std::min(1.0f, cutoff + envMod * envLevel + accentBoost);
 
-            // --- Filter ---
-            const float filtered = filter.process(osc, totalCutoff, resonance, sampleRate);
+            // --- Filter (cutoff curve + feedback gain from the model profile) ---
+            const float freqHz = profile.cutoffBaseHz * std::pow(profile.cutoffRangeMul, totalCutoff);
+            const float k      = resonance * profile.resFeedback;
+            const float filtered = filter.process(osc, freqHz, k, sampleRate);
 
             // --- Output gain ---
             float gain = volume;
-            if (accented) gain *= (1.0f + accent * 0.3f);
+            if (accented) gain *= (1.0f + accent * profile.accentGainBoost);
             output[i] = filtered * gain;
         }
     }
@@ -429,7 +508,77 @@ void open303_process(uintptr_t handle, uintptr_t outputPtr, int numFrames)
     inst->process(out, numFrames);
 }
 
+// ── 303 model registry API ("303 Voices") ───────────────────────────────────
+
+/** Number of models in the registry (all engine families). */
+EMSCRIPTEN_KEEPALIVE
+int open303_get_model_count()
+{
+    return k303ModelCount;
+}
+
+/** Stable id of the model at @p index (null-terminated static string), or 0. */
+EMSCRIPTEN_KEEPALIVE
+const char* open303_get_model_id(int index)
+{
+    const Open303ModelProfile* m = find303Model(index);
+    return m ? m->id : nullptr;
+}
+
+/** Human-readable label of the model at @p index, or 0. */
+EMSCRIPTEN_KEEPALIVE
+const char* open303_get_model_label(int index)
+{
+    const Open303ModelProfile* m = find303Model(index);
+    return m ? m->label : nullptr;
+}
+
+/** Engine family of the model at @p index (TB303EngineKind), or -1. */
+EMSCRIPTEN_KEEPALIVE
+int open303_get_model_engine(int index)
+{
+    const Open303ModelProfile* m = find303Model(index);
+    return m ? m->engine : -1;
+}
+
+/** Apply the model profile at @p index to an open303 instance. Returns 1 on
+ *  success, 0 for an unknown index, a jc303-family model, or a bad handle. */
+EMSCRIPTEN_KEEPALIVE
+int open303_set_model(uintptr_t handle, int index)
+{
+    Open303Instance* inst = lookupInstance(handle);
+    return inst ? inst->setModel(index) : 0;
+}
+
+/** Currently applied model index for an open303 instance (default 0 = stock). */
+EMSCRIPTEN_KEEPALIVE
+int open303_get_model(uintptr_t handle)
+{
+    Open303Instance* inst = lookupInstance(handle);
+    return inst ? inst->modelIndex : -1;
+}
+
 } // extern "C"
+
+/** JSON list of all registered 303 models for dynamic UI population:
+ *  [{"id":"stock-open303","label":"Stock Open303","engine":"open303"}, …] */
+static std::string getAvailable303Models()
+{
+    std::string json = "[";
+    for (int i = 0; i < k303ModelCount; ++i) {
+        const Open303ModelProfile& m = k303Models[i];
+        if (i > 0) json += ",";
+        json += "{\"id\":\"";
+        json += m.id;
+        json += "\",\"label\":\"";
+        json += m.label;
+        json += "\",\"engine\":\"";
+        json += (m.engine == ENGINE_JC303) ? "jc303" : "open303";
+        json += "\"}";
+    }
+    json += "]";
+    return json;
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Embind bindings  (makes the same functions callable from the JS module
@@ -445,4 +594,10 @@ EMSCRIPTEN_BINDINGS(open303_module) {
     function("open303_all_notes_off", &open303_all_notes_off);
     function("open303_set_param",     &open303_set_param);
     function("open303_process",       &open303_process);
+
+    function("open303_get_model_count",  &open303_get_model_count);
+    function("open303_get_model_engine", &open303_get_model_engine);
+    function("open303_set_model",        &open303_set_model);
+    function("open303_get_model",        &open303_get_model);
+    function("getAvailable303Models",    &getAvailable303Models);
 }

--- a/src/__tests__/RbsImporter.boundaries.test.ts
+++ b/src/__tests__/RbsImporter.boundaries.test.ts
@@ -25,6 +25,7 @@ const SYNTH_PARAM_KEYS = new Set(Object.keys({
   delayFeedback: 0,
   delayMix: 0,
   engine303: 'open303',
+  model303: 'stock-open303',
   pitchAttack: 0,
   pitchDecay: 0,
   pitchAmount: 0,
@@ -50,6 +51,7 @@ const BASS2_PARAM_KEYS = new Set(Object.keys({
   pitch: 0,
   pan: 0,
   engine303: 'open303',
+  model303: 'stock-open303',
   slideTime: 0,
   drive: 0,
 } satisfies Record<keyof Bass2Params, unknown>));

--- a/src/__tests__/TB303Models.test.ts
+++ b/src/__tests__/TB303Models.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Tests for the "303 Voices" model registry (src/engines/TB303Models.ts)
+ * and the model-selection plumbing through Open303Oscillator/Open303Manager.
+ *
+ * Covers:
+ *  - Registry integrity (unique stable ids, stock voices present + available)
+ *  - normalizeTB303Model: legacy engine303 fallback, unknown ids, unavailable
+ *    models falling back to their family's stock voice
+ *  - Open303Oscillator.setModel303() posts the set-303-model worklet message
+ *    with the engine-family fallback hint and re-pushes params
+ *  - Open303Manager model delegation + syncModel303Settings
+ *  - model303 survives a SavedSongData-style JSON round-trip
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+    TB303_MODELS,
+    getTB303Model,
+    getAvailableTB303Models,
+    normalizeTB303Model,
+    tb303ModelFamily,
+    stockModelForFamily,
+} from '../engines/TB303Models';
+import { Open303Oscillator } from '../engines/Open303Oscillator';
+import { Open303Manager } from '../engines/Open303Manager';
+import { DEFAULT_BASS2_PARAMS } from '../constants';
+import type { SynthParams, TB303ModelId } from '../types';
+
+// ---------------------------------------------------------------------------
+// Registry integrity
+// ---------------------------------------------------------------------------
+
+describe('TB303_MODELS registry', () => {
+    it('has unique ids', () => {
+        const ids = TB303_MODELS.map((m) => m.id);
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('contains both stock voices, available, on the right families', () => {
+        const stock = getTB303Model('stock-open303');
+        const jc = getTB303Model('jc303');
+        expect(stock).toMatchObject({ family: 'open303', available: true });
+        expect(jc).toMatchObject({ family: 'jc303', available: true });
+    });
+
+    it('lists stock-open303 first (safe default ordering for the UI)', () => {
+        expect(TB303_MODELS[0].id).toBe('stock-open303');
+    });
+
+    it('ships the first-wave experimental voices', () => {
+        expect(getTB303Model('experimental-01')?.available).toBe(true);
+        expect(getTB303Model('1ink303-v1')?.available).toBe(true);
+    });
+
+    it('catalogues the P2 character voices as not yet available', () => {
+        for (const id of ['rebirth-338-1.5', 'rebirth-2.0', 'mb33-mkii', 'raveolution']) {
+            const m = getTB303Model(id);
+            expect(m, id).toBeDefined();
+            expect(m!.available, id).toBe(false);
+        }
+    });
+
+    it('getAvailableTB303Models returns only available entries', () => {
+        const available = getAvailableTB303Models();
+        expect(available.length).toBeGreaterThanOrEqual(4);
+        expect(available.every((m) => m.available)).toBe(true);
+    });
+
+    it('every model has a label and a description (used for UI tooltips)', () => {
+        for (const m of TB303_MODELS) {
+            expect(m.label.length, m.id).toBeGreaterThan(0);
+            expect(m.description.length, m.id).toBeGreaterThan(0);
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeTB303Model
+// ---------------------------------------------------------------------------
+
+describe('normalizeTB303Model()', () => {
+    it('defaults to stock-open303 with no inputs', () => {
+        expect(normalizeTB303Model()).toBe('stock-open303');
+        expect(normalizeTB303Model(undefined, undefined)).toBe('stock-open303');
+    });
+
+    it('keeps a known, available model', () => {
+        expect(normalizeTB303Model('experimental-01')).toBe('experimental-01');
+        expect(normalizeTB303Model('jc303')).toBe('jc303');
+    });
+
+    it('maps legacy engine303 values when model303 is absent (old songs)', () => {
+        expect(normalizeTB303Model(undefined, 'jc303')).toBe('jc303');
+        expect(normalizeTB303Model(undefined, 'open303')).toBe('stock-open303');
+    });
+
+    it('model303 wins over a conflicting legacy engine303', () => {
+        expect(normalizeTB303Model('experimental-01', 'jc303')).toBe('experimental-01');
+    });
+
+    it('falls back to the family stock voice for catalogued-but-unavailable models', () => {
+        expect(normalizeTB303Model('rebirth-2.0')).toBe('jc303');          // jc303 family
+        expect(normalizeTB303Model('mb33-mkii')).toBe('stock-open303');    // open303 family
+    });
+
+    it('falls back for unknown ids from future song versions', () => {
+        expect(normalizeTB303Model('some-future-voice')).toBe('stock-open303');
+        expect(normalizeTB303Model('some-future-voice', 'jc303')).toBe('jc303');
+    });
+});
+
+describe('family helpers', () => {
+    it('tb303ModelFamily resolves families and defaults to open303', () => {
+        expect(tb303ModelFamily('jc303')).toBe('jc303');
+        expect(tb303ModelFamily('experimental-01')).toBe('open303');
+        expect(tb303ModelFamily('nope')).toBe('open303');
+        expect(tb303ModelFamily(undefined)).toBe('open303');
+    });
+
+    it('stockModelForFamily returns the stock voice per family', () => {
+        expect(stockModelForFamily('open303')).toBe('stock-open303');
+        expect(stockModelForFamily('jc303')).toBe('jc303');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Open303Oscillator.setModel303
+// ---------------------------------------------------------------------------
+
+describe('Open303Oscillator.setModel303()', () => {
+    let oscillator: Open303Oscillator;
+    let mockPostMessage: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        oscillator = new Open303Oscillator();
+        mockPostMessage = vi.fn();
+        const fakePort = { postMessage: mockPostMessage } as unknown as MessagePort;
+        const fakeNode = { port: fakePort } as unknown as AudioWorkletNode;
+        (oscillator as any).workletNode = fakeNode;
+        (oscillator as any).isReady = true;
+    });
+
+    it('posts set-303-model with the engine-family fallback hint and re-pushes params', () => {
+        oscillator.setModel303('experimental-01');
+
+        expect(mockPostMessage).toHaveBeenCalledWith({
+            type: 'set-303-model',
+            data: { model: 'experimental-01', engine: 'open303' },
+        });
+        expect(mockPostMessage.mock.calls.some(
+            (call) => call[0]?.type === 'param' && call[0]?.data?.func === 'jc303_setCutoff',
+        )).toBe(true);
+    });
+
+    it('selecting the jc303 voice carries engine="jc303"', () => {
+        oscillator.setModel303('jc303');
+        expect(mockPostMessage).toHaveBeenCalledWith({
+            type: 'set-303-model',
+            data: { model: 'jc303', engine: 'jc303' },
+        });
+    });
+
+    it('normalizes unknown model ids to stock-open303', () => {
+        oscillator.setModel303('definitely-not-a-voice');
+        expect(mockPostMessage).toHaveBeenCalledWith({
+            type: 'set-303-model',
+            data: { model: 'stock-open303', engine: 'open303' },
+        });
+        expect(oscillator.getModel303()).toBe('stock-open303');
+    });
+
+    it('legacy setEngine303 keeps the model state in sync', () => {
+        oscillator.setEngine303('jc303');
+        expect(oscillator.getModel303()).toBe('jc303');
+        oscillator.setEngine303('open303');
+        expect(oscillator.getModel303()).toBe('stock-open303');
+    });
+
+    it('does nothing when workletNode is null (model still persisted for later)', () => {
+        (oscillator as any).workletNode = null;
+        oscillator.setModel303('1ink303-v1');
+        expect(mockPostMessage).not.toHaveBeenCalled();
+        expect(oscillator.getModel303()).toBe('1ink303-v1');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Open303Manager model delegation
+// ---------------------------------------------------------------------------
+
+describe('Open303Manager model selection', () => {
+    let manager: Open303Manager;
+    let bass1SetModel: ReturnType<typeof vi.fn>;
+    let bass2SetModel: ReturnType<typeof vi.fn>;
+    let leadSetModel: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        manager = new Open303Manager();
+        bass1SetModel = vi.fn();
+        bass2SetModel = vi.fn();
+        leadSetModel = vi.fn();
+
+        (manager as any).bass1 = { setModel303: bass1SetModel } as unknown as Open303Oscillator;
+        (manager as any).bass2 = { setModel303: bass2SetModel } as unknown as Open303Oscillator;
+        (manager as any).lead303 = { setModel303: leadSetModel } as unknown as Open303Oscillator;
+    });
+
+    it('setBass1Model / setBass2Model / setLead303Model delegate independently', () => {
+        manager.setBass1Model('experimental-01');
+        manager.setBass2Model('jc303');
+        manager.setLead303Model('1ink303-v1');
+
+        expect(bass1SetModel).toHaveBeenCalledWith('experimental-01');
+        expect(bass2SetModel).toHaveBeenCalledWith('jc303');
+        expect(leadSetModel).toHaveBeenCalledWith('1ink303-v1');
+    });
+
+    it('model setters are no-ops when the oscillator is null', () => {
+        (manager as any).bass1 = null;
+        (manager as any).bass2 = null;
+        (manager as any).lead303 = null;
+        expect(() => {
+            manager.setBass1Model('jc303');
+            manager.setBass2Model('jc303');
+            manager.setLead303Model('jc303');
+        }).not.toThrow();
+    });
+
+    it('syncModel303Settings applies every provided voice', () => {
+        manager.syncModel303Settings({
+            lead: 'jc303',
+            bass1: 'stock-open303',
+            bass2: 'experimental-01',
+        });
+        expect(leadSetModel).toHaveBeenCalledWith('jc303');
+        expect(bass1SetModel).toHaveBeenCalledWith('stock-open303');
+        expect(bass2SetModel).toHaveBeenCalledWith('experimental-01');
+    });
+
+    it('syncModel303Settings skips omitted voices', () => {
+        manager.syncModel303Settings({ bass2: 'jc303' });
+        expect(bass2SetModel).toHaveBeenCalledWith('jc303');
+        expect(leadSetModel).not.toHaveBeenCalled();
+        expect(bass1SetModel).not.toHaveBeenCalled();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+describe('model303 persistence', () => {
+    it('DEFAULT_BASS2_PARAMS carries the stock voice and the legacy mirror', () => {
+        expect(DEFAULT_BASS2_PARAMS.model303).toBe('stock-open303');
+        expect(DEFAULT_BASS2_PARAMS.engine303).toBe('open303');
+    });
+
+    it('model303 survives a JSON round-trip on SynthParams', () => {
+        const params: SynthParams = {
+            waveform: '303-saw',
+            pitch: 0,
+            filterCutoff: 3000,
+            filterResonance: 8,
+            attack: 0.01,
+            decay: 0.3,
+            sustain: 0,
+            release: 0.1,
+            length: 0.25,
+            volume: 0.8,
+            delayTime: 0,
+            delayFeedback: 0,
+            delayMix: 0,
+            engine303: 'open303',
+            model303: 'experimental-01',
+        };
+        const restored = JSON.parse(JSON.stringify(params)) as SynthParams;
+        expect(restored.model303).toBe('experimental-01');
+        // A legacy build reading the same song still gets a valid stock engine.
+        expect(restored.engine303).toBe('open303');
+    });
+
+    it('legacy songs (engine303 only) resolve to the correct voices on load', () => {
+        const legacyA = { engine303: 'jc303' as const };
+        const legacyB = {};
+        expect(normalizeTB303Model(undefined, legacyA.engine303)).toBe('jc303');
+        expect(normalizeTB303Model(undefined, (legacyB as { engine303?: string }).engine303)).toBe('stock-open303');
+    });
+
+    it('every available model id round-trips as a TB303ModelId', () => {
+        for (const m of getAvailableTB303Models()) {
+            const restored = JSON.parse(JSON.stringify({ model303: m.id })) as { model303: TB303ModelId };
+            expect(normalizeTB303Model(restored.model303)).toBe(m.id);
+        }
+    });
+});

--- a/src/audio-worklets/open303-processor.ts
+++ b/src/audio-worklets/open303-processor.ts
@@ -79,6 +79,13 @@ class Open303Processor extends AudioWorkletProcessor {
      *  'jc303'   = authentic rosic::Open303 (jc303_* multi-instance API)
      */
     private activeEngine: 'open303' | 'jc303' = 'open303';
+
+    /** Native 303 model registry (open303_get_model_* exports), discovered at
+     *  init. null = the loaded WASM predates the voices architecture; model
+     *  selection then degrades to plain engine-family switching. */
+    private modelRegistry: Map<string, { index: number; engine: 'open303' | 'jc303' }> | null = null;
+    /** Currently selected 303 voice/model id (informational). */
+    private activeModel: string = 'stock-open303';
     private readonly perf = new WorkletPerfReporter(this.port, 'open303');
 
     // Mild makeup gain — hyphon_native 303 engines already run near full scale.
@@ -123,7 +130,7 @@ class Open303Processor extends AudioWorkletProcessor {
         }
 
         if (this.synthState !== SynthState.READY || !this.wasmInstance) {
-            if (type === 'set-engine' || type === 'param') {
+            if (type === 'set-engine' || type === 'set-303-model' || type === 'param') {
                 this.pendingMessages.push({ type, data });
             }
             return;
@@ -141,6 +148,8 @@ class Open303Processor extends AudioWorkletProcessor {
             this.handleNoteOff(data.note);
         } else if (type === 'set-engine') {
             this.handleSetEngine(data.engine as 'open303' | 'jc303');
+        } else if (type === 'set-303-model') {
+            this.handleSetModel(data.model as string, data.engine as 'open303' | 'jc303' | undefined);
         } else if (type === 'param') {
             this.applyParamMessage(exports, data);
         }
@@ -405,6 +414,8 @@ class Open303Processor extends AudioWorkletProcessor {
             // so that per-voice engine switching works without a full reinit.
             this.initializeJc303MultiInstance(exports, sampleRate);
 
+            this.discoverModelRegistry(exports);
+
             return true;
         } catch (e) {
             console.error('[Open303] Native API init failed:', e);
@@ -467,6 +478,91 @@ class Open303Processor extends AudioWorkletProcessor {
         this.activeEngine = engine;
         console.log(`[Open303] Engine switched to: ${engine}`);
         this.port.postMessage({ type: 'engine-changed', data: { engine } });
+    }
+
+    /** Read a null-terminated UTF-8 string from the WASM heap. */
+    private readWasmCString(ptr: number | bigint | null | undefined): string | null {
+        const memory =
+            (this.wasmInstance?.exports as { memory?: WebAssembly.Memory } | undefined)?.memory
+            ?? this.importedMemory;
+        const start = typeof ptr === 'bigint' ? Number(ptr) : ptr;
+        if (!memory?.buffer || !start || !Number.isFinite(start) || start <= 0) return null;
+
+        const bytes = new Uint8Array(memory.buffer);
+        let end = start;
+        const limit = Math.min(bytes.length, start + 256); // model ids are short
+        while (end < limit && bytes[end] !== 0) end++;
+        if (end === start) return null;
+
+        let str = '';
+        for (let i = start; i < end; i++) str += String.fromCharCode(bytes[i]);
+        return str;
+    }
+
+    /** Discover the native 303 model registry (open303_get_model_* exports).
+     *  Absent on WASM builds that predate the voices architecture — model
+     *  selection then falls back to plain engine-family switching. */
+    private discoverModelRegistry(exports: any): void {
+        if (typeof exports.open303_get_model_count !== 'function' ||
+            typeof exports.open303_get_model_id !== 'function' ||
+            typeof exports.open303_get_model_engine !== 'function') {
+            console.log('[Open303] Native 303 model registry not available in this WASM build');
+            return;
+        }
+        try {
+            const count = Number(exports.open303_get_model_count());
+            if (!Number.isFinite(count) || count <= 0 || count > 64) return;
+
+            const registry = new Map<string, { index: number; engine: 'open303' | 'jc303' }>();
+            for (let i = 0; i < count; i++) {
+                const id = this.readWasmCString(exports.open303_get_model_id(i));
+                if (!id) continue;
+                const engine = Number(exports.open303_get_model_engine(i)) === 1 ? 'jc303' : 'open303';
+                registry.set(id, { index: i, engine });
+            }
+            if (registry.size > 0) {
+                this.modelRegistry = registry;
+                console.log(`[Open303] Native 303 model registry: ${[...registry.keys()].join(', ')}`);
+            }
+        } catch (e) {
+            console.warn('[Open303] Failed to read native 303 model registry:', e);
+            this.modelRegistry = null;
+        }
+    }
+
+    /** Select the active 303 voice/model. Resolves the engine family from the
+     *  native registry when available, otherwise trusts the fallbackEngine hint
+     *  sent by Open303Oscillator (mirrored TS registry). */
+    private handleSetModel(model: string, fallbackEngine?: 'open303' | 'jc303'): void {
+        const entry = this.modelRegistry?.get(model);
+        const engine = entry?.engine ?? fallbackEngine ?? 'open303';
+
+        if (engine === 'jc303' && !this.hasJc303MultiApi) {
+            console.warn(`[Open303] Model "${model}" needs the JC303 engine which is unavailable — ignoring`);
+            return;
+        }
+
+        const exports = this.getExports();
+
+        // Apply the coefficient profile to the custom open303 instance.
+        if (entry && engine === 'open303' && this.isNativeApi &&
+            typeof exports.open303_set_model === 'function') {
+            try {
+                exports.open303_set_model(this.toWasmHandle(this.instanceHandle), entry.index);
+            } catch (e) {
+                console.warn(`[Open303] open303_set_model("${model}") failed:`, e);
+            }
+        }
+
+        if (engine !== this.activeEngine) {
+            // Release any held notes on the current engine before switching
+            this.clearAllNotes();
+            this.activeEngine = engine;
+        }
+
+        this.activeModel = model;
+        console.log(`[Open303] 303 model set to: ${model} (engine=${engine}, native=${entry !== undefined})`);
+        this.port.postMessage({ type: 'model-changed', data: { model, engine } });
     }
 
     private initializeLegacyApi(exports: any, sampleRate: number): boolean {

--- a/src/components/Engine303Selector.tsx
+++ b/src/components/Engine303Selector.tsx
@@ -12,6 +12,10 @@ interface Engine303SelectorProps {
 }
 
 /**
+ * @deprecated Superseded by Voice303Selector (dynamic "303 Voice" list driven
+ * by the TB303_MODELS registry). Kept for backward compatibility only — the
+ * rack panels now render Voice303Selector.
+ *
  * Engine selector toggle for TB-303 voices (SYNTH A, SYNTH B and BASS 2).
  *
  * Lets the user switch between:

--- a/src/components/Voice303Selector.tsx
+++ b/src/components/Voice303Selector.tsx
@@ -1,0 +1,97 @@
+import React, { memo } from 'react';
+import type { TB303ModelId } from '../types';
+import { getAvailableTB303Models, tb303ModelFamily } from '../engines/TB303Models';
+import { HelpIconButton, HelpTip } from './help/HelpTip';
+
+interface Voice303SelectorProps {
+    /** Currently active 303 voice/model for this track. */
+    model: TB303ModelId;
+    /** Called when the user selects a different voice. */
+    onChange: (model: TB303ModelId) => void;
+    /** Accent colour matching the rack module (default: 'pink'). */
+    accentColor?: 'pink' | 'cyan';
+}
+
+/**
+ * "303 Voice" selector for TB-303 tracks (SYNTH A, SYNTH B and BASS 2).
+ *
+ * Successor of the two-way Engine303Selector: the list is populated
+ * dynamically from the TB303_MODELS registry (src/engines/TB303Models.ts),
+ * so new voices added to the C++ registry + TS mirror appear here without
+ * touching this component. Each track picks its voice independently.
+ */
+export const Voice303Selector: React.FC<Voice303SelectorProps> = memo(({
+    model,
+    onChange,
+    accentColor = 'pink',
+}) => {
+    const models = getAvailableTB303Models();
+    const activeFamily = tb303ModelFamily(model);
+
+    // Themed by engine family (open303 = emerald, jc303 = teal), matching the
+    // established osc-type visual treatment. Part accent (cyan/pink) is used
+    // for the header label/badge.
+    const openActive = 'bg-gradient-to-b from-emerald-500 to-emerald-600 text-white border-emerald-400 shadow-[0_0_12px_rgba(16,185,129,0.5),inset_0_1px_0_rgba(255,255,255,0.2)]';
+    const jcActive = 'bg-gradient-to-b from-teal-500 to-teal-600 text-white border-teal-400 shadow-[0_0_12px_rgba(20,184,166,0.5),inset_0_1px_0_rgba(255,255,255,0.2)]';
+    const inactiveStyle = 'bg-gradient-to-b from-zinc-800 to-zinc-900 text-zinc-400 border-zinc-700 hover:text-zinc-200 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]';
+
+    const badgeColorStyle = accentColor === 'cyan'
+        ? 'bg-cyan-950/90 text-cyan-300 border-cyan-500/60'
+        : 'bg-pink-950/90 text-pink-300 border-pink-500/60';
+
+    const labelColorStyle = accentColor === 'cyan'
+        ? 'text-cyan-400/70'
+        : 'text-pink-400/70';
+
+    const borderColorStyle = accentColor === 'cyan'
+        ? 'border-cyan-500/20'
+        : 'border-pink-500/20';
+
+    return (
+        <HelpTip topicId="engine-303-switch" showOnFirstUse position="right" className="w-full">
+        <div
+            className={`flex flex-col gap-1 p-2 rounded-lg bg-zinc-950/80 border ${borderColorStyle} w-full`}
+            role="group"
+            aria-label="303 voice selection"
+        >
+            {/* Row: "303 Voice" label + active-family badge */}
+            <div className="flex items-center justify-between gap-1">
+                <span className={`text-[8px] font-mono uppercase tracking-wider ${labelColorStyle}`}>
+                    303 Voice
+                </span>
+                <div className="flex items-center gap-1">
+                    <span
+                        className={`text-[7px] font-bold uppercase tracking-widest px-1.5 py-0.5 rounded-full border ${badgeColorStyle}`}
+                        title={`Active engine family: ${activeFamily === 'jc303' ? 'authentic rosic::Open303 (jc303)' : 'custom Open303'}`}
+                        aria-label={`${activeFamily === 'jc303' ? 'JC303' : 'Open303'} engine family active`}
+                    >
+                        {activeFamily === 'jc303' ? 'JC303' : 'OPEN303'}
+                    </span>
+                    <HelpIconButton topicId="engine-303-switch" />
+                </div>
+            </div>
+
+            {models.map((m) => {
+                const isActive = m.id === model;
+                return (
+                    <button
+                        type="button"
+                        key={m.id}
+                        onClick={() => onChange(m.id)}
+                        title={m.description}
+                        aria-pressed={isActive}
+                        aria-label={`Select ${m.label} voice`}
+                        className={`px-3 py-1.5 text-[9px] font-bold rounded-md transition-all border focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 ${
+                            isActive
+                                ? (m.family === 'jc303' ? jcActive : openActive)
+                                : inactiveStyle
+                        }`}
+                    >
+                        {m.label}
+                    </button>
+                );
+            })}
+        </div>
+        </HelpTip>
+    );
+});

--- a/src/components/__tests__/Voice303Selector.test.tsx
+++ b/src/components/__tests__/Voice303Selector.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { Voice303Selector } from '../Voice303Selector';
+import { getAvailableTB303Models } from '../../engines/TB303Models';
+
+describe('Voice303Selector', () => {
+    it('renders one button per available voice from the registry', () => {
+        render(<Voice303Selector model="stock-open303" onChange={vi.fn()} />);
+        for (const m of getAvailableTB303Models()) {
+            expect(screen.getByRole('button', { name: `Select ${m.label} voice` })).toBeInTheDocument();
+        }
+    });
+
+    it('marks the active voice with aria-pressed', () => {
+        render(<Voice303Selector model="experimental-01" onChange={vi.fn()} />);
+        expect(screen.getByRole('button', { name: 'Select Experimental 01 voice' }))
+            .toHaveAttribute('aria-pressed', 'true');
+        expect(screen.getByRole('button', { name: 'Select Stock Open303 voice' }))
+            .toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('calls onChange with the picked model id', () => {
+        const onChange = vi.fn();
+        render(<Voice303Selector model="stock-open303" onChange={onChange} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Select Authentic JC303 voice' }));
+        expect(onChange).toHaveBeenCalledWith('jc303');
+    });
+
+    it('exposes the voice description as a tooltip', () => {
+        render(<Voice303Selector model="stock-open303" onChange={vi.fn()} />);
+        for (const m of getAvailableTB303Models()) {
+            expect(screen.getByRole('button', { name: `Select ${m.label} voice` }))
+                .toHaveAttribute('title', m.description);
+        }
+    });
+
+    it('shows the OPEN303 family badge for open303-family voices', () => {
+        render(<Voice303Selector model="1ink303-v1" onChange={vi.fn()} />);
+        expect(screen.getByLabelText('Open303 engine family active')).toBeInTheDocument();
+    });
+
+    it('shows the JC303 family badge when a jc303-family voice is active', () => {
+        render(<Voice303Selector model="jc303" onChange={vi.fn()} />);
+        expect(screen.getByLabelText('JC303 engine family active')).toBeInTheDocument();
+    });
+
+    it('is grouped and labelled for assistive tech', () => {
+        render(<Voice303Selector model="stock-open303" onChange={vi.fn()} />);
+        expect(screen.getByRole('group', { name: '303 voice selection' })).toBeInTheDocument();
+    });
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -72,6 +72,7 @@ export const DEFAULT_BASS2_PARAMS = {
   envMod: 0.5,
   volume: 0.45,
   engine303: 'open303' as const,
+  model303: 'stock-open303' as const,
 };
 
 export const DEFAULT_KICK_PARAMS: KickParams = { pitch: 60, decay: 0.4, tone: 0.9, volume: 1 };

--- a/src/engines/Open303Manager.ts
+++ b/src/engines/Open303Manager.ts
@@ -1,4 +1,5 @@
 import type { Bass2Params } from '../types';
+import type { TB303ModelId } from './TB303Models';
 import { Open303Oscillator } from './Open303Oscillator';
 import { engineTelemetry, logEngineFallback } from '../utils/engineTelemetry';
 import type { Open303Config } from './Open303Params';
@@ -721,5 +722,38 @@ export class Open303Manager {
         if (settings.lead) this.setLead303Engine(settings.lead);
         if (settings.bass1) this.setBass1Engine(settings.bass1);
         if (settings.bass2) this.setBass2Engine(settings.bass2);
+    }
+
+    // -------------------------------------------------------------------------
+    // 303 voice/model selection (see engines/TB303Models.ts)
+    // -------------------------------------------------------------------------
+
+    /** Select the 303 voice/model for the bass1 (SYNTH B / partB) voice. */
+    setBass1Model(model: TB303ModelId): void {
+        this.bass1?.setModel303(model);
+    }
+
+    /** Select the 303 voice/model for the bass2 (BASS 2) voice. */
+    setBass2Model(model: TB303ModelId): void {
+        this.bass2?.setModel303(model);
+    }
+
+    /** Select the 303 voice/model for the lead303 (SYNTH A / LEAD) voice. */
+    setLead303Model(model: TB303ModelId): void {
+        this.lead303?.setModel303(model);
+    }
+
+    /**
+     * Apply persisted per-voice model303 settings after audio init or song load.
+     * The model-aware successor of syncEngine303Settings.
+     */
+    syncModel303Settings(settings: {
+        lead?: TB303ModelId;
+        bass1?: TB303ModelId;
+        bass2?: TB303ModelId;
+    }): void {
+        if (settings.lead) this.setLead303Model(settings.lead);
+        if (settings.bass1) this.setBass1Model(settings.bass1);
+        if (settings.bass2) this.setBass2Model(settings.bass2);
     }
 }

--- a/src/engines/Open303Oscillator.ts
+++ b/src/engines/Open303Oscillator.ts
@@ -1,5 +1,7 @@
 import type { Open303Params, Open303Config } from './Open303Params';
 import { DEFAULT_303_PARAMS } from './Open303Params';
+import type { TB303ModelId } from './TB303Models';
+import { normalizeTB303Model, stockModelForFamily, tb303ModelFamily } from './TB303Models';
 import { FallbackBassSynth } from './FallbackBassSynth';
 import {
     engineTelemetry,
@@ -30,6 +32,8 @@ export class Open303Oscillator {
     private params: Open303Params = { ...DEFAULT_303_PARAMS };
     /** Persisted engine choice — applied once the worklet is ready. */
     private engine303: 'open303' | 'jc303' = 'open303';
+    /** Persisted 303 voice/model choice — applied once the worklet is ready. */
+    private model303: TB303ModelId = 'stock-open303';
     public isReady: boolean = false;
     public isFallback: boolean = false;
 
@@ -175,7 +179,7 @@ export class Open303Oscillator {
 
             this.isReady = true;
             this.isFallback = false;
-            this.applyEngine303();
+            this.applyModel303();
             this.applyAllParameters();
             try { engineTelemetry.registerResolution('open303', isNative ? 'wasm-native' : 'wasm', 'worklet-ready'); } catch (_) {}
             return true;
@@ -264,12 +268,46 @@ export class Open303Oscillator {
      */
     setEngine303(engine: 'open303' | 'jc303'): void {
         this.engine303 = engine;
+        this.model303 = stockModelForFamily(engine);
         this.applyEngine303();
     }
 
     private applyEngine303(): void {
         if (!this.workletNode) return;
         this.workletNode.port.postMessage({ type: 'set-engine', data: { engine: this.engine303 } });
+        if (this.isReady) {
+            // Params were routed to the previous engine — push them to the new one.
+            this.applyAllParameters();
+        }
+    }
+
+    /**
+     * Select the 303 voice/model for this oscillator (see engines/TB303Models.ts).
+     *
+     * Unknown or not-yet-shipped models normalize to the stock voice of their
+     * engine family. When the loaded WASM predates the model registry the
+     * worklet falls back to plain engine-family switching, so stock voices
+     * always work.
+     */
+    setModel303(model: TB303ModelId | string): void {
+        this.model303 = normalizeTB303Model(model);
+        this.engine303 = tb303ModelFamily(this.model303);
+        this.applyModel303();
+    }
+
+    /** Currently selected 303 voice/model. */
+    getModel303(): TB303ModelId {
+        return this.model303;
+    }
+
+    private applyModel303(): void {
+        if (!this.workletNode) return;
+        this.workletNode.port.postMessage({
+            type: 'set-303-model',
+            // engine is included so the worklet can route correctly even when
+            // the WASM build has no native model registry (pre-voices builds).
+            data: { model: this.model303, engine: this.engine303 },
+        });
         if (this.isReady) {
             // Params were routed to the previous engine — push them to the new one.
             this.applyAllParameters();

--- a/src/engines/TB303Models.ts
+++ b/src/engines/TB303Models.ts
@@ -1,0 +1,169 @@
+/**
+ * TB303Models.ts — the "303 Voices" registry.
+ *
+ * A TB-303 *model* (a.k.a. voice) is a named sound character built on top of
+ * one of the two DSP engine families compiled into hyphon_native.wasm:
+ *
+ *  - 'open303' family — custom synthesizer (emscripten/open303_wrapper.cpp).
+ *    Models in this family are coefficient profiles applied to the same DSP
+ *    topology (filter curves, envelope ranges, accent punch, waveshaping).
+ *  - 'jc303' family — authentic rosic::Open303 (emscripten/jc303_wrapper.cpp).
+ *
+ * This registry is mirrored by `k303Models[]` in emscripten/open303_wrapper.cpp.
+ * Adding a new voice:
+ *   1. Add a profile row to `k303Models[]` in open303_wrapper.cpp and rebuild
+ *      the WASM (`pnpm run build:emcc`).
+ *   2. Add a matching entry here with `available: true`.
+ * Every call site (UI selector, worklet routing, song load/save) picks the new
+ * voice up from this list — no other changes required.
+ *
+ * Backward compatibility: songs saved before the voices architecture carry an
+ * `engine303: 'open303' | 'jc303'` field. `normalizeTB303Model()` maps those
+ * (and any unknown/future ids) onto a valid model id, so legacy songs load
+ * with the exact stock sound they were saved with.
+ */
+
+/** Which WASM API family a model is built on. Matches the legacy Engine303 type. */
+export type Engine303Family = 'open303' | 'jc303';
+
+export type TB303ModelId =
+  | 'stock-open303'
+  | 'jc303'
+  | 'rebirth-338-1.5'
+  | 'rebirth-2.0'
+  | 'mb33-mkii'
+  | 'raveolution'
+  | '1ink303-v1'        // in-house
+  | 'experimental-01';  // scratchpad
+
+export interface TB303ModelInfo {
+  id: TB303ModelId;
+  /** Full human-readable name (tooltip / docs). */
+  label: string;
+  /** Short label for tight UI (selector buttons). */
+  shortLabel: string;
+  /** One-line character description shown as a tooltip. */
+  description: string;
+  /** DSP engine family the model runs on. */
+  family: Engine303Family;
+  /**
+   * Whether the DSP profile for this model has shipped in hyphon_native.wasm.
+   * Catalogued-but-unavailable models are hidden from the UI selector and
+   * normalize to the stock model of their family when loaded from a song.
+   */
+  available: boolean;
+}
+
+/**
+ * The 303 voice catalog, in display order. Stock voices first.
+ * Keep ids stable forever — they are persisted in saved songs.
+ */
+export const TB303_MODELS: readonly TB303ModelInfo[] = [
+  {
+    id: 'stock-open303',
+    label: 'Stock Open303',
+    shortLabel: 'Stock 303',
+    description: 'Built-in custom Open303 synthesizer — the pristine default voice.',
+    family: 'open303',
+    available: true,
+  },
+  {
+    id: 'jc303',
+    label: 'Authentic JC303',
+    shortLabel: 'JC303',
+    description: 'Authentic rosic::Open303 DSP from the jc303_wasm submodule — accurate TB-303 behaviour.',
+    family: 'jc303',
+    available: true,
+  },
+  {
+    id: '1ink303-v1',
+    label: '1ink303 v1',
+    shortLabel: '1ink v1',
+    description: 'In-house voice — warmer filter base, rounder accent, slower slides.',
+    family: 'open303',
+    available: true,
+  },
+  {
+    id: 'experimental-01',
+    label: 'Experimental 01',
+    shortLabel: 'Exp 01',
+    description: 'Scratchpad voice — hotter resonance feedback, snappier envelope, harder accent punch.',
+    family: 'open303',
+    available: true,
+  },
+  {
+    id: 'rebirth-338-1.5',
+    label: 'ReBirth RB-338 1.5',
+    shortLabel: 'RB-338 1.5',
+    description: 'ReBirth 1.5 character profile (filter/env/accent) — coming soon.',
+    family: 'jc303',
+    available: false,
+  },
+  {
+    id: 'rebirth-2.0',
+    label: 'ReBirth 2.0',
+    shortLabel: 'RB 2.0',
+    description: 'ReBirth 2.0 character profile — coming soon.',
+    family: 'jc303',
+    available: false,
+  },
+  {
+    id: 'mb33-mkii',
+    label: 'MB33 mkII',
+    shortLabel: 'MB33',
+    description: 'MAM MB33 mkII character profile — coming soon.',
+    family: 'open303',
+    available: false,
+  },
+  {
+    id: 'raveolution',
+    label: 'Raveolution 309',
+    shortLabel: 'Rave 309',
+    description: 'Quasimidi Raveolution character profile — coming soon.',
+    family: 'open303',
+    available: false,
+  },
+];
+
+const MODEL_BY_ID: ReadonlyMap<string, TB303ModelInfo> = new Map(
+  TB303_MODELS.map((m) => [m.id, m]),
+);
+
+/** Look up a model entry by id. Returns undefined for unknown ids. */
+export function getTB303Model(id: string | undefined): TB303ModelInfo | undefined {
+  return id ? MODEL_BY_ID.get(id) : undefined;
+}
+
+/** Models selectable in the UI (DSP profile shipped in the WASM build). */
+export function getAvailableTB303Models(): TB303ModelInfo[] {
+  return TB303_MODELS.filter((m) => m.available);
+}
+
+/** The engine family a model runs on ('open303' for anything unknown). */
+export function tb303ModelFamily(id: string | undefined): Engine303Family {
+  return getTB303Model(id)?.family ?? 'open303';
+}
+
+/** Stock (default) model id for an engine family. */
+export function stockModelForFamily(family: Engine303Family): TB303ModelId {
+  return family === 'jc303' ? 'jc303' : 'stock-open303';
+}
+
+/**
+ * Resolve a persisted model/engine pair to a valid, available model id.
+ *
+ *  - A known, available `model303` wins.
+ *  - A known-but-unavailable model falls back to its family's stock voice.
+ *  - Otherwise the legacy `engine303` field decides ('jc303' → 'jc303').
+ *  - Default: 'stock-open303'.
+ */
+export function normalizeTB303Model(
+  model303?: string,
+  engine303?: string,
+): TB303ModelId {
+  const model = getTB303Model(model303);
+  if (model) {
+    return model.available ? model.id : stockModelForFamily(model.family);
+  }
+  return engine303 === 'jc303' ? 'jc303' : 'stock-open303';
+}

--- a/src/hooks/appState/useHardwarePanels.tsx
+++ b/src/hooks/appState/useHardwarePanels.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
-import { Engine303Selector } from '../../components/Engine303Selector'
+import { Voice303Selector } from '../../components/Voice303Selector'
+import { normalizeTB303Model, stockModelForFamily, tb303ModelFamily } from '../../engines/TB303Models'
 import { ProphecyPanel } from '../../components/ProphecyPanel'
 import { CppPanel } from '../../components/CppPanel'
 import { OscillatorTypeSelector } from '../../components/OscillatorTypeSelector'
@@ -7,7 +8,7 @@ import { OscillatorVariantSelector } from '../../components/OscillatorVariantSel
 import { SamplerPanel } from '../../components/SamplerPanel'
 import { engineTelemetry } from '../../utils/engineTelemetry'
 import type { AlignmentResult } from '../../engines/rubberband/PhonemeAligner'
-import type { SynthParams, Bass2Params, SamplerParams, OscillatorType } from '../../types'
+import type { SynthParams, Bass2Params, SamplerParams, OscillatorType, TB303ModelId } from '../../types'
 import { waveformToOscillatorType, getDefaultWaveformForType, getOscillatorPanelClasses } from '../../types'
 
 export function useHardwarePanels(deps: {
@@ -54,26 +55,32 @@ export function useHardwarePanels(deps: {
     const synthAChild = useMemo(() => {
         const is303 = synthA.waveform === '303-saw' || synthA.waveform === '303-sqr';
         const isProphecy = synthA.waveform?.startsWith('prophecy-') ?? false;
-        const engine = synthA.engine303 ?? 'open303';
-        const currentTypeA: OscillatorType = waveformToOscillatorType(synthA.waveform, synthA.engine303);
+        const modelA = normalizeTB303Model(synthA.model303, synthA.engine303);
+        const currentTypeA: OscillatorType = waveformToOscillatorType(synthA.waveform, tb303ModelFamily(modelA));
         const panelClassesA = getOscillatorPanelClasses(currentTypeA);
 
-        const handleSynthAEngineChange = (e: 'open303' | 'jc303') => {
-            updateSynthA({ engine303: e });
+        const handleSynthAVoiceChange = (m: TB303ModelId) => {
+            // engine303 is mirrored for older builds loading the saved song.
+            updateSynthA({ model303: m, engine303: tb303ModelFamily(m) });
             const mgr = audioEngine?.open303Engine;
-            if (mgr && 'setLead303Engine' in mgr) (mgr as any).setLead303Engine(e);
-            engineTelemetry.registerResolution('synthA-engine303', e, 'user-initiated');
+            if (mgr && 'setLead303Model' in mgr) (mgr as any).setLead303Model(m);
+            else if (mgr && 'setLead303Engine' in mgr) (mgr as any).setLead303Engine(tb303ModelFamily(m));
+            engineTelemetry.registerResolution('synthA-model303', m, 'user-initiated');
         };
 
         const handleSynthATypeChange = (newType: OscillatorType) => {
             const nextWave = getDefaultWaveformForType(newType);
-            const nextEngine = (newType === 'jc303') ? 'jc303' : (newType === 'open303' ? 'open303' : undefined);
             const update: any = { waveform: nextWave };
-            if (nextEngine) update.engine303 = nextEngine;
-            updateSynthA(update);
             if (newType === 'open303' || newType === 'jc303') {
+                const nextModel = stockModelForFamily(newType);
+                update.model303 = nextModel;
+                update.engine303 = newType;
+                updateSynthA(update);
                 const mgr = audioEngine?.open303Engine;
-                if (mgr && 'setLead303Engine' in mgr) (mgr as any).setLead303Engine(nextEngine ?? 'open303');
+                if (mgr && 'setLead303Model' in mgr) (mgr as any).setLead303Model(nextModel);
+                else if (mgr && 'setLead303Engine' in mgr) (mgr as any).setLead303Engine(newType);
+            } else {
+                updateSynthA(update);
             }
             engineTelemetry.registerResolution('synthA-oscType', newType, 'user-initiated');
         };
@@ -105,7 +112,7 @@ export function useHardwarePanels(deps: {
                     />
                 )}
                 {is303 && (
-                    <Engine303Selector engine={engine} onChange={handleSynthAEngineChange} accentColor="cyan" />
+                    <Voice303Selector model={modelA} onChange={handleSynthAVoiceChange} accentColor="cyan" />
                 )}
                 {isProphecy && (
                     <ProphecyPanel
@@ -121,31 +128,36 @@ export function useHardwarePanels(deps: {
                 </div>
             </div>
         );
-    }, [synthA.waveform, synthA.engine303, synthA.vowel, synthA.portamento, synthA.formantShift, synthA.cppFine, updateSynthA, audioEngine]);
+    }, [synthA.waveform, synthA.engine303, synthA.model303, synthA.vowel, synthA.portamento, synthA.formantShift, synthA.cppFine, updateSynthA, audioEngine]);
 
     const synthBChild = useMemo(() => {
         const is303 = synthB.waveform === '303-saw' || synthB.waveform === '303-sqr';
         const isProphecy = synthB.waveform?.startsWith('prophecy-') ?? false;
-        const engine = synthB.engine303 ?? 'open303';
-        const currentTypeB: OscillatorType = waveformToOscillatorType(synthB.waveform, synthB.engine303);
+        const modelB = normalizeTB303Model(synthB.model303, synthB.engine303);
+        const currentTypeB: OscillatorType = waveformToOscillatorType(synthB.waveform, tb303ModelFamily(modelB));
         const panelClassesB = getOscillatorPanelClasses(currentTypeB);
 
-        const handleSynthBEngineChange = (e: 'open303' | 'jc303') => {
-            updateSynthB({ engine303: e });
+        const handleSynthBVoiceChange = (m: TB303ModelId) => {
+            updateSynthB({ model303: m, engine303: tb303ModelFamily(m) });
             const mgr = audioEngine?.open303Engine;
-            if (mgr && 'setBass1Engine' in mgr) mgr.setBass1Engine(e);
-            engineTelemetry.registerResolution('synthB-engine303', e, 'user-initiated');
+            if (mgr && 'setBass1Model' in mgr) (mgr as any).setBass1Model(m);
+            else if (mgr && 'setBass1Engine' in mgr) mgr.setBass1Engine(tb303ModelFamily(m));
+            engineTelemetry.registerResolution('synthB-model303', m, 'user-initiated');
         };
 
         const handleSynthBTypeChange = (newType: OscillatorType) => {
             const nextWave = getDefaultWaveformForType(newType);
-            const nextEngine = (newType === 'jc303') ? 'jc303' : (newType === 'open303' ? 'open303' : undefined);
             const update: any = { waveform: nextWave };
-            if (nextEngine) update.engine303 = nextEngine;
-            updateSynthB(update);
             if (newType === 'open303' || newType === 'jc303') {
+                const nextModel = stockModelForFamily(newType);
+                update.model303 = nextModel;
+                update.engine303 = newType;
+                updateSynthB(update);
                 const mgr = audioEngine?.open303Engine;
-                if (mgr && 'setBass1Engine' in mgr) mgr.setBass1Engine(nextEngine ?? 'open303');
+                if (mgr && 'setBass1Model' in mgr) (mgr as any).setBass1Model(nextModel);
+                else if (mgr && 'setBass1Engine' in mgr) mgr.setBass1Engine(newType);
+            } else {
+                updateSynthB(update);
             }
             engineTelemetry.registerResolution('synthB-oscType', newType, 'user-initiated');
         };
@@ -177,7 +189,7 @@ export function useHardwarePanels(deps: {
                     />
                 )}
                 {is303 && (
-                    <Engine303Selector engine={engine} onChange={handleSynthBEngineChange} accentColor="pink" />
+                    <Voice303Selector model={modelB} onChange={handleSynthBVoiceChange} accentColor="pink" />
                 )}
                 {isProphecy && (
                     <ProphecyPanel
@@ -193,17 +205,18 @@ export function useHardwarePanels(deps: {
                 </div>
             </div>
         );
-    }, [synthB.waveform, synthB.engine303, synthB.vowel, synthB.portamento, synthB.formantShift, synthB.cppFine, updateSynthB, audioEngine]);
+    }, [synthB.waveform, synthB.engine303, synthB.model303, synthB.vowel, synthB.portamento, synthB.formantShift, synthB.cppFine, updateSynthB, audioEngine]);
 
     const bass2Child = useMemo(() => {
-        const engine = bass2.engine303 ?? 'open303';
-        const handleBass2EngineChange = (e: 'open303' | 'jc303') => {
-            updateBass2({ engine303: e });
+        const modelB2 = normalizeTB303Model(bass2.model303, bass2.engine303);
+        const handleBass2VoiceChange = (m: TB303ModelId) => {
+            updateBass2({ model303: m, engine303: tb303ModelFamily(m) });
             const mgr = audioEngine?.open303Engine;
-            if (mgr && 'setBass2Engine' in mgr) mgr.setBass2Engine(e);
-            engineTelemetry.registerResolution('bass2-engine303', e, 'user-initiated');
+            if (mgr && 'setBass2Model' in mgr) (mgr as any).setBass2Model(m);
+            else if (mgr && 'setBass2Engine' in mgr) mgr.setBass2Engine(tb303ModelFamily(m));
+            engineTelemetry.registerResolution('bass2-model303', m, 'user-initiated');
         };
-        const bass2Type: OscillatorType = engine === 'jc303' ? 'jc303' : 'open303';
+        const bass2Type: OscillatorType = tb303ModelFamily(modelB2) === 'jc303' ? 'jc303' : 'open303';
         return (
         <div className="absolute top-4 right-6 pointer-events-none">
             <div className="pointer-events-auto flex flex-col gap-2 p-2 rounded-lg bg-zinc-950/80 border border-pink-500/20 w-fit">
@@ -213,11 +226,11 @@ export function useHardwarePanels(deps: {
                     onChange={(w) => updateBass2({ waveform: w as '303-saw' | '303-sqr' })}
                     accentColor="pink"
                 />
-                <Engine303Selector engine={engine} onChange={handleBass2EngineChange} accentColor="pink" />
+                <Voice303Selector model={modelB2} onChange={handleBass2VoiceChange} accentColor="pink" />
             </div>
         </div>
         );
-    }, [bass2.waveform, bass2.engine303, updateBass2, audioEngine]);
+    }, [bass2.waveform, bass2.engine303, bass2.model303, updateBass2, audioEngine]);
 
     const samplerChild = useMemo(() => (
         <div className="absolute top-2 left-[10%] right-[10%] max-h-[38%] h-auto pointer-events-auto z-10 bg-gray-900/90 rounded-lg border border-purple-500/30 backdrop-blur-sm overflow-y-auto">

--- a/src/hooks/useAppState.tsx
+++ b/src/hooks/useAppState.tsx
@@ -12,6 +12,7 @@ import { SupertonicService } from '../services/Supertonic'
 import { automationStore } from '../stores/automationStore';
 import { AutomationScheduler } from '../audio/automation/AutomationScheduler';
 import type { PcfEffect } from '../engines/PcfEffect';
+import { normalizeTB303Model } from '../engines/TB303Models';
 import type { MainSequencerHandle } from '../components/MainSequencer'
 
 import {
@@ -217,13 +218,23 @@ export function useAppState() {
 
     useEffect(() => {
         const mgr = (audioEngine as any)?.open303Engine;
-        if (!mgr || typeof mgr.syncEngine303Settings !== 'function') return;
-        mgr.syncEngine303Settings({
-            lead: synthA.engine303 ?? 'open303',
-            bass1: synthB.engine303 ?? 'open303',
-            bass2: bass2.engine303 ?? 'open303',
-        });
-    }, [audioEngine, synthA.engine303, synthB.engine303, bass2.engine303]);
+        if (!mgr) return;
+        // normalizeTB303Model resolves the persisted model303, falling back to
+        // the legacy engine303 field for songs saved before the voices update.
+        if (typeof mgr.syncModel303Settings === 'function') {
+            mgr.syncModel303Settings({
+                lead: normalizeTB303Model(synthA.model303, synthA.engine303),
+                bass1: normalizeTB303Model(synthB.model303, synthB.engine303),
+                bass2: normalizeTB303Model(bass2.model303, bass2.engine303),
+            });
+        } else if (typeof mgr.syncEngine303Settings === 'function') {
+            mgr.syncEngine303Settings({
+                lead: synthA.engine303 ?? 'open303',
+                bass1: synthB.engine303 ?? 'open303',
+                bass2: bass2.engine303 ?? 'open303',
+            });
+        }
+    }, [audioEngine, synthA.engine303, synthB.engine303, bass2.engine303, synthA.model303, synthB.model303, bass2.model303]);
 
     const activeKeyboardNotesRef = useRef<Map<string, number>>(new Map());
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,8 @@ import type { Open303Oscillator } from './engines/Open303Oscillator';
 import type { ScaleDefinition } from './utils/musicTheory';
 import type { MultisampleBank } from './engines/MultisampleGenerator';
 export type { MultisampleBank } from './engines/MultisampleGenerator';
+import type { TB303ModelId } from './engines/TB303Models';
+export type { TB303ModelId, TB303ModelInfo, Engine303Family } from './engines/TB303Models';
 
 export type Waveform =
   | 'sawtooth' | 'square' | 'triangle' | 'sine'
@@ -36,8 +38,11 @@ export interface SynthParams {
   delayTime: number; // seconds
   delayFeedback: number; // 0-1
   delayMix: number; // 0-1 (wet/dry)
-  /** Which DSP engine to use when waveform is '303-saw' or '303-sqr'. Defaults to 'open303'. */
+  /** Legacy DSP engine field for '303-saw'/'303-sqr' waveforms. Superseded by
+   *  model303 but still written on save so older builds load songs correctly. */
   engine303?: Engine303;
+  /** Selected 303 voice/model (see engines/TB303Models.ts). Defaults to 'stock-open303'. */
+  model303?: TB303ModelId;
   /** Prophecy: Vowel formant preset 0–4 (A=0, E=1, I=2, O=3, U=4) */
   pitchAttack?: number;
   pitchDecay?: number;
@@ -377,8 +382,10 @@ export interface Bass2Params {
   volume: number;
   pitch: number;
   pan?: number;
-  /** Which DSP engine to use for this voice. Defaults to 'open303'. */
+  /** Legacy DSP engine field. Superseded by model303 but still written on save. */
   engine303?: Engine303;
+  /** Selected 303 voice/model (see engines/TB303Models.ts). Defaults to 'stock-open303'. */
+  model303?: TB303ModelId;
   /**
    * Slide/portamento time (0–1 normalized, where 0.33 ≈ 60 ms TB-303 default).
    * Maps to Open303Params.slideTime for the Devil Fish MOD.


### PR DESCRIPTION
## Summary

Evolves the dual-engine switch (`open303` / `jc303`) into a **selectable, growing list of TB-303 "voices"** — independently per track (SYNTH A / SYNTH B / BASS 2), with stock sounds kept pristine and a registry-driven pipeline that makes adding the next voice trivial. Covers child issues #901 (C++ factory + registry), #899 (TS/worklet generalization), #897 (UI voice selector), #898 (first experimental voices) and the docs/tests portion of #902.

## C++ layer (`emscripten/open303_wrapper.cpp`)

- New `k303Models[]` registry of `Open303ModelProfile` rows: stable string id, label, engine family, and a coefficient profile (filter cutoff curve, resonance feedback gain, accent filter/VCA boost depths, envelope decay range, slide range, square/saw waveshaping).
- `Open303Instance` renders through the active profile. **`stock-open303` is row 0 with the exact pre-registry constants** — the default sound is bit-identical (the `sawDrive = 0` fast path skips the waveshaper entirely).
- New exports (also added to `build.sh` `EXPORTED_FUNCTIONS`): `open303_get_model_count` / `_id` / `_label` / `_engine`, `open303_set_model`, `open303_get_model`, plus embind `getAvailable303Models()` returning a JSON catalog.
- First-wave voices proving the pipeline: **`1ink303-v1`** (in-house: warmer filter base, rounder accent, slower slides) and **`experimental-01`** (scratchpad: hotter resonance feedback, snappier envelope, harder accent punch).

## TypeScript / audio engine

- `src/engines/TB303Models.ts` — mirrored registry (`TB303_MODELS`), `TB303ModelId` union (includes the catalogued-but-unshipped ReBirth/MB33/Raveolution ids for the P2 issues), and `normalizeTB303Model()` which resolves any persisted model/engine pair to a valid available voice.
- `SynthParams` / `Bass2Params` gain `model303`; the legacy `engine303` field is kept and mirrored on every change, so **old songs load correctly and new songs still load on old builds**.
- `Open303Oscillator.setModel303()` posts a `set-303-model` message carrying an engine-family fallback hint; `Open303Manager` gains `setBass1Model` / `setBass2Model` / `setLead303Model` + `syncModel303Settings` (applied after audio init / song load).
- The worklet discovers the native model registry at init by reading the new exports — **feature-detected**, so the currently shipped `hyphon_native.wasm` (pre-registry) keeps working with plain engine-family switching until the next `pnpm run build:emcc`.

## UI

- `Voice303Selector` — a "303 Voice" list populated dynamically from the registry with per-voice tooltip descriptions, rendered on all three 303 rack panels. New registry entries appear with zero component changes. The old two-way `Engine303Selector` is deprecated but kept.

## Docs + tests

- `docs/audio-engine/303-voices.md` — architecture, degradation matrix, and the 3-step "adding a new voice" recipe.
- New suites: `TB303Models.test.ts` (28 tests: registry integrity, normalization, oscillator/manager plumbing, persistence round-trip) and `Voice303Selector.test.tsx` (7 tests). All existing engine303 suites pass unchanged (113 tests green across the 8 related files).

## Verification

- `pnpm run typecheck` ✅ and `pnpm run lint` ✅ clean.
- Full `pnpm test`: same 3 failures/10 collection errors as on `main` (pre-existing missing-WASM environment issues, verified via stash A/B) — no new failures.
- C++ syntax-checked with `g++ -fsyntax-only` (emcc unavailable in this environment); **the WASM binary is not rebuilt in this PR** — new voices sound stock until `pnpm run build:emcc` is run on a machine with the emsdk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Xp97cStZTGJqhbZmSpmvb

---
_Generated by [Claude Code](https://claude.ai/code/session_016Xp97cStZTGJqhbZmSpmvb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selectable 303 voices for Synth A, Synth B, and Bass2.
  * Added voice-specific sound profiles, including Open303 and JC303 families.
  * Added dynamic voice selectors with descriptions and active engine indicators.
  * Saved projects now preserve selected voices while remaining compatible with older projects.

* **Bug Fixes**
  * Added fallback handling for unavailable, unknown, and legacy voice selections.
  * Improved compatibility with older audio engines and WASM builds.

* **Documentation**
  * Added documentation covering available voices, compatibility, selection behavior, and adding future voices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->