### PR TITLE
feat/test(audio): 303 Voices — ReBirth voices, factory string API, E2E & offline verification (#900, #901, #898, #897)

### DIFF
--- a/tests/engine303-switch.spec.ts
+++ b/tests/engine303-switch.spec.ts
@@ -1,20 +1,28 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * E2E: 303 engine switch scenario
+ * E2E: 303 voice selection scenario ("303 Voices" architecture)
+ *
+ * The Voice303Selector (src/components/Voice303Selector.tsx) renders one
+ * button per available voice from the TB303_MODELS registry
+ * (src/engines/TB303Models.ts). These specs intentionally avoid hardcoding
+ * the full voice list — they derive expectations from the registry ids that
+ * are stable ('stock-open303', 'jc303') so the specs keep passing as the
+ * catalog grows.
  *
  * Tests that:
- * 1. Setting a 303 waveform (303-saw) on SYNTH B reveals the Engine303Selector
- * 2. Clicking "Authentic JC303" switches the engine and shows the JC303 badge
- *    in the RackNode title bar
- * 3. The EngineStatusPill in the Transport header reflects the active engine
- * 4. Switching back to "Custom Open303" removes the badge
+ * 1. Setting a 303 waveform (303-saw) on SYNTH B reveals the 303 Voice list
+ * 2. Picking "Authentic JC303" switches the voice, updates aria-pressed and
+ *    the engine-family badge, and shows JC303 in the Transport status pill
+ * 3. SYNTH A / SYNTH B / BASS 2 select voices independently
+ * 4. Every listed voice carries a tooltip description
  *
  * TODO: Fix Playwright environment setup for full audio context initialisation.
  * Temporarily skipped like other E2E specs until the CI environment is stable.
  */
-test.skip('303 engine switch: SYNTH B toggles between open303 and jc303', async ({ page }) => {
-    // 1. Navigate and initialise
+
+/** Shared boot sequence: initialise the audio system and wait for the UI. */
+async function initApp(page: import('@playwright/test').Page): Promise<void> {
     await page.goto('/');
 
     const startBtn = page.getByRole('button', { name: 'INITIALIZE SYSTEM' });
@@ -24,98 +32,132 @@ test.skip('303 engine switch: SYNTH B toggles between open303 and jc303', async 
     await startBtn.waitFor({ state: 'hidden', timeout: 30000 });
 
     await expect(page.getByRole('button', { name: 'Start Playback' })).toBeVisible({ timeout: 60000 });
+}
 
-    // 2. Open the SYNTH B module overlay by clicking the waveform selector area
-    //    (the Engine303Selector only appears when a 303 waveform is active)
+test.skip('303 voice switch: SYNTH B toggles between stock and JC303 voices', async ({ page }) => {
+    await initApp(page);
+
+    // 1. Open the SYNTH B module (the Voice303Selector only appears when a
+    //    303 waveform is active)
     const synthBModule = page.locator('[class*="rounded"]', { hasText: 'SYNTH B' }).first();
     await expect(synthBModule).toBeVisible({ timeout: 10000 });
 
-    // 3. Select a 303-saw waveform on SYNTH B to reveal the Engine303Selector
+    // 2. Select a 303-saw waveform on SYNTH B to reveal the 303 Voice list
     const waveformBtn303Saw = synthBModule.getByLabel(/Select 303-saw waveform/i);
     await waveformBtn303Saw.click();
 
-    // 4. The Engine303Selector should now be visible
-    const engineGroup = synthBModule.getByRole('group', { name: /303 engine selection/i });
-    await expect(engineGroup).toBeVisible({ timeout: 5000 });
+    // 3. The Voice303Selector should now be visible
+    const voiceGroup = synthBModule.getByRole('group', { name: /303 voice selection/i });
+    await expect(voiceGroup).toBeVisible({ timeout: 5000 });
 
-    // 5. Click "Authentic JC303" to switch engine
-    const jc303Btn = engineGroup.getByRole('button', { name: /Authentic JC303/i });
+    // 4. Pick "Authentic JC303"
+    const jc303Btn = voiceGroup.getByRole('button', { name: /Select Authentic JC303 voice/i });
     await jc303Btn.click();
 
-    // 6. Verify aria-pressed state updated
+    // 5. Verify aria-pressed state updated and the family badge flipped
     await expect(jc303Btn).toHaveAttribute('aria-pressed', 'true');
-    const open303Btn = engineGroup.getByRole('button', { name: /Custom Open303/i });
-    await expect(open303Btn).toHaveAttribute('aria-pressed', 'false');
+    const stockBtn = voiceGroup.getByRole('button', { name: /Select Stock Open303 voice/i });
+    await expect(stockBtn).toHaveAttribute('aria-pressed', 'false');
+    await expect(voiceGroup.getByLabel('JC303 engine family active')).toBeVisible();
 
-    // 7. The JC303 badge should appear in the rack module title bar
-    const jc303Badge = synthBModule.getByLabel('JC303 engine active');
-    await expect(jc303Badge).toBeVisible({ timeout: 3000 });
-
-    // 8. The EngineStatusPill in the TransportToolbar should show the engine
+    // 6. The EngineStatusPill in the TransportToolbar should show the engine
     const header = page.locator('header');
     const statusPill = header.getByRole('status');
     await expect(statusPill).toBeVisible({ timeout: 3000 });
     await expect(statusPill).toContainText('JC303');
 
-    // 9. Switch back to Custom Open303 and verify badge disappears
-    await open303Btn.click();
-    await expect(jc303Badge).not.toBeVisible({ timeout: 3000 });
+    // 7. Switch back to the stock voice and verify state returns
+    await stockBtn.click();
+    await expect(stockBtn).toHaveAttribute('aria-pressed', 'true');
     await expect(jc303Btn).toHaveAttribute('aria-pressed', 'false');
-    await expect(open303Btn).toHaveAttribute('aria-pressed', 'true');
+    await expect(voiceGroup.getByLabel('Open303 engine family active')).toBeVisible();
 });
 
-test.skip('303 engine switch: BASS 2 shows Engine303Selector always', async ({ page }) => {
-    // 1. Navigate and initialise
-    await page.goto('/');
+test.skip('303 voice switch: BASS 2 shows the Voice303Selector always', async ({ page }) => {
+    await initApp(page);
 
-    const startBtn = page.getByRole('button', { name: 'INITIALIZE SYSTEM' });
-    await startBtn.waitFor({ state: 'visible', timeout: 90000 });
-    await expect(startBtn).toBeEnabled({ timeout: 90000 });
-    await startBtn.click({ force: true });
-    await startBtn.waitFor({ state: 'hidden', timeout: 30000 });
-
-    await expect(page.getByRole('button', { name: 'Start Playback' })).toBeVisible({ timeout: 60000 });
-
-    // 2. BASS 2 always shows the Engine303Selector (no waveform prerequisite)
+    // 1. BASS 2 always shows the Voice303Selector (no waveform prerequisite)
     const bass2Module = page.locator('[class*="rounded"]', { hasText: 'BASS 2' }).first();
     await expect(bass2Module).toBeVisible({ timeout: 10000 });
 
-    const engineGroup = bass2Module.getByRole('group', { name: /303 engine selection/i });
-    await expect(engineGroup).toBeVisible({ timeout: 5000 });
+    const voiceGroup = bass2Module.getByRole('group', { name: /303 voice selection/i });
+    await expect(voiceGroup).toBeVisible({ timeout: 5000 });
 
-    // 3. Switch to JC303 and verify
-    const jc303Btn = engineGroup.getByRole('button', { name: /Authentic JC303/i });
+    // 2. Switch to JC303 and verify
+    const jc303Btn = voiceGroup.getByRole('button', { name: /Select Authentic JC303 voice/i });
     await jc303Btn.click();
     await expect(jc303Btn).toHaveAttribute('aria-pressed', 'true');
 
-    // 4. The EngineStatusPill should update
+    // 3. The EngineStatusPill should update
     const header = page.locator('header');
     const statusPill = header.getByRole('status');
     await expect(statusPill).toContainText('JC303');
 });
 
+test.skip('303 voice switch: SYNTH A, SYNTH B and BASS 2 select independently', async ({ page }) => {
+    await initApp(page);
+
+    // 1. Put SYNTH A and SYNTH B on 303 waveforms so all three voice lists show
+    const synthAModule = page.locator('[class*="rounded"]', { hasText: 'SYNTH A' }).first();
+    await synthAModule.getByLabel(/Select 303-saw waveform/i).click();
+    const synthBModule = page.locator('[class*="rounded"]', { hasText: 'SYNTH B' }).first();
+    await synthBModule.getByLabel(/Select 303-saw waveform/i).click();
+    const bass2Module = page.locator('[class*="rounded"]', { hasText: 'BASS 2' }).first();
+
+    const groupA = synthAModule.getByRole('group', { name: /303 voice selection/i });
+    const groupB = synthBModule.getByRole('group', { name: /303 voice selection/i });
+    const groupB2 = bass2Module.getByRole('group', { name: /303 voice selection/i });
+    await expect(groupA).toBeVisible({ timeout: 5000 });
+    await expect(groupB).toBeVisible({ timeout: 5000 });
+    await expect(groupB2).toBeVisible({ timeout: 5000 });
+
+    // 2. Pick a different voice on each part
+    await groupA.getByRole('button', { name: /Select Authentic JC303 voice/i }).click();
+    await groupB2.getByRole('button', { name: /Select Experimental 01 voice/i }).click();
+    // SYNTH B stays on the default stock voice.
+
+    // 3. Each part reflects only its own selection
+    await expect(groupA.getByRole('button', { name: /Select Authentic JC303 voice/i }))
+        .toHaveAttribute('aria-pressed', 'true');
+    await expect(groupB.getByRole('button', { name: /Select Stock Open303 voice/i }))
+        .toHaveAttribute('aria-pressed', 'true');
+    await expect(groupB.getByRole('button', { name: /Select Authentic JC303 voice/i }))
+        .toHaveAttribute('aria-pressed', 'false');
+    await expect(groupB2.getByRole('button', { name: /Select Experimental 01 voice/i }))
+        .toHaveAttribute('aria-pressed', 'true');
+});
+
+test.skip('303 voice list: every voice exposes a tooltip description', async ({ page }) => {
+    await initApp(page);
+
+    const bass2Module = page.locator('[class*="rounded"]', { hasText: 'BASS 2' }).first();
+    const voiceGroup = bass2Module.getByRole('group', { name: /303 voice selection/i });
+    await expect(voiceGroup).toBeVisible({ timeout: 5000 });
+
+    // Registry-driven: every rendered voice button must carry a non-empty
+    // title (the model description), whatever the current catalog size.
+    const voiceButtons = voiceGroup.getByRole('button', { name: /^Select .+ voice$/ });
+    const count = await voiceButtons.count();
+    expect(count).toBeGreaterThanOrEqual(2); // at minimum stock + jc303
+    for (let i = 0; i < count; i++) {
+        const title = await voiceButtons.nth(i).getAttribute('title');
+        expect(title, `voice button ${i} tooltip`).toBeTruthy();
+    }
+});
+
 test.skip('Prophecy engine: status pill appears when prophecy-saw waveform is selected', async ({ page }) => {
-    // 1. Navigate and initialise
-    await page.goto('/');
+    await initApp(page);
 
-    const startBtn = page.getByRole('button', { name: 'INITIALIZE SYSTEM' });
-    await startBtn.waitFor({ state: 'visible', timeout: 90000 });
-    await expect(startBtn).toBeEnabled({ timeout: 90000 });
-    await startBtn.click({ force: true });
-    await startBtn.waitFor({ state: 'hidden', timeout: 30000 });
-
-    await expect(page.getByRole('button', { name: 'Start Playback' })).toBeVisible({ timeout: 60000 });
-
-    // 2. Select prophecy-saw waveform on SYNTH A
+    // 1. Select prophecy-saw waveform on SYNTH A
     const synthAModule = page.locator('[class*="rounded"]', { hasText: 'SYNTH A' }).first();
     const prophecySawBtn = synthAModule.getByLabel(/Select prophecy-saw waveform/i);
     await prophecySawBtn.click();
 
-    // 3. The Prophecy parameters panel should appear
+    // 2. The Prophecy parameters panel should appear
     const prophecyGroup = synthAModule.getByRole('group', { name: /Prophecy parameters/i });
     await expect(prophecyGroup).toBeVisible({ timeout: 5000 });
 
-    // 4. The EngineStatusPill should show PROPHECY for SYNTH A
+    // 3. The EngineStatusPill should show PROPHECY for SYNTH A
     const header = page.locator('header');
     const statusPill = header.getByRole('status');
     await expect(statusPill).toContainText('PROPHECY');


### PR DESCRIPTION
## Summary

Follow-ups to the merged #955 (303 Voices architecture) completing several child issues. #955 shipped the registry, the two stock voices, the two first custom voices, and the UI selector. This PR adds the **ReBirth character voices** (#900), rounds out the **C++ factory string API** (#901), and adds the **E2E + offline verification** the issues call for (#898, #897).

## #900 — ReBirth RB-338 character voices

Two **inspired-by (not clone)** voices, shipped as open303-family coefficient profiles (moved from catalogued-unavailable → available):

- `rebirth-338-1.5` — squishier, self-oscillation-prone filter (darker cutoff base, resonance feedback 4.10), big accent lift, gooey longer slides, mild saw grit.
- `rebirth-2.0` — cleaner/tighter filter, punchier accent (VCA + filter), snappier envelope, a touch more drive.

UI tooltips and docs carry the explicit "inspired by … (not a clone)" disclaimer; no ReBirth samples/assets. Full ReBirth *song* fidelity stays out of scope (epic #876). `docs/audio-engine/303-voices.md` gets a coefficient-delta table and character notes. Offline A/B shows both differ from stock (relRMS 110 % / 100 %) and from each other (113 %). Stock/JC303/experimental paths untouched.

## #901 — C++ factory string API + coverage

The registry, discovery exports, `open303_set_model`, embind `getAvailable303Models()` and `build.sh` wiring landed in #955. Added the future-proof string setter from the issue's sketch:

- `open303_set_model_by_id(handle, id)` (`set303Model(instanceId, modelName)`) + `open303_find_model_index(id)`; unknown ids / jc303 models return 0; equivalent to the index path. Wired into `EXPORTED_FUNCTIONS` + `EMSCRIPTEN_BINDINGS`. Worklet keeps the index path (needs the engine family to route jc303/open303).
- `emscripten/tests/tb303_factory_smoke_test.cpp`: `getAvailable303Models()` JSON, per-model create/process/finite/non-silent, index vs string-id equivalence, unknown-id + jc303 rejection, mid-session switching.

## #898 — First voices: offline buffer verification

`emscripten/tests/tb303_voices_offline_test.cpp` renders a fixed, documented pattern and asserts `experimental-01`, `1ink303-v1` (and now the ReBirth voices) differ audibly from stock, the stock render is bit-identical and unchanged after a mid-session switch, and no crash/NaN on per-block switching. Both C++ suites build with host `g++` via `emscripten/tests/emscripten_stub/` (**no emsdk**) and run through `emscripten/tests/run_offline_voices_test.sh`.

## #897 — UI 303 Voice selector: Playwright coverage

`tests/engine303-switch.spec.ts` retargeted to the shipped `Voice303Selector` with new per-part independent-selection and registry-agnostic tooltip specs; `initApp()` helper. Skipped like the rest of the E2E suite; collects 5 specs.

## Verification

- `pnpm run typecheck` ✅, `pnpm run lint` ✅, `g++ -fsyntax-only` on the wrapper ✅.
- `bash emscripten/tests/run_offline_voices_test.sh` → **both suites ALL PASSED**.
- `pnpm exec vitest run` TB303Models + Voice303Selector → **37 passed**.
- `pnpm exec playwright test tests/engine303-switch.spec.ts --list` → 5 specs.

Note: this PR does **not** rebuild `hyphon_native.wasm` (no emsdk here). The new voices, exports and coefficient profiles go live in-app on the next `pnpm run build:emcc`; the C++ tests validate them directly meanwhile. Existing stock/JC303 behaviour is unchanged (stock render proven bit-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Xp97cStZTGJqhbZmSpmvb