### PR TITLE
Add MB33 mkII and Raveolution 303 voice profiles (#902)

### DIFF
--- a/docs/audio-engine/303-voices.md
+++ b/docs/audio-engine/303-voices.md
@@ -23,8 +23,8 @@ track without touching the others.
 | `experimental-01` | open303 | ✅ shipped | Scratchpad: hotter resonance feedback (4.15), snappier envelope, harder accent punch, heavier square drive. |
 | `rebirth-338-1.5` | open303 | ✅ shipped | Inspired by ReBirth RB-338 1.5 (not a clone): squishier, self-oscillation-prone filter, gooey slides, big accent lift. |
 | `rebirth-2.0` | open303 | ✅ shipped | Inspired by ReBirth 2.0 (not a clone): cleaner/tighter filter than 1.5, punchier accent, snappier envelope. |
-| `mb33-mkii` | open303 | 🚧 catalogued | MAM MB33 mkII profile. |
-| `raveolution` | open303 | 🚧 catalogued | Quasimidi Raveolution 309 profile. |
+| `mb33-mkii` | open303 | ✅ shipped | Inspired by MAM MB33 mkII (not a clone): boxier digital filter, distinct accent punch, square/saw grit. |
+| `raveolution` | open303 | ✅ shipped | Inspired by Quasimidi Raveolution 309 (not a clone): brighter harsh self-osc, aggressive resonance, snappy envelope, heavy drive. |
 
 Catalogued-but-unshipped voices are hidden from the UI and normalize to the
 stock voice of their family when loaded from a song.
@@ -58,6 +58,32 @@ tighter and cleaner with a harder, punchier accent and snappier envelope.
 Full ReBirth *song* fidelity is out of scope here (owned by epic #876); these
 voices target instrument character only, validated by A/B render (below), not
 by matching real RB-338 recordings.
+
+### P2 character voices (`mb33-mkii`, `raveolution`)
+
+These are **inspired-by profiles, not bit-perfect or legal clones** of the
+referenced hardware/software emulations — the UI tooltips and this catalog say
+so. They ship no third-party samples or assets; they are coefficient profiles
+on the stock open303 DSP tuned toward each target's *character*.
+
+Coefficient deltas vs `stock-open303`:
+
+| Knob | stock | `mb33-mkii` | `raveolution` |
+|------|-------|-------------|---------------|
+| cutoff base Hz | 20 | 24 (boxier mid) | 18 (brighter low) |
+| cutoff range × | 400 | 360 (narrower sweep) | 440 (brighter top) |
+| resonance feedback | 3.9 | 3.85 (distinct curve) | 4.25 (aggressive self-osc) |
+| accent filter boost | 0.40 | 0.52 (distinct punch) | 0.58 (hard filter hit) |
+| accent VCA boost | 0.30 | 0.38 | 0.48 (aggressive envelope) |
+| decay min / range s | 0.05 / 1.95 | 0.045 / 1.70 | 0.028 / 1.15 (snappy) |
+| slide min / range s | 0.01 / 0.49 | 0.014 / 0.45 | 0.006 / 0.35 (fast) |
+| square drive × | 3.0 | 3.8 (digital grit) | 4.2 (heavy drive) |
+| saw drive | 0.0 | 0.25 (digital grit) | 0.08 |
+
+Character summary: **MB33 mkII** leans into a boxier, more "digital" filter
+feel with a distinct accent punch and waveshaping grit; **Raveolution** is
+brighter and harsher with aggressive resonance/self-oscillation, a snappy
+envelope, and heavier drive for dance-floor character.
 
 ## Architecture
 
@@ -206,19 +232,21 @@ bash emscripten/tests/run_offline_voices_test.sh
 
 What it asserts:
 
-1. `experimental-01`, `1ink303-v1`, `rebirth-338-1.5` and `rebirth-2.0` are
-   registered as open303-family models.
+1. `experimental-01`, `1ink303-v1`, `rebirth-338-1.5`, `rebirth-2.0`,
+   `mb33-mkii` and `raveolution` are registered as open303-family models.
 2. The stock render is **deterministic** (bit-identical across two runs).
 3. **Stock unchanged**: stock → other voice → stock reproduces the exact stock
    buffer (a mid-session switch does not corrupt the stock path).
 4. **Audible difference**: each shipped voice differs from stock by relative
    RMS > 2 % and peak sample delta > 1e-3 (all currently render ~1.0 relative
-   RMS), and the two ReBirth eras are audibly distinct from each other.
+   RMS), the two ReBirth eras are audibly distinct from each other, and the
+   MB33 mkII and Raveolution profiles are audibly distinct from each other.
 5. `open303_set_model()` rejects the jc303-family model and unknown indices.
 6. Switching the model every block mid-render stays finite — no crash, no NaN.
 
 This same fixed pattern is the **shared A/B regression pattern** for both the
-first custom voices (#898) and the ReBirth character voices (#900).
+first custom voices (#898), the ReBirth character voices (#900), and the P2
+character voices (#902).
 
 ### Manual A/B checklist (in-app, after `pnpm run build:emcc`)
 

--- a/emscripten/open303_wrapper.cpp
+++ b/emscripten/open303_wrapper.cpp
@@ -148,6 +148,14 @@ static const Open303ModelProfile k303Models[] = {
     // Inspired-by ReBirth 2.0 (NOT a clone): cleaner/tighter filter than 1.5,
     // punchier accent (VCA + filter), snappier envelope, slightly more drive.
     { "rebirth-2.0",     "ReBirth 2.0",      ENGINE_OPEN303, 20.0f, 410.0f, 3.95f, 0.60f, 0.42f, 0.035f, 1.40f, 0.012f, 0.50f, 3.4f, 0.12f },
+    // Inspired-by MAM MB33 mkII (NOT a clone): boxier, more "digital" filter
+    // feel — narrower cutoff sweep, distinct accent punch, square/saw grit for
+    // the hardware-emulation character.
+    { "mb33-mkii",       "MB33 mkII",        ENGINE_OPEN303, 24.0f, 360.0f, 3.85f, 0.52f, 0.38f, 0.045f, 1.70f, 0.014f, 0.45f, 3.8f, 0.25f },
+    // Inspired-by Quasimidi Raveolution 309 (NOT a clone): brighter/harsher
+    // self-oscillation, aggressive resonance curve, snappy envelope, heavy drive
+    // for dance-floor character.
+    { "raveolution",     "Raveolution 309",  ENGINE_OPEN303, 18.0f, 440.0f, 4.25f, 0.58f, 0.48f, 0.028f, 1.15f, 0.006f, 0.35f, 4.2f, 0.08f },
 };
 
 static constexpr int k303ModelCount = static_cast<int>(sizeof(k303Models) / sizeof(k303Models[0]));

--- a/emscripten/tests/tb303_voices_offline_test.cpp
+++ b/emscripten/tests/tb303_voices_offline_test.cpp
@@ -200,13 +200,23 @@ int main() {
     struct VoiceCase { const char* id; int idx; };
     const int iRb15 = findModelIndex("rebirth-338-1.5");
     const int iRb20 = findModelIndex("rebirth-2.0");
+    const int iMb33 = findModelIndex("mb33-mkii");
+    const int iRave = findModelIndex("raveolution");
     check(iRb15 >= 0, "rebirth-338-1.5 registered");
     check(iRb20 >= 0, "rebirth-2.0 registered");
+    check(iMb33 >= 0, "mb33-mkii registered");
+    check(iRave >= 0, "raveolution registered");
+    check(iMb33 >= 0 && open303_get_model_engine(iMb33) == ENGINE_OPEN303,
+          "mb33-mkii is open303-family");
+    check(iRave >= 0 && open303_get_model_engine(iRave) == ENGINE_OPEN303,
+          "raveolution is open303-family");
     const VoiceCase voices[] = {
         { "experimental-01",  iExp },
         { "1ink303-v1",       i1ink },
         { "rebirth-338-1.5",  iRb15 },
         { "rebirth-2.0",      iRb20 },
+        { "mb33-mkii",        iMb33 },
+        { "raveolution",      iRave },
     };
     for (const VoiceCase& vc : voices) {
         if (vc.idx < 0) { ++g_failures; std::printf("  [FAIL] %s missing\n", vc.id); continue; }
@@ -229,6 +239,15 @@ int main() {
         const double relRms = stockRms > 0.0 ? rmsDiff(rb15, rb20) / stockRms : 0.0;
         std::printf("ReBirth 1.5 vs 2.0 relRMS=%.4f (%.2f%%)\n", relRms, relRms * 100.0);
         check(relRms > 0.02, "rebirth-338-1.5 and rebirth-2.0 are audibly distinct");
+    }
+
+    // 4c. The P2 character voices must be audibly distinct from each other.
+    if (iMb33 >= 0 && iRave >= 0) {
+        const std::vector<float> mb33 = renderVoice(iMb33);
+        const std::vector<float> rave = renderVoice(iRave);
+        const double relRms = stockRms > 0.0 ? rmsDiff(mb33, rave) / stockRms : 0.0;
+        std::printf("MB33 mkII vs Raveolution relRMS=%.4f (%.2f%%)\n", relRms, relRms * 100.0);
+        check(relRms > 0.02, "mb33-mkii and raveolution are audibly distinct");
     }
 
     // 5. Engine-family guard: jc303 is not an open303-family profile.

--- a/src/__tests__/TB303Models.test.ts
+++ b/src/__tests__/TB303Models.test.ts
@@ -63,11 +63,14 @@ describe('TB303_MODELS registry', () => {
         }
     });
 
-    it('catalogues the remaining P2 character voices as not yet available', () => {
+    it('ships the P2 character voices as open303-family profiles', () => {
         for (const id of ['mb33-mkii', 'raveolution']) {
             const m = getTB303Model(id);
             expect(m, id).toBeDefined();
-            expect(m!.available, id).toBe(false);
+            expect(m!.available, id).toBe(true);
+            expect(m!.family, id).toBe('open303');
+            // "inspired-by" disclaimer surfaced to the user, not a clone claim.
+            expect(m!.description.toLowerCase(), id).toContain('not a clone');
         }
     });
 
@@ -114,9 +117,9 @@ describe('normalizeTB303Model()', () => {
         expect(normalizeTB303Model('rebirth-2.0')).toBe('rebirth-2.0');
     });
 
-    it('falls back to the family stock voice for catalogued-but-unavailable models', () => {
-        expect(normalizeTB303Model('mb33-mkii')).toBe('stock-open303');    // open303 family
-        expect(normalizeTB303Model('raveolution')).toBe('stock-open303');  // open303 family
+    it('keeps the P2 character voices', () => {
+        expect(normalizeTB303Model('mb33-mkii')).toBe('mb33-mkii');
+        expect(normalizeTB303Model('raveolution')).toBe('raveolution');
     });
 
     it('falls back for unknown ids from future song versions', () => {

--- a/src/engines/TB303Models.ts
+++ b/src/engines/TB303Models.ts
@@ -111,17 +111,17 @@ export const TB303_MODELS: readonly TB303ModelInfo[] = [
     id: 'mb33-mkii',
     label: 'MB33 mkII',
     shortLabel: 'MB33',
-    description: 'MAM MB33 mkII character profile — coming soon.',
+    description: 'Inspired by MAM MB33 mkII (not a clone) — boxier digital filter feel, distinct accent punch, square/saw grit.',
     family: 'open303',
-    available: false,
+    available: true,
   },
   {
     id: 'raveolution',
     label: 'Raveolution 309',
     shortLabel: 'Rave 309',
-    description: 'Quasimidi Raveolution character profile — coming soon.',
+    description: 'Inspired by Quasimidi Raveolution 309 (not a clone) — brighter harsh self-osc, aggressive resonance, snappy envelope, heavy drive.',
     family: 'open303',
-    available: false,
+    available: true,
   },
 ];
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds two P2 character voices to the selectable 303 model registry:

| Model ID | Character target |
|----------|------------------|
| `mb33-mkii` | MB33 mkII-style boxy digital filter, distinct accent punch, square/saw grit |
| `raveolution` | Raveolution-style aggressive resonance/self-osc, snappy envelope, heavy drive |

Both are **inspired-by profiles** implemented via coefficient tweaks on the shared Open303 DSP core — no separate DSP class introduced.

## Changes

- **`emscripten/open303_wrapper.cpp`** — two new rows in `k303Models[]` with tuned coefficient profiles
- **`src/engines/TB303Models.ts`** — `available: true` with "inspired by (not a clone)" UI descriptions
- **`docs/audio-engine/303-voices.md`** — catalog updated to ✅ shipped, coefficient delta table added
- **Tests** — unit tests updated; offline DSP test extended with registry + audible-difference checks

## Acceptance criteria

- [x] Both IDs in model registry + UI (registry-driven `Voice303Selector` picks them up automatically)
- [x] Audible differentiation from stock verified offline (relRMS > 2%, peak delta > 1e-3)
- [x] Audible differentiation between the two new voices verified offline
- [x] No glitches on model switch (mid-render switching stays finite; stock path bit-identical after switch)
- [x] Notes added to `docs/audio-engine/303-voices.md`

## Test plan

- [x] `bash emscripten/tests/run_offline_voices_test.sh` — all passed
- [x] `CI=true pnpm exec vitest run src/__tests__/TB303Models.test.ts src/components/__tests__/Voice303Selector.test.tsx` — 37/37 passed
- [ ] `pnpm run build:emcc` — blocked by pre-existing embind error on `open303_find_model_index` (unrelated to this PR)

Part of epic #896.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd54acf6-5eb2-4ae6-bd70-424e01b76d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd54acf6-5eb2-4ae6-bd70-424e01b76d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

