### PR TITLE
docs(tests): Lock 303 voice contract — docs, links, model303 round-trip tests (#896)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 ### Key Features
 - **Dual synthesizers** (Lead & Bass / Part A & Part B) with ADSR, filters, delay, and multiple waveform engines
-- **TB-303 engines** with per-voice `engine303` switching (`open303` or authentic `jc303`) plus Prophecy formant waveforms
+- **TB-303 engines** with per-voice `model303` voice selection (growing catalog) and legacy `engine303` family switching (`open303` or authentic `jc303`) plus Prophecy formant waveforms
 - **Drum machine** (Kick, Snare, Open/Closed Hi-Hats)
 - **Sampler with 8 independent banks** and Supertonic TTS integration
 - **Real-time voice designer** with GPU-accelerated DSP (sharpen, echo, tremolo, jitter, geometric transforms)
@@ -54,7 +54,8 @@
 
 #### Emscripten dual-303 + Prophecy internals (`hyphon_native.wasm`)
 - **Wrappers compiled together**: `emscripten/open303_wrapper.cpp`, `emscripten/jc303_wrapper.cpp`, `emscripten/prophecy_wrapper.cpp` (see `emscripten/build.sh`)
-- **Per-voice 303 switching**: `SynthParams.engine303` (`'open303' | 'jc303'`) flows through `Open303Manager.setBass1Engine/setBass2Engine/setLead303Engine` into the `open303-processor` `set-engine` message path.
+- **303 voice catalog**: `SynthParams.model303` (stable voice id, e.g. `stock-open303`, `experimental-01`) with legacy `engine303` mirror for older songs — see [docs/audio-engine/303-voices.md](docs/audio-engine/303-voices.md)
+- **Per-voice 303 switching**: `model303` flows through `Open303Manager.setBass1Model/setBass2Model/setLead303Model` (and legacy `setBass1Engine/...`) into the `open303-processor` `set-303-model` message path
 - **Current routing**:
   - `partB` / **SYNTH B** 303 waves → `bass1`
   - **BASS 2** 303 waves → `bass2`
@@ -607,6 +608,7 @@ Only the **Vite dev server on port 5173** is required for interactive developmen
 
 ## Resources
 
+- **303 Voices catalog**: [docs/audio-engine/303-voices.md](docs/audio-engine/303-voices.md) — selectable TB-303 models, WASM registry, migration, tests
 - **Supertonic TTS**: https://github.com/supertone-inc/supertonic
 - **Rubberband Library**: https://breakfastquay.com/rubberband/
 - **JC-303 / Open303 / Prophecy wrappers**: `emscripten/open303_wrapper.cpp`, `emscripten/jc303_wrapper.cpp`, `emscripten/prophecy_wrapper.cpp`

--- a/DOCS.md
+++ b/DOCS.md
@@ -47,6 +47,7 @@ Single entry point for all **live** Hyphon / web_sequencer documentation. Stale 
 |------|-------------|
 | [HARMONIZER_IMPLEMENTATION.md](docs/audio-engine/HARMONIZER_IMPLEMENTATION.md) | Vocal harmonizer engine design |
 | [JC303_STACK_OVERFLOW_FIX.md](docs/audio-engine/JC303_STACK_OVERFLOW_FIX.md) | JC-303 WASM stack overflow fix |
+| [303-voices.md](docs/audio-engine/303-voices.md) | Selectable TB-303 voice catalog, WASM registry, migration, and tests |
 | [jc303-prophecy.md](docs/audio-engine/jc303-prophecy.md) | Open303/JC303 switching and Prophecy routing |
 | [jc303-fix-plan.md](docs/audio-engine/jc303-fix-plan.md) | JC-303 WASM fix plan |
 | [jc303-technical-analysis.md](docs/audio-engine/jc303-technical-analysis.md) | JC-303 build/stack technical analysis |

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ For a quick-start overview see the root [README.md](../README.md).
 |------|---------|
 | [HARMONIZER_IMPLEMENTATION.md](audio-engine/HARMONIZER_IMPLEMENTATION.md) | Vocal harmonizer engine design and implementation details |
 | [JC303_STACK_OVERFLOW_FIX.md](audio-engine/JC303_STACK_OVERFLOW_FIX.md) | Fix for stack overflow in the JC-303 TB-303 clone WASM build |
+| [303-voices.md](audio-engine/303-voices.md) | Selectable TB-303 voice catalog, WASM registry, migration, and tests |
 | [jc303-prophecy.md](audio-engine/jc303-prophecy.md) | Current per-voice Open303/JC303 switching and Prophecy integration notes |
 | [PLAYBACK_STABILITY.md](audio-engine/PLAYBACK_STABILITY.md) | Jitter thresholds, scheduler guards, and stress-test guidance for song-mode playback |
 | [MULTISAMPLE_GENERATOR_DESIGN.md](audio-engine/MULTISAMPLE_GENERATOR_DESIGN.md) | Design notes for the multisample generator |

--- a/docs/audio-engine/303-voices.md
+++ b/docs/audio-engine/303-voices.md
@@ -15,16 +15,20 @@ track without touching the others.
 
 ## Current catalog
 
-| Id | Family | Status | Character |
-|----|--------|--------|-----------|
-| `stock-open303` | open303 | ✅ shipped | Pristine default — bit-identical to the pre-voices custom engine. |
-| `jc303` | jc303 | ✅ shipped | Authentic rosic::Open303 — identical to the old "Authentic JC303" engine setting. |
-| `1ink303-v1` | open303 | ✅ shipped | In-house: warmer filter base (26 Hz), rounder accent, slower slides, gentle saw shaping. |
-| `experimental-01` | open303 | ✅ shipped | Scratchpad: hotter resonance feedback (4.15), snappier envelope, harder accent punch, heavier square drive. |
-| `rebirth-338-1.5` | open303 | ✅ shipped | Inspired by ReBirth RB-338 1.5 (not a clone): squishier, self-oscillation-prone filter, gooey slides, big accent lift. |
-| `rebirth-2.0` | open303 | ✅ shipped | Inspired by ReBirth 2.0 (not a clone): cleaner/tighter filter than 1.5, punchier accent, snappier envelope. |
-| `mb33-mkii` | open303 | ✅ shipped | Inspired by MAM MB33 mkII (not a clone): boxier digital filter, distinct accent punch, square/saw grit. |
-| `raveolution` | open303 | ✅ shipped | Inspired by Quasimidi Raveolution 309 (not a clone): brighter harsh self-osc, aggressive resonance, snappy envelope, heavy drive. |
+Canonical registry: `src/engines/TB303Models.ts` (`TB303_MODELS`) mirrored by
+`k303Models[]` in `emscripten/open303_wrapper.cpp`. Ids are persisted in saved
+songs — **never rename** a shipped id.
+
+| Id | Label | Base engine | Character | Inspired by |
+|----|-------|-------------|-----------|-------------|
+| `stock-open303` | Stock Open303 | `open303` | Pristine default — bit-identical to the pre-voices custom engine | Hyphon built-in Open303 |
+| `jc303` | Authentic JC303 | `jc303` | Authentic rosic::Open303 DSP — same as the legacy "Authentic JC303" engine | TB-303 (rosic::Open303) |
+| `1ink303-v1` | 1ink303 v1 | `open303` | Warmer filter base, rounder accent, slower slides, gentle saw shaping | In-house Hyphon voice |
+| `experimental-01` | Experimental 01 | `open303` | Hot resonance feedback, snappier envelope, harder accent punch, heavier square drive | Scratchpad / dev voice |
+| `rebirth-338-1.5` | ReBirth RB-338 1.5 | `open303` | Squishier, self-oscillation-prone filter, gooey slides, big accent lift | ReBirth RB-338 1.5 *(not a clone)* |
+| `rebirth-2.0` | ReBirth 2.0 | `open303` | Cleaner/tighter filter than 1.5, punchier accent, snappier envelope | ReBirth RB-338 2.0 *(not a clone)* |
+| `mb33-mkii` | MB33 mkII | `open303` | Boxier digital filter, distinct accent punch, square/saw grit | MAM MB33 mkII *(not a clone)* |
+| `raveolution` | Raveolution 309 | `open303` | Bright harsh self-osc, aggressive resonance, snappy envelope, heavy drive | Quasimidi Raveolution 309 *(not a clone)* |
 
 Catalogued-but-unshipped voices are hidden from the UI and normalize to the
 stock voice of their family when loaded from a song.
@@ -86,6 +90,63 @@ brighter and harsher with aggressive resonance/self-oscillation, a snappy
 envelope, and heavier drive for dance-floor character.
 
 ## Architecture
+
+End-to-end flow from the C++ factory through the UI:
+
+```mermaid
+flowchart LR
+  subgraph cpp ["C++ factory (open303_wrapper.cpp)"]
+    K303["k303Models[] profiles"]
+    EXP["WASM exports\nopen303_get_model_*\nopen303_set_model*"]
+    K303 --> EXP
+  end
+
+  subgraph wasm ["hyphon_native.wasm"]
+    EXP
+    JC["jc303_* API\n(jc303_wrapper.cpp)"]
+  end
+
+  subgraph worklet ["AudioWorklet"]
+    PROC["open303-processor.ts\nset-303-model message"]
+    EXP --> PROC
+    JC --> PROC
+  end
+
+  subgraph ts ["TypeScript"]
+    OSC["Open303Oscillator\nsetModel303()"]
+    MGR["Open303Manager\nsetBass1/2/Lead303Model"]
+    REG["TB303Models.ts registry"]
+    UI["Voice303Selector"]
+    REG --> UI
+    UI --> MGR
+    MGR --> OSC
+    OSC --> PROC
+  end
+
+  subgraph persist ["Persistence"]
+    SONG["SavedSongData\nmodel303 + engine303 mirror"]
+    NORM["normalizeTB303Model()"]
+    SONG --> NORM --> MGR
+  end
+```
+
+See also [jc303-prophecy.md](jc303-prophecy.md) for the legacy dual-engine
+switch and Prophecy formant routing.
+
+### Per-instance routing
+
+Each 303 track picks its voice independently. Three `Open303Oscillator`
+instances share one `open303-processor` worklet but hold separate model state:
+
+| UI part | Track key | Manager method | Oscillator instance |
+|---------|-----------|----------------|---------------------|
+| SYNTH A (303 waves) | `partA` | `setLead303Model` | `lead303` |
+| SYNTH B (303 waves) | `partB` | `setBass1Model` | `bass1` |
+| BASS 2 | `bass2` | `setBass2Model` | `bass2` |
+
+After audio init or song load, `useAppState` calls
+`Open303Manager.syncModel303Settings({ lead, bass1, bass2 })` with ids from
+`normalizeTB303Model(model303, engine303)` per part.
 
 ### C++ (`emscripten/open303_wrapper.cpp`)
 
@@ -171,17 +232,48 @@ populated from `getAvailableTB303Models()` with the model description as the
 tooltip — new registry entries appear automatically. The old two-way
 `Engine303Selector` is deprecated but kept for compatibility.
 
+## Legacy `engine303` → `model303` migration
+
+Songs saved before the voices architecture carry only `engine303: 'open303' |
+'jc303'`. New songs write **both** fields so older builds still load the
+closest stock voice.
+
+| Saved field(s) | Resolved `model303` | Notes |
+|----------------|---------------------|-------|
+| `model303: 'experimental-01'` | `experimental-01` | Primary field wins |
+| `model303` + conflicting `engine303` | `model303` (if known + available) | `model303` takes precedence |
+| `engine303: 'jc303'` only | `jc303` | Legacy JC path |
+| `engine303: 'open303'` only | `stock-open303` | **`open303` aliases to `stock-open303`** |
+| Unknown future id | `stock-open303` or `jc303` | Falls back via `engine303` hint |
+
+API aliases:
+
+- `setEngine303('open303')` → `stock-open303` (via `stockModelForFamily`)
+- `setEngine303('jc303')` → `jc303`
+- On save, `useHardwarePanels` mirrors each `model303` change into `engine303`
+  via `tb303ModelFamily(model)`.
+
 ## Adding a new voice
 
-1. Add a profile row to `k303Models[]` in `emscripten/open303_wrapper.cpp`
-   (for an `open303`-family coefficient voice — bigger topology changes get a
-   separate DSP class behind the same instance API).
-2. Rebuild the WASM: `pnpm run build:emcc`.
-3. Add the matching entry to `TB303_MODELS` in `src/engines/TB303Models.ts`
-   with `available: true`.
+Checklist — this is the **only** guide needed to ship voice #N:
 
-That's it — the selector, worklet routing, persistence and normalization all
-read the registry.
+1. **C++ coefficient row** — add a profile to `k303Models[]` in
+   `emscripten/open303_wrapper.cpp` (open303-family voices are coefficient
+   profiles; jc303-family voices route to `jc303_wrapper.cpp` instead).
+2. **Registry entry** — add a matching row to `TB303_MODELS` in
+   `src/engines/TB303Models.ts` with `available: true`, `label`,
+   `shortLabel`, and `description` (tooltip text).
+3. **Rebuild emcc** — `pnpm run build:emcc` (or `bash emscripten/build.sh`).
+4. **UI description** — the `description` field in step 2 is the tooltip shown by
+   `Voice303Selector`; no component changes required.
+5. **Test pattern A/B** — run the offline voice test and manual in-app check:
+   - Automated: `bash emscripten/tests/run_offline_voices_test.sh`
+   - Manual: program a 303 bassline, toggle stock → new voice → stock (see
+     [Manual A/B checklist](#manual-ab-checklist-in-app-after-pnpm-run-buildemcc)
+     below).
+
+No other call-site changes — the selector, worklet routing, persistence, and
+normalization all read the registry.
 
 ## Out of scope for v1
 

--- a/docs/audio-engine/jc303-prophecy.md
+++ b/docs/audio-engine/jc303-prophecy.md
@@ -1,5 +1,8 @@
 # JC303 / Open303 Engine Selection + Prophecy Integration
 
+> **See also:** [303-voices.md](303-voices.md) — the growing selectable 303 voice
+> catalog (`model303`), registry contract, and how to add new voices.
+
 This note documents the current `hyphon_native.wasm` engine layout for TB-303-style synthesis and Korg Prophecy-style formants.
 
 ## 1) Dual 303 engine model in `hyphon_native.wasm`

--- a/src/__tests__/engine303-roundtrip.test.ts
+++ b/src/__tests__/engine303-roundtrip.test.ts
@@ -1,8 +1,8 @@
 /**
  * engine303-roundtrip.test.ts
  *
- * Verifies that the engine303 field is correctly preserved when a song is
- * serialised to and deserialised from the SavedSongData JSON format.
+ * Verifies that the engine303 and model303 fields are correctly preserved when
+ * a song is serialised to and deserialised from the SavedSongData JSON format.
  *
  * This exercises the data-layer round-trip (JSON.stringify → JSON.parse)
  * that all storage paths (localStorage, cloud, AI importer) share.
@@ -11,6 +11,7 @@
 import { describe, it, expect } from 'vitest';
 import type { SavedSongData, SynthParams, Bass2Params } from '../types';
 import { DEFAULT_SYNTH_PARAMS_A, DEFAULT_SYNTH_PARAMS_B, DEFAULT_BASS2_PARAMS } from '../constants';
+import { getAvailableTB303Models, normalizeTB303Model } from '../engines/TB303Models';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -20,6 +21,9 @@ function makeSongData(overrides: {
     synthAEngine?: SynthParams['engine303'];
     synthBEngine?: SynthParams['engine303'];
     bass2Engine?: Bass2Params['engine303'];
+    synthAModel?: SynthParams['model303'];
+    synthBModel?: SynthParams['model303'];
+    bass2Model?: Bass2Params['model303'];
 }): SavedSongData {
     return {
         version: 1,
@@ -34,12 +38,26 @@ function makeSongData(overrides: {
             sampler: Array(32).fill(0),
         } as any,
         params: {
-            synthA: { ...DEFAULT_SYNTH_PARAMS_A, engine303: overrides.synthAEngine },
-            synthB: { ...DEFAULT_SYNTH_PARAMS_B, engine303: overrides.synthBEngine },
+            synthA: {
+                ...DEFAULT_SYNTH_PARAMS_A,
+                engine303: overrides.synthAEngine,
+                ...(overrides.synthAModel !== undefined && { model303: overrides.synthAModel }),
+            },
+            synthB: {
+                ...DEFAULT_SYNTH_PARAMS_B,
+                engine303: overrides.synthBEngine,
+                ...(overrides.synthBModel !== undefined && { model303: overrides.synthBModel }),
+            },
             // bass2 is not in the official SavedSongData params type, but is stored by useSongStorage
-            ...(overrides.bass2Engine !== undefined && {
-                bass2: { ...DEFAULT_BASS2_PARAMS, engine303: overrides.bass2Engine } as any,
-            }),
+            ...(overrides.bass2Engine !== undefined || overrides.bass2Model !== undefined
+                ? {
+                    bass2: {
+                        ...DEFAULT_BASS2_PARAMS,
+                        ...(overrides.bass2Engine !== undefined && { engine303: overrides.bass2Engine }),
+                        ...(overrides.bass2Model !== undefined && { model303: overrides.bass2Model }),
+                    } as any,
+                }
+                : {}),
             kick: { pitch: 60, decay: 0.4, tone: 0.9, volume: 1 },
             snare: { decay: 0.2, tone: 150, noise: 5000, volume: 0.8 },
             closedHat: { pitch: 9000, decay: 0.05, volume: 0.4 },
@@ -131,5 +149,74 @@ describe('engine303 in SavedSongData version field', () => {
         const restored = roundTrip(song);
         expect(restored.version).toBe(1);
         expect(restored.params.synthA.engine303).toBe('jc303');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// model303 JSON round-trip (SavedSongData)
+// ---------------------------------------------------------------------------
+
+describe('model303 JSON round-trip (SavedSongData)', () => {
+    it('synthA.model303="experimental-01" survives JSON serialisation', () => {
+        const song = makeSongData({ synthAModel: 'experimental-01', synthAEngine: 'open303' });
+        const restored = roundTrip(song);
+        expect(restored.params.synthA.model303).toBe('experimental-01');
+    });
+
+    it('synthB.model303="jc303" survives JSON serialisation', () => {
+        const song = makeSongData({ synthBModel: 'jc303', synthBEngine: 'jc303' });
+        const restored = roundTrip(song);
+        expect(restored.params.synthB.model303).toBe('jc303');
+    });
+
+    it('bass2.model303="1ink303-v1" survives JSON serialisation', () => {
+        const song = makeSongData({ bass2Model: '1ink303-v1', bass2Engine: 'open303' });
+        const restored = roundTrip(song);
+        expect((restored.params as any).bass2?.model303).toBe('1ink303-v1');
+    });
+
+    it('all three parts with distinct model303 ids survive a round-trip', () => {
+        const song = makeSongData({
+            synthAModel: 'jc303',
+            synthBModel: 'stock-open303',
+            bass2Model: 'experimental-01',
+            synthAEngine: 'jc303',
+            synthBEngine: 'open303',
+            bass2Engine: 'open303',
+        });
+        const restored = roundTrip(song);
+        expect(restored.params.synthA.model303).toBe('jc303');
+        expect(restored.params.synthB.model303).toBe('stock-open303');
+        expect((restored.params as any).bass2?.model303).toBe('experimental-01');
+    });
+
+    it('model303 does not bleed between voices during round-trip', () => {
+        const song = makeSongData({
+            synthAModel: 'rebirth-338-1.5',
+            synthBModel: 'mb33-mkii',
+            bass2Model: 'raveolution',
+        });
+        const restored = roundTrip(song);
+        expect(restored.params.synthA.model303).toBe('rebirth-338-1.5');
+        expect(restored.params.synthB.model303).toBe('mb33-mkii');
+        expect((restored.params as any).bass2?.model303).toBe('raveolution');
+    });
+
+    it('every available model id round-trips and normalizes to itself on load', () => {
+        for (const m of getAvailableTB303Models()) {
+            const song = makeSongData({ synthAModel: m.id });
+            const restored = roundTrip(song);
+            expect(restored.params.synthA.model303).toBe(m.id);
+            expect(normalizeTB303Model(restored.params.synthA.model303, restored.params.synthA.engine303))
+                .toBe(m.id);
+        }
+    });
+
+    it('legacy engine303="open303" without model303 normalizes to stock-open303 on load', () => {
+        const song = makeSongData({ synthAEngine: 'open303' });
+        const restored = roundTrip(song);
+        expect(restored.params.synthA.model303).toBeUndefined();
+        expect(normalizeTB303Model(restored.params.synthA.model303, restored.params.synthA.engine303))
+            .toBe('stock-open303');
     });
 });

--- a/tests/engine303-switch.spec.ts
+++ b/tests/engine303-switch.spec.ts
@@ -17,8 +17,10 @@ import { test, expect } from '@playwright/test';
  * 3. SYNTH A / SYNTH B / BASS 2 select voices independently
  * 4. Every listed voice carries a tooltip description
  *
- * TODO: Fix Playwright environment setup for full audio context initialisation.
- * Temporarily skipped like other E2E specs until the CI environment is stable.
+ * TODO: Unskip when Playwright browsers are installed in the target environment.
+ * Specs are registry-driven (no hardcoded voice list) and cover multi-voice
+ * independent selection — they run in CI via `.github/workflows/playwright-e2e.yml`
+ * once unskipped.
  */
 
 /** Shared boot sequence: initialise the audio system and wait for the UI. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the documentation and test-contract work for Epic #896 (selectable growing TB-303 voices). Core plumbing was already on `main`; this PR links the guide into the docs index and adds `model303` persistence tests.

## Changes

### Documentation (`docs/audio-engine/303-voices.md`)
- Mermaid architecture diagram (C++ factory → WASM → worklet → Open303Manager → UI)
- Full model ID table: id, label, base engine, character, inspired-by attribution
- Per-instance routing table (lead303 / bass1 / bass2)
- Legacy `engine303` → `model303` migration / alias table (`open303` → `stock-open303`)
- Expanded "add a new voice" checklist (C++, registry, emcc rebuild, UI description, A/B test pattern)

### Index links
- `AGENTS.md` — updated 303 voice overview + Resources link
- `DOCS.md` + `docs/README.md` — audio-engine index entry
- `docs/audio-engine/jc303-prophecy.md` — cross-link to 303-voices guide

### Tests
- `engine303-roundtrip.test.ts` — 7 new `model303` SavedSongData round-trip tests (per-part independence, all available ids, legacy `open303` alias normalization on load)
- Existing coverage unchanged and green: `TB303Models.test.ts`, `Voice303Selector.test.tsx`, `Open303EngineSelect.test.ts` (74 tests total)
- E2E `engine303-switch.spec.ts` — specs remain skipped; comment updated to note registry-driven multi-voice coverage is ready for CI unskip

## Acceptance checklist

- [x] `303-voices.md` linked from AGENTS/docs index
- [x] Round-trip + selector unit tests green
- [x] Checklist section usable as sole guide for adding voice #N
- [ ] E2E unskip (deferred — Playwright browsers not available in dev env; specs written for CI)

## Test plan

- [x] `CI=true pnpm exec vitest run src/__tests__/TB303Models.test.ts src/__tests__/engine303-roundtrip.test.ts src/__tests__/Open303EngineSelect.test.ts src/components/__tests__/Voice303Selector.test.tsx --pool forks`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d1429b5-0b69-464b-851b-334a37f42f32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d1429b5-0b69-464b-851b-334a37f42f32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

