### PR TITLE
feat(303): model303 voice ID plumbing for Epic #896

### DIFF
--- a/src/__tests__/RbsImporter.fidelity.test.ts
+++ b/src/__tests__/RbsImporter.fidelity.test.ts
@@ -42,6 +42,15 @@ function assertValidNote(note: Note) {
 }
 
 describe('RbsImporter TB-303 fidelity', () => {
+  it('sets stock model303 voice fields on imported 303 synth params', () => {
+    const importer = new RbsImporter({ expandTo32Steps: false });
+    const result = importer.convertToHyphonSong(makeRaw());
+    expect(result.song.params.synthA.model303).toBe('stock-open303');
+    expect(result.song.params.synthA.engine303).toBe('open303');
+    expect(result.song.params.synthB.model303).toBe('stock-open303');
+    expect(result.song.params.synthB.engine303).toBe('open303');
+  });
+
   it('16→32 tied note sustains without re-triggering envelope', () => {
     const steps: Tb303Step[] = Array.from({ length: 16 }, (_, i) => {
       if (i === 0) return tb303Step({ index: 0, note: 0, accent: true });

--- a/src/__tests__/TB303Models.test.ts
+++ b/src/__tests__/TB303Models.test.ts
@@ -18,12 +18,14 @@ import {
     getTB303Model,
     getAvailableTB303Models,
     normalizeTB303Model,
+    reportTB303ModelFallback,
     tb303ModelFamily,
     stockModelForFamily,
 } from '../engines/TB303Models';
 import { Open303Oscillator } from '../engines/Open303Oscillator';
 import { Open303Manager } from '../engines/Open303Manager';
 import { DEFAULT_BASS2_PARAMS } from '../constants';
+import { DEFAULT_TB303_VOICE_FIELDS } from '../engines/TB303Models';
 import type { SynthParams, TB303ModelId } from '../types';
 
 // ---------------------------------------------------------------------------
@@ -125,6 +127,17 @@ describe('normalizeTB303Model()', () => {
     it('falls back for unknown ids from future song versions', () => {
         expect(normalizeTB303Model('some-future-voice')).toBe('stock-open303');
         expect(normalizeTB303Model('some-future-voice', 'jc303')).toBe('jc303');
+    });
+
+    it('reportFallback logs and resolves when an unknown id is requested', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const resolved = normalizeTB303Model('wasm-discovered-voice', undefined, {
+            reportFallback: true,
+            subsystem: 'test-model303',
+        });
+        expect(resolved).toBe('stock-open303');
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('wasm-discovered-voice'));
+        warn.mockRestore();
     });
 });
 
@@ -271,6 +284,11 @@ describe('Open303Manager model selection', () => {
 describe('model303 persistence', () => {
     it('DEFAULT_BASS2_PARAMS carries the stock voice and the legacy mirror', () => {
         expect(DEFAULT_BASS2_PARAMS.model303).toBe('stock-open303');
+        expect(DEFAULT_BASS2_PARAMS.engine303).toBe('open303');
+        expect(DEFAULT_TB303_VOICE_FIELDS).toEqual({
+            model303: 'stock-open303',
+            engine303: 'open303',
+        });
         expect(DEFAULT_BASS2_PARAMS.engine303).toBe('open303');
     });
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,7 @@ import { noteToMidi, applyMicrotonalTuning } from './utils/musicTheory';
 import type { ScaleDefinition } from './utils/musicTheory';
 import type { Pattern, SynthParams, KickParams, SnareParams, HatParams, SamplerBankParams, SamplerParams, AmbianceTrack, DrumKitType } from './types';
 import { DRUM_KIT_PRESETS } from './engines/DrumKitPresets';
+import { DEFAULT_TB303_VOICE_FIELDS } from './engines/TB303Models';
 
 export const NUM_STEPS = 32;
 export const DEFAULT_TEMPO = 120;
@@ -71,8 +72,8 @@ export const DEFAULT_BASS2_PARAMS = {
   accent: 0.7,
   envMod: 0.5,
   volume: 0.45,
-  engine303: 'open303' as const,
-  model303: 'stock-open303' as const,
+  engine303: DEFAULT_TB303_VOICE_FIELDS.engine303,
+  model303: DEFAULT_TB303_VOICE_FIELDS.model303,
 };
 
 export const DEFAULT_KICK_PARAMS: KickParams = { pitch: 60, decay: 0.4, tone: 0.9, volume: 1 };

--- a/src/engines/Open303Oscillator.ts
+++ b/src/engines/Open303Oscillator.ts
@@ -1,7 +1,7 @@
 import type { Open303Params, Open303Config } from './Open303Params';
 import { DEFAULT_303_PARAMS } from './Open303Params';
 import type { TB303ModelId } from './TB303Models';
-import { normalizeTB303Model, stockModelForFamily, tb303ModelFamily } from './TB303Models';
+import { normalizeTB303Model, reportTB303ModelFallback, stockModelForFamily, tb303ModelFamily } from './TB303Models';
 import { FallbackBassSynth } from './FallbackBassSynth';
 import {
     engineTelemetry,
@@ -290,7 +290,12 @@ export class Open303Oscillator {
      * always work.
      */
     setModel303(model: TB303ModelId | string): void {
-        this.model303 = normalizeTB303Model(model);
+        const requested = typeof model === 'string' ? model.trim() : model;
+        const resolved = normalizeTB303Model(requested);
+        if (requested && resolved !== requested) {
+            reportTB303ModelFallback(requested, resolved, 'runtime apply', 'open303-model');
+        }
+        this.model303 = resolved;
         this.engine303 = tb303ModelFamily(this.model303);
         this.applyModel303();
     }

--- a/src/engines/TB303Models.ts
+++ b/src/engines/TB303Models.ts
@@ -36,6 +36,15 @@ export type TB303ModelId =
   | '1ink303-v1'        // in-house
   | 'experimental-01';  // scratchpad
 
+/** Catalog ids plus WASM-discovered voice strings from future builds. */
+export type TB303Model = TB303ModelId | (string & {});
+
+/** Default persisted 303 voice fields for new patterns and RBS imports. */
+export const DEFAULT_TB303_VOICE_FIELDS = {
+  model303: 'stock-open303' as const,
+  engine303: 'open303' as const,
+};
+
 export interface TB303ModelInfo {
   id: TB303ModelId;
   /** Full human-readable name (tooltip / docs). */
@@ -150,20 +159,55 @@ export function stockModelForFamily(family: Engine303Family): TB303ModelId {
 }
 
 /**
+ * Report when a requested 303 voice could not be used as-is (HUD + console).
+ * Call sites pass a stable subsystem id (e.g. `synthA-model303`).
+ */
+export function reportTB303ModelFallback(
+  requested: string,
+  resolved: TB303ModelId,
+  reason: string,
+  subsystem = 'tb303-model',
+): void {
+  const msg = `[TB303] Model "${requested}" unavailable (${reason}) — using "${resolved}"`;
+  console.warn(msg);
+  try {
+    // Lazy import avoids pulling DOM code into every unit test.
+    void import('../utils/engineTelemetry').then(({ engineTelemetry }) => {
+      engineTelemetry.registerResolution(subsystem, resolved, `${requested}: ${reason}`);
+    });
+  } catch {
+    /* telemetry optional */
+  }
+}
+
+/**
  * Resolve a persisted model/engine pair to a valid, available model id.
  *
  *  - A known, available `model303` wins.
  *  - A known-but-unavailable model falls back to its family's stock voice.
  *  - Otherwise the legacy `engine303` field decides ('jc303' → 'jc303').
  *  - Default: 'stock-open303'.
+ *
+ * When `reportFallback` is true and the resolved id differs from the requested
+ * string, `reportTB303ModelFallback` is invoked (song load / runtime apply).
  */
 export function normalizeTB303Model(
   model303?: string,
   engine303?: string,
+  options?: { reportFallback?: boolean; subsystem?: string },
 ): TB303ModelId {
-  const model = getTB303Model(model303);
+  const requested = model303?.trim();
+  const model = getTB303Model(requested);
   if (model) {
-    return model.available ? model.id : stockModelForFamily(model.family);
+    const resolved = model.available ? model.id : stockModelForFamily(model.family);
+    if (options?.reportFallback && requested && resolved !== requested) {
+      reportTB303ModelFallback(requested, resolved, 'catalogued but not shipped', options.subsystem);
+    }
+    return resolved;
   }
-  return engine303 === 'jc303' ? 'jc303' : 'stock-open303';
+  const resolved = engine303 === 'jc303' ? 'jc303' : 'stock-open303';
+  if (options?.reportFallback && requested && resolved !== requested) {
+    reportTB303ModelFallback(requested, resolved, 'unknown id', options.subsystem);
+  }
+  return resolved;
 }

--- a/src/hooks/useAppState.tsx
+++ b/src/hooks/useAppState.tsx
@@ -223,9 +223,18 @@ export function useAppState() {
         // the legacy engine303 field for songs saved before the voices update.
         if (typeof mgr.syncModel303Settings === 'function') {
             mgr.syncModel303Settings({
-                lead: normalizeTB303Model(synthA.model303, synthA.engine303),
-                bass1: normalizeTB303Model(synthB.model303, synthB.engine303),
-                bass2: normalizeTB303Model(bass2.model303, bass2.engine303),
+                lead: normalizeTB303Model(synthA.model303, synthA.engine303, {
+                    reportFallback: true,
+                    subsystem: 'synthA-model303',
+                }),
+                bass1: normalizeTB303Model(synthB.model303, synthB.engine303, {
+                    reportFallback: true,
+                    subsystem: 'synthB-model303',
+                }),
+                bass2: normalizeTB303Model(bass2.model303, bass2.engine303, {
+                    reportFallback: true,
+                    subsystem: 'bass2-model303',
+                }),
             });
         } else if (typeof mgr.syncEngine303Settings === 'function') {
             mgr.syncEngine303Settings({

--- a/src/importers/rbs/importer/synthParams.ts
+++ b/src/importers/rbs/importer/synthParams.ts
@@ -14,6 +14,10 @@ import {
   mapRange,
 } from './parameterCurves';
 import type { ImporterContext } from './importerContext';
+import { DEFAULT_TB303_VOICE_FIELDS } from '../../../engines/TB303Models';
+
+/** Persisted 303 voice defaults for RBS imports (ReBirth hardware → stock Hyphon voice). */
+const RBS_TB303_VOICE_FIELDS = DEFAULT_TB303_VOICE_FIELDS;
 
 /** Convert TB-303 params to Bass2Params (Open303 format). */
 export function convertToBass2Params(
@@ -56,6 +60,7 @@ export function convertToBass2Params(
 
   return {
     waveform: tb303.waveform === 0 ? '303-saw' : '303-sqr',
+    ...RBS_TB303_VOICE_FIELDS,
     pitch: 0,
     cutoff,
     resonance,
@@ -85,6 +90,7 @@ export function mapTb303PatternToSynthParams(
   const portamento = clampNormalized((tb303.slideTime ?? TB303_DEFAULT_SLIDE_TIME) / 127);
   return {
     waveform,
+    ...RBS_TB303_VOICE_FIELDS,
     pitch: 0,
     filterCutoff: cutoffHz,
     filterResonance: resonance,
@@ -273,6 +279,7 @@ export function convertSynthParams(
 
     return {
       waveform,
+      ...RBS_TB303_VOICE_FIELDS,
       pitch: 0,
       filterCutoff: cutoffHz,
       filterResonance: resonance,

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ import type { ScaleDefinition } from './utils/musicTheory';
 import type { MultisampleBank } from './engines/MultisampleGenerator';
 export type { MultisampleBank } from './engines/MultisampleGenerator';
 import type { TB303ModelId } from './engines/TB303Models';
-export type { TB303ModelId, TB303ModelInfo, Engine303Family } from './engines/TB303Models';
+export type { TB303ModelId, TB303Model, TB303ModelInfo, Engine303Family } from './engines/TB303Models';
 
 export type Waveform =
   | 'sawtooth' | 'square' | 'triangle' | 'sine'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the TypeScript app-glue layer for the selectable TB-303 voices/models system (Epic #896). Most of the architecture was already landed on `main` via #960–#963; this PR closes the remaining integration gaps.

### What was already on `main`
- `SynthParams.model303` + legacy `engine303` mirror in `types.ts`
- `TB303Models.ts` registry with `normalizeTB303Model()`, stock/jc303/experimental/ReBirth/P2 voices
- `Open303Manager.setBass1Model` / `setBass2Model` / `setLead303Model` (+ legacy `set*Engine` wrappers)
- `Open303Oscillator` posts `set-303-model`; worklet handles both `set-engine` and `set-303-model`
- `useAppState` → `syncModel303Settings` on audio init / param change
- Round-trip tests in `engine303-roundtrip.test.ts` and `TB303Models.test.ts`

### What this PR adds
- **`TB303Model` type** — catalog ids plus `string` for WASM-discovered voices
- **`DEFAULT_TB303_VOICE_FIELDS`** — shared `{ model303: 'stock-open303', engine303: 'open303' }` used by `DEFAULT_BASS2_PARAMS` and RBS import
- **RBS importer** — sets `model303` / `engine303` when mapping TB-303 pattern params to Hyphon synth/bass2 params
- **Fallback telemetry** — `reportTB303ModelFallback()` logs + registers HUD telemetry when an unavailable/unknown model id is normalized (song load + runtime `setModel303`)

## Acceptance criteria

- [x] Per-voice independent model selection for bass1, bass2, lead303
- [x] Legacy songs/patterns with `engine303: 'open303' | 'jc303'` load without loss (`open303` → `stock-open303`)
- [x] Worklet accepts both `set-engine` and `set-303-model`
- [x] Round-trip tests cover stock, jc303, and new model IDs (`experimental-01`, `rebirth-*`, etc.)
- [x] No silent fallback — console warn + `engineTelemetry.registerResolution` on unavailable models

## Tests

```
pnpm exec vitest run src/__tests__/engine303-roundtrip.test.ts \
  src/__tests__/TB303Models.test.ts \
  src/__tests__/Open303EngineSelect.test.ts \
  src/__tests__/RbsImporter.fidelity.test.ts
```

Closes Epic #896 (app glue). Depends on #901 for full WASM model registry; current build ships open303/jc303 + coefficient profiles.

Related: #897 (UI), #898+ (voice landings), #902 (migration docs)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3237706-2a7b-4c10-9081-a27c3ace879d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3237706-2a7b-4c10-9081-a27c3ace879d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

