### PR TITLE
fix Embind raw-pointer bind for open303 model-id APIs

### DIFF
--- a/emscripten/open303_wrapper.cpp
+++ b/emscripten/open303_wrapper.cpp
@@ -624,6 +624,19 @@ static std::string getAvailable303Models()
     return json;
 }
 
+// Embind cannot bind raw pointers to primitives (const char*). These
+// std::string wrappers are the main-thread module surface; the extern "C"
+// EMSCRIPTEN_KEEPALIVE exports above remain the worklet/ccall path.
+static int open303_find_model_index_str(const std::string& id)
+{
+    return open303_find_model_index(id.c_str());
+}
+
+static int open303_set_model_by_id_str(uintptr_t handle, const std::string& id)
+{
+    return open303_set_model_by_id(handle, id.c_str());
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Embind bindings  (makes the same functions callable from the JS module
 // wrapper / main-thread AudioDSP bridge)
@@ -643,7 +656,7 @@ EMSCRIPTEN_BINDINGS(open303_module) {
     function("open303_get_model_engine",  &open303_get_model_engine);
     function("open303_set_model",         &open303_set_model);
     function("open303_get_model",         &open303_get_model);
-    function("open303_find_model_index",  &open303_find_model_index);
-    function("open303_set_model_by_id",   &open303_set_model_by_id);
+    function("open303_find_model_index",  &open303_find_model_index_str);
+    function("open303_set_model_by_id",   &open303_set_model_by_id_str);
     function("getAvailable303Models",     &getAvailable303Models);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Embind fails to compile `open303_wrapper.cpp` when binding functions that take `const char*`:

```
wire.h: static_assert failed: Implicitly binding raw pointers is illegal.
  … open303_find_model_index(const char*)
```

Embind does not support raw pointers to primitives (`const char*`). This change routes the Embind (main-thread module) surface through `std::string` wrappers while keeping the existing `EMSCRIPTEN_KEEPALIVE` C API (`const char*`) for worklet/`ccall` callers.

## Change

In `emscripten/open303_wrapper.cpp`:
- Add `open303_find_model_index_str` / `open303_set_model_by_id_str` that take `const std::string&`
- Point `EMSCRIPTEN_BINDINGS` at those wrappers
- Leave the extern "C" exports unchanged

## Verification

- Offline smoke test (`tb303_factory_smoke_test.cpp`): all passed
- `em++ -c open303_wrapper.cpp`: clean compile
- Full `emscripten/build.sh`: successful (`hyphon_native.js` generated)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74dacfc4-fbc0-40c2-800b-91484f4abad0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74dacfc4-fbc0-40c2-800b-91484f4abad0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

