### PR TITLE
feat: Add formant sidechaining to kick drum

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -245,5 +245,6 @@
 
 
 * [x] **Idea:** "Granular Pitch Envelope" - Apply a dedicated pitch envelope explicitly to the granular synthesis engine.
+* [x] **Idea:** "Formant Envelope Sidechaining" - Duck the lead vocal formant shift when the kick drum hits to create rhythmic voweling.
 ## 2026-08-06 - Implemented Granular Pitch Envelope: Completed implementation by adding UI controls to ContextMenuNode and fixing syntax in useAudioEngine. Fulfills "Granular Pitch Envelope" Innovation Lab idea.
 * [x] **Idea:** "Granular Pitch Envelope" - Apply a dedicated pitch envelope explicitly to the granular synthesis engine.

--- a/src/engines/SingingVoice.ts
+++ b/src/engines/SingingVoice.ts
@@ -1121,6 +1121,19 @@ export class SingingVoice {
   }
 
   /**
+   * Trigger a sidechain duck on the formant filters.
+   */
+  triggerFormantSidechainDuck(
+    time: number,
+    depth: number,
+    releaseTime: number,
+  ) {
+    if (this.formantShifter && this.config.enableFormantShifting) {
+      this.formantShifter.triggerSidechainDuck(time, depth, releaseTime);
+    }
+  }
+
+  /**
    * Set character morphing amount and target.
    * @param amount Morph amount (0 to 1)
    * @param target Target voice character

--- a/src/engines/rubberband/FormantShifter.ts
+++ b/src/engines/rubberband/FormantShifter.ts
@@ -104,6 +104,10 @@ export class FormantShifter {
     private envNode: ConstantSourceNode | null = null;
     private envGain: GainNode | null = null;
 
+    // Sidechain Duck components
+    private sidechainEnvNode: ConstantSourceNode | null = null;
+    private sidechainEnvGain: GainNode | null = null;
+
     // Envelope Follower components
     private followerWaveshaper: WaveShaperNode | null = null;
     private followerFilter: BiquadFilterNode | null = null;
@@ -216,6 +220,19 @@ export class FormantShifter {
             }
 
             this.envNode.start();
+
+            // Sidechain envelope
+            this.sidechainEnvNode = this.audioContext.createConstantSource();
+            this.sidechainEnvGain = this.audioContext.createGain();
+            this.sidechainEnvGain.gain.value = 0; // Idle state
+
+            this.sidechainEnvNode.connect(this.sidechainEnvGain);
+
+            for (let i = 0; i < formants.length; i++) {
+                this.sidechainEnvGain.connect(filters[i].detune);
+            }
+
+            this.sidechainEnvNode.start();
         }
 
         // Create Envelope Follower components
@@ -592,6 +609,16 @@ export class FormantShifter {
             this.envGain = null;
         }
 
+        if (this.sidechainEnvNode) {
+            this.sidechainEnvNode.stop();
+            this.sidechainEnvNode.disconnect();
+            this.sidechainEnvNode = null;
+        }
+        if (this.sidechainEnvGain) {
+            this.sidechainEnvGain.disconnect();
+            this.sidechainEnvGain = null;
+        }
+
         if (this.followerWaveshaper) {
             this.followerWaveshaper.disconnect();
             this.followerWaveshaper = null;
@@ -651,6 +678,30 @@ export class FormantShifter {
         } else {
             gainParam.setValueAtTime(0, t + attack);
         }
+    }
+
+    /**
+     * Trigger a sidechain duck on the formant filters.
+     * @param time Trigger time
+     * @param depth Duck depth in semitones (usually negative)
+     * @param releaseTime Time to recover back to 0
+     */
+    triggerSidechainDuck(time: number, depth: number, releaseTime: number): void {
+        if (!this.sidechainEnvGain) return;
+
+        const t = time;
+        const gainParam = this.sidechainEnvGain.gain;
+
+        gainParam.cancelScheduledValues(t);
+        gainParam.setValueAtTime(gainParam.value, t);
+
+        const duckAmount = depth * 100; // Map semitones to cents
+
+        // Instant drop (10ms to prevent clicking)
+        gainParam.linearRampToValueAtTime(duckAmount, t + 0.01);
+
+        // Recover
+        gainParam.setTargetAtTime(0.0, t + 0.01, releaseTime / 3);
     }
 
     /**

--- a/src/hooks/audioEngine/audioPlayback.ts
+++ b/src/hooks/audioEngine/audioPlayback.ts
@@ -427,8 +427,15 @@ export function createPlayDrum(
         // Use DrumKitEngine for authentic 808/909 synthesis when available
         const kitEngine = refs.drumKitEngineRef?.current;
         if (kitEngine) {
-            if (sound === 'kick' && refs.sidechainGainRef.current) {
-                triggerSidechainDuck(context, refs.sidechainGainRef.current, now);
+            if (sound === 'kick') {
+                if (refs.sidechainGainRef.current) {
+                    triggerSidechainDuck(context, refs.sidechainGainRef.current, now);
+                }
+                if (refs.singingVoiceManagerRef?.current) {
+                    refs.singingVoiceManagerRef.current.getAllVoices().forEach(voice => {
+                        voice.triggerFormantSidechainDuck(now, -12, 0.25);
+                    });
+                }
             }
 
             kitEngine.play(context, refs.masterGainRef.current, refs.noiseBufferRef.current, sound, adjustedParams, now);
@@ -439,6 +446,11 @@ export function createPlayDrum(
         if (sound === 'kick') {
                 if (refs.sidechainGainRef.current) {
                     triggerSidechainDuck(context, refs.sidechainGainRef.current, now);
+                }
+                if (refs.singingVoiceManagerRef?.current) {
+                    refs.singingVoiceManagerRef.current.getAllVoices().forEach(voice => {
+                        voice.triggerFormantSidechainDuck(now, -12, 0.25);
+                    });
                 }
 
                 const kickParams = params as KickParams;


### PR DESCRIPTION
Implements Formant Envelope Sidechaining.
Ducks the lead vocal formant shift whenever the kick drum hits to create a rhythmic voweling effect.
- Adds `triggerSidechainDuck` method to `FormantShifter` via a dedicated ConstantSourceNode envelope
- Adds `triggerFormantSidechainDuck` mapping to `SingingVoice`
- Hooks up the trigger to kick occurrences inside `audioPlayback.ts`

---
*PR created automatically by Jules for task [5486269532469767846](https://jules.google.com/task/5486269532469767846) started by @ford442*