### PR TITLE
⚡ Bolt: Remove closure allocations in voice param updates

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -14,3 +14,7 @@
 ## 2024-05-20 - [Closure Allocations in High Frequency Sequences]
 **Learning:** `forEach` closures on real-time sequencer paths (`useStepHandler`, `samplerPlayback`) continuously allocate memory, leading to main-thread GC spikes during playback. These allocations compound rapidly, especially when iterating over polyphonic voices or per-step sequences on every tick.
 **Action:** Consistently replace `Array.prototype.forEach` (and similar higher-order functions like `.map` or `.filter`) with standard `for` or `for...of` loops in high-frequency loops, Web Audio callbacks, and sequencer logic to eliminate closure instantiation overhead entirely.
+
+## 2026-07-25 - Automation Lane Flow Closure Hot Paths
+**Learning:** In the `useStepHandler.ts` step loop, unified automation lane updates continuously call into `applyVoiceParamUpdate` and `applySamplerVoiceParamUpdate` (via `audioEngine.updateSamplerVoiceParams` and `onParamChange`). This means iterating over voices inside these param updaters is also a high-frequency real-time execution path. Previously, they used `manager.getAllVoices().forEach(...)`, which allocates closures every step during playback, contributing to GC spikes.
+**Action:** Always replace `.forEach` with standard `for` loops not just directly inside `useStepHandler`, but in any downstream module (like `sampleManagement.ts`) that is synchronously called by the step sequencer on every tick.

--- a/src/hooks/audioEngine/sampleManagement.ts
+++ b/src/hooks/audioEngine/sampleManagement.ts
@@ -146,7 +146,9 @@ export function applyVoiceParamUpdate({
     rampTime
 }: VoiceParamUpdateOptions): void {
     if (manager) {
-        manager.getAllVoices().forEach((voice) => {
+        const voices = manager.getAllVoices();
+        for (let i = 0; i < voices.length; i++) {
+            const voice = voices[i];
             switch (key) {
                 case 'timeRatio':
                     voice.setTimeRatio(value);
@@ -179,7 +181,7 @@ export function applyVoiceParamUpdate({
                     voice.setRelease(value);
                     break;
             }
-        });
+        }
     }
 
     if (key === 'choir') {
@@ -206,7 +208,9 @@ export function applySamplerVoiceParamUpdate({
         return;
     }
 
-    manager.getAllVoices().forEach((voice) => {
+    const voices = manager.getAllVoices();
+    for (let i = 0; i < voices.length; i++) {
+        const voice = voices[i];
         switch (param) {
             case 'vibratoRate':
                 voice.setVibratoRate(value as number);
@@ -253,5 +257,5 @@ export function applySamplerVoiceParamUpdate({
                 voice.setCharacterMorph(value as number, 'female', 0.05);
                 break;
         }
-    });
+    }
 }


### PR DESCRIPTION
💡 What: Replaced `manager.getAllVoices().forEach(...)` with traditional `for` loops in `applyVoiceParamUpdate` and `applySamplerVoiceParamUpdate` inside `src/hooks/audioEngine/sampleManagement.ts`.

🎯 Why: These functions are continuously called on a per-step basis by the sequencer (`useStepHandler`) when automation lanes stream real-time updates. Using `.forEach` inside these hot paths causes transient function closures to be allocated on every tick, contributing to main-thread garbage collection (GC) pressure and potential audio dropouts.

📊 Impact: Reduces main-thread GC allocations and pauses during active sequencer playback with automation.

🔬 Measurement: Verified that unit tests pass and behavior remains identical. Can be verified by profiling JS heap allocations during continuous sequence playback with an active automation lane targeting a sampler parameter.

---
*PR created automatically by Jules for task [2209117756323310343](https://jules.google.com/task/2209117756323310343) started by @ford442*