### PR TITLE
feat(TTS): implement per-phoneme vibrato

### DIFF
--- a/.Jules/agent_plan.md
+++ b/.Jules/agent_plan.md
@@ -7,7 +7,9 @@
 - [x] Implement Phoneme Envelope shaping per step
 - [x] Implement Lyric Track parsing
 - [x] Implement Vowel-Preserving Time Stretch for TTS voices
-- [ ] Implement per-phoneme pitch drift/vibrato
+- [x] Implement per-phoneme pitch drift/vibrato
 - [ ] Add Formant Modulation LFO
+- [ ] Add Formant Glide per phoneme
+- [ ] Add granular random jitter per phoneme
 
 ## Roadmap

--- a/src/audio-worklets/rubberband-processor.ts
+++ b/src/audio-worklets/rubberband-processor.ts
@@ -263,15 +263,15 @@ class RubberBandProcessor extends AudioWorkletProcessor {
    */
   /**
    * Determine the phoneme parameters for the current sample position.
-   * Returns [stretchRatio, volume, pitchBend]
+   * Returns [stretchRatio, volume, pitchBend, vibDepth, vibRate]
    */
-  private getPhonemeDataAtSample(currentSample: number): [number, number, number] {
-    if (!this.phonemeData || !this.phonemeRatios) return [1.0, 1.0, 0.0];
+  private getPhonemeDataAtSample(currentSample: number): [number, number, number, number, number] {
+    if (!this.phonemeData || !this.phonemeRatios) return [1.0, 1.0, 0.0, -1.0, -1.0];
 
     const count = this.phonemeData[0];
-    // Phoneme data stride is 6 floats: start, end, isVowel, stretch(unused in buffer), volume, pitchBend
+    // Phoneme data stride is 8 floats: start, end, isVowel, stretch(unused in buffer), volume, pitchBend, vibDepth, vibRate
     for (let i = 0; i < count; i++) {
-      const baseIndex = 1 + i * 6;
+      const baseIndex = 1 + i * 8;
       const start = this.phonemeData[baseIndex];
       const end = this.phonemeData[baseIndex + 1];
 
@@ -279,10 +279,12 @@ class RubberBandProcessor extends AudioWorkletProcessor {
         const ratio = this.phonemeRatios[i] || 1.0;
         const volume = this.phonemeData[baseIndex + 4] !== undefined ? this.phonemeData[baseIndex + 4] : 1.0;
         const pitchBend = this.phonemeData[baseIndex + 5] !== undefined ? this.phonemeData[baseIndex + 5] : 0.0;
-        return [ratio, volume, pitchBend];
+        const vibDepth = this.phonemeData[baseIndex + 6] !== undefined ? this.phonemeData[baseIndex + 6] : -1.0;
+        const vibRate = this.phonemeData[baseIndex + 7] !== undefined ? this.phonemeData[baseIndex + 7] : -1.0;
+        return [ratio, volume, pitchBend, vibDepth, vibRate];
       }
     }
-    return [1.0, 1.0, 0.0];
+    return [1.0, 1.0, 0.0, -1.0, -1.0];
   }
 
   process(_inputs: Float32Array[][], outputs: Float32Array[][], parameters: Record<string, Float32Array>): boolean {
@@ -328,8 +330,16 @@ class RubberBandProcessor extends AudioWorkletProcessor {
     const sustain = parameters.sustain ? parameters.sustain[0] : 1.0;
     const release = parameters.release ? parameters.release[0] : 0.1;
 
+    let currentVibDepth = vibDepth;
+    let currentVibRate = vibRate;
+    if (this.isPlaying && this.fullSampleBuffer && this.phonemeData && this.phonemeRatios) {
+        const [_, _vol, _pBend, pVibDepth, pVibRate] = this.getPhonemeDataAtSample(this.currentSamplePtr);
+        if (pVibDepth !== -1.0) currentVibDepth = pVibDepth;
+        if (pVibRate !== -1.0) currentVibRate = pVibRate;
+    }
+
     this.expressiveProcessor.updateConfig({
-      vibrato: { depth: vibDepth, rate: vibRate, enabled: vibDepth > 0 },
+      vibrato: { depth: currentVibDepth, rate: currentVibRate, enabled: currentVibDepth > 0 },
       tremolo: { depth: tremDepth, rate: tremRate, enabled: tremDepth > 0 },
       gate: { depth: gateDepth, rate: gateRate, enabled: gateDepth > 0 },
       breath: { amount: breath, enabled: breath > 0, filterCutoff: 2000 },
@@ -368,7 +378,7 @@ class RubberBandProcessor extends AudioWorkletProcessor {
 
     // Apply Phoneme Pitch Bend (if we're streaming from a buffer and have it calculated)
     if (this.isPlaying && this.fullSampleBuffer && this.phonemeData && this.phonemeRatios) {
-        const [_, _vol, pBend] = this.getPhonemeDataAtSample(this.currentSamplePtr);
+        const [_, _vol, pBend, _vDepth, _vRate] = this.getPhonemeDataAtSample(this.currentSamplePtr);
         if (pBend !== 0.0) {
             const pitchBendRatio = Math.pow(2.0, pBend / 1200.0);
             finalPitch *= pitchBendRatio;
@@ -394,7 +404,7 @@ class RubberBandProcessor extends AudioWorkletProcessor {
         let phonemeVolume = 1.0;
         let phonemePitchBendCents = 0.0;
         if (this.phonemeData && this.phonemeRatios) {
-          const [pRatio, pVol, pBend] = this.getPhonemeDataAtSample(this.currentSamplePtr);
+          const [pRatio, pVol, pBend, _vDepth, _vRate] = this.getPhonemeDataAtSample(this.currentSamplePtr);
           ratio = pRatio;
           phonemeVolume = pVol;
           phonemePitchBendCents = pBend;
@@ -559,7 +569,7 @@ class RubberBandProcessor extends AudioWorkletProcessor {
 
         // Apply phoneme volume
         if (this.isPlaying && this.fullSampleBuffer && this.phonemeData && this.phonemeRatios) {
-            const [_, pVol, _pBend] = this.getPhonemeDataAtSample(this.currentSamplePtr);
+            const [_, pVol, _pBend, _vDepth, _vRate] = this.getPhonemeDataAtSample(this.currentSamplePtr);
             if (pVol !== 1.0) {
                 for (let i = 0; i < outputChannel.length; i++) {
                     outputChannel[i] *= pVol;

--- a/src/engines/rubberband/PhonemeAligner.ts
+++ b/src/engines/rubberband/PhonemeAligner.ts
@@ -482,8 +482,8 @@ export class PhonemeAligner {
      * @returns SharedArrayBuffer with phoneme data
      */
     createSharedPhonemeBuffer(phonemes: PhonemeSegment[], sampleRate: number, userPhonemes?: PhonemeData[]): SharedArrayBuffer {
-        // 1 int for count + 6 floats per phoneme (start, end, isVowel, stretchRatio, volume, pitchBend)
-        const bufferSize = (1 + phonemes.length * 6) * 4; // 4 bytes per float32
+        // 1 int for count + 8 floats per phoneme (start, end, isVowel, stretchRatio, volume, pitchBend, vibDepth, vibRate)
+        const bufferSize = (1 + phonemes.length * 8) * 4; // 4 bytes per float32
         const sharedBuffer = new SharedArrayBuffer(bufferSize);
         const view = new Float32Array(sharedBuffer);
         
@@ -491,7 +491,7 @@ export class PhonemeAligner {
         
         for (let i = 0; i < phonemes.length; i++) {
             const p = phonemes[i];
-            const baseIndex = 1 + i * 6;
+            const baseIndex = 1 + i * 8;
             view[baseIndex] = p.start * sampleRate;     // Start sample
             view[baseIndex + 1] = p.end * sampleRate;   // End sample
             view[baseIndex + 2] = p.isVowel ? 1.0 : 0.0; // Boolean as float
@@ -500,6 +500,9 @@ export class PhonemeAligner {
             // Map user phoneme data if available
             let volume = 1.0;
             let pitchBend = 0.0;
+            let vibDepth = -1.0; // -1 means use global
+            let vibRate = -1.0;  // -1 means use global
+
             if (userPhonemes && userPhonemes.length > i) {
                 // If userPhonemes are provided, we map them by index.
                 // Alternatively, we could map them by normalized time,
@@ -507,9 +510,13 @@ export class PhonemeAligner {
                 const userP = userPhonemes[i];
                 if (userP.volume !== undefined) volume = userP.volume;
                 if (userP.pitchBend !== undefined) pitchBend = userP.pitchBend;
+                if (userP.vibratoDepth !== undefined) vibDepth = userP.vibratoDepth;
+                if (userP.vibratoRate !== undefined) vibRate = userP.vibratoRate;
             }
             view[baseIndex + 4] = volume;
             view[baseIndex + 5] = pitchBend;
+            view[baseIndex + 6] = vibDepth;
+            view[baseIndex + 7] = vibRate;
         }
         
         return sharedBuffer;

--- a/src/types.ts
+++ b/src/types.ts
@@ -416,6 +416,8 @@ export interface PhonemeData {
   start: number;
   end: number;
   pitchBend: number;
+  vibratoDepth?: number;
+  vibratoRate?: number;
   volume?: number;
 }
 

--- a/tests/knob-drag-modifiers.spec.ts
+++ b/tests/knob-drag-modifiers.spec.ts
@@ -9,6 +9,7 @@ test.describe('knob drag modifiers', () => {
         await expect(cutoff).toBeVisible({ timeout: 30_000 });
 
         const start = await readSliderValue(cutoff);
+        console.log("start:", start);
 
         await verticalDragKnob(page, cutoff, 50);
         const afterNormal = await readSliderValue(cutoff);


### PR DESCRIPTION
Implemented per-phoneme pitch drift/vibrato (depth and rate) in the SingingVoice TTS engine by packing the parameters into the shared array buffer and applying them at the sample level within the RubberBand AudioWorklet.

---
*PR created automatically by Jules for task [12969654309410643379](https://jules.google.com/task/12969654309410643379) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-phoneme vibrato controls, allowing individual phonemes to specify vibrato depth and rate.
  * Phoneme playback now applies these vibrato settings dynamically, with support for falling back to global settings.

* **Documentation**
  * Updated the innovation plan to mark per-phoneme pitch drift and vibrato as implemented.
  * Added planned tasks for formant glide and granular per-phoneme jitter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->