### PR TITLE
feat(303): Phase-3 WGSL gpu-highfid authenticity tier (#976)

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -64,6 +64,7 @@ Only these markdown files may live at the repository root. `pnpm run check:root`
 | [OPENMP_IMPLEMENTATION.md](docs/audio-engine/OPENMP_IMPLEMENTATION.md) | OpenMP threading for Emscripten |
 | [OFFLINE_303_OVERSAMPLE.md](docs/audio-engine/OFFLINE_303_OVERSAMPLE.md) | Phase-1 offline 303 oversampling + worker pool |
 | [HIGHFID_CPU_303.md](docs/audio-engine/HIGHFID_CPU_303.md) | Phase-2 diode-ladder highfid-cpu offline reference |
+| [GPU_HIGHFID_303.md](docs/audio-engine/GPU_HIGHFID_303.md) | Phase-3 WGSL gpu-highfid offline authenticity tier |
 | [OPENMP_RUBBERBAND_PATCHES.md](docs/audio-engine/OPENMP_RUBBERBAND_PATCHES.md) | Rubberband OpenMP patches |
 | [RBS_IMPORT_PIPELINE.md](docs/audio-engine/RBS_IMPORT_PIPELINE.md) | RBS import pipeline documentation |
 | [RUBBERBAND_ANALYSIS.md](docs/audio-engine/RUBBERBAND_ANALYSIS.md) | Rubberband library integration analysis |

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,8 @@ For a quick-start overview see the root [README.md](../README.md).
 | [303-authenticity-gaps.md](audio-engine/303-authenticity-gaps.md) | Phase-0 TB-303 authenticity gap audit, thresholds, and baseline links (epic #972) |
 | [303-baseline/](audio-engine/303-baseline/) | Canonical-pattern engine baseline WAVs + hardware capture protocol |
 | [303-baseline-spectra/](audio-engine/303-baseline-spectra/) | Spectrogram PNGs and RMS/band metrics for Phase-0 baselines |
+| [HIGHFID_CPU_303.md](audio-engine/HIGHFID_CPU_303.md) | Phase-2 diode-ladder highfid-cpu offline reference |
+| [GPU_HIGHFID_303.md](audio-engine/GPU_HIGHFID_303.md) | Phase-3 WGSL gpu-highfid offline authenticity tier |
 | [jc303-prophecy.md](audio-engine/jc303-prophecy.md) | Current per-voice Open303/JC303 switching and Prophecy integration notes |
 | [PLAYBACK_STABILITY.md](audio-engine/PLAYBACK_STABILITY.md) | Jitter thresholds, scheduler guards, and stress-test guidance for song-mode playback |
 | [MULTISAMPLE_GENERATOR_DESIGN.md](audio-engine/MULTISAMPLE_GENERATOR_DESIGN.md) | Design notes for the multisample generator |

--- a/docs/audio-engine/303-authenticity-gaps.md
+++ b/docs/audio-engine/303-authenticity-gaps.md
@@ -240,6 +240,7 @@ Listening / spectrogram review of committed baselines:
 | `docs/audio-engine/303-baseline/` | Committed engine WAVs + acquisition protocol |
 | `docs/audio-engine/303-baseline-spectra/` | Committed PNG spectra + metrics |
 | `docs/audio-engine/HIGHFID_CPU_303.md` | Phase-2 diode-ladder reference docs |
+| `docs/audio-engine/GPU_HIGHFID_303.md` | Phase-3 WGSL gpu-highfid docs |
 
 `assets/` is gitignored (TTS models); baselines live under `docs/audio-engine/`
 per the Phase-0 “or preferred” path.
@@ -249,8 +250,8 @@ per the Phase-0 “or preferred” path.
 ## Next phases (blocked on this audit)
 
 1. **#974 Phase-1** — OpenMP oversampling + offline worker pool (closes G5 infrastructure). **Done.**
-2. **#975 Phase-2** — Diode-ladder CPU reference (closes G1–G3 core). **In progress / see HIGHFID_CPU_303.md.**
-3. **#976 Phase-3** — WGSL full voice (GPU path for G1–G4).
+2. **#975 Phase-2** — Diode-ladder CPU reference (closes G1–G3 core). **Done** — see HIGHFID_CPU_303.md.
+3. **#976 Phase-3** — WGSL full voice (GPU path for G1–G4). **See GPU_HIGHFID_303.md.**
 4. **#977–#979** — Registry/UI, automated regression against these thresholds, docs/rollout.
 
 When the hardware WAV arrives, re-run spectrograms with that `--reference`, fill

--- a/docs/audio-engine/303-voices.md
+++ b/docs/audio-engine/303-voices.md
@@ -279,11 +279,15 @@ normalization all read the registry.
 
 ### Offline-only high-fidelity voices (Phase-2+)
 
-`highfid-cpu` is a special case: `family: 'highfid'`, `offlineOnly: true`.
-It ships its own C++ module (`emscripten/highfid303_wrapper.cpp`) rather than
-an open303 coefficient row. Keep it out of the real-time selector
-(`getAvailableTB303Models()` excludes `offlineOnly` by default). See
-[`HIGHFID_CPU_303.md`](./HIGHFID_CPU_303.md).
+`highfid-cpu` and `gpu-highfid` are special cases: `family: 'highfid'`,
+`offlineOnly: true`.
+
+- `highfid-cpu` — C++ / TS diode-ladder oracle ([HIGHFID_CPU_303.md](./HIGHFID_CPU_303.md)).
+- `gpu-highfid` — WGSL WebGPU path with automatic highfid-cpu fallback
+  ([GPU_HIGHFID_303.md](./GPU_HIGHFID_303.md)).
+
+Keep both out of the real-time selector (`getAvailableTB303Models()` excludes
+`offlineOnly` by default). See Phase-4 for freeze/export UI selection.
 
 ## Out of scope for v1
 

--- a/docs/audio-engine/GPU_HIGHFID_303.md
+++ b/docs/audio-engine/GPU_HIGHFID_303.md
@@ -1,0 +1,131 @@
+# GPU High-Fidelity 303 Voice (Phase-3 / #976)
+
+## Goal
+
+Provide an **offline WGSL authenticity tier** (`gpu-highfid`) that evaluates the
+same diode-ladder nonlinear model as [`highfid-cpu`](./HIGHFID_CPU_303.md) on
+the GPU for multisamples, freeze-bounces, and WAV export — without blocking the
+AudioWorklet.
+
+Real-time AudioWorklet latency is **unchanged** — this path is offline-only.
+
+## Topology
+
+Matches Phase-2 `highfid-cpu` so spectrograms can A/B within Phase-0/2 gates:
+
+| Piece | Implementation |
+|-------|----------------|
+| Filter | mystran / kunn TB_303 diode-ladder + feedback HP @ 150 Hz |
+| Nonlinearity | Cubic soft clip `x − x³/6` on the feedback loop |
+| Oscillator | PolyBLEP saw / soft-driven square |
+| Accent | Coupled envelope (~3 ms attack then decay) |
+| Oversample | `1 \| 2 \| 4` (optional internal factor in uniforms) |
+
+Sources:
+
+- `src/webgpu/shaders/303Voice.wgsl.ts` — WGSL compute kernel (`render303`)
+- `src/engines/WebGpu303Engine.ts` — host wrapper, pooling, read-back, fallback
+- `src/audio/offline/OfflineHighFid303Engine.ts` — CPU oracle / fallback
+
+## Why sequential compute?
+
+The diode-ladder is recursive (each sample depends on prior filter state). The
+kernel therefore uses `@compute @workgroup_size(1)` and walks the buffer in
+one invocation. Parallelism is across **independent notes / multisample slots**,
+not inside the IIR.
+
+## API
+
+```ts
+import { WebGpu303Engine, renderGpuHighFid303, float32ToAudioBuffer } from '@/engines/WebGpu303Engine';
+
+const eng = new WebGpu303Engine();
+await eng.init(); // false → no WebGPU; render still works via highfid-cpu
+
+const samples = await eng.render303(
+  { cutoff: 0.35, resonance: 0.7, envMod: 0.55, decay: 0.5, accent: 0.7, volume: 0.8 },
+  44100, // 1 s @ 44.1 kHz
+  { oversample: 4, midiNote: 36 },
+);
+
+// Or full pattern:
+const meta = await renderGpuHighFid303(pattern, { oversample: 4 });
+const audioBuf = float32ToAudioBuffer(audioContext, meta.buffer);
+```
+
+Offline renderer entry:
+
+```ts
+await render303Offline('gpu-highfid', pattern, { oversample: 4 });
+```
+
+MultisampleGenerator:
+
+```ts
+await multisampleGenerator.generate303HighFidMultisamples({
+  durationSec: 1,
+  midiNotes: [36, 38, 40, 41, 43],
+  params: { cutoff: 0.35, resonance: 0.7 },
+  render: { oversample: 4 },
+});
+```
+
+## Model registry
+
+| Field | Value |
+|-------|-------|
+| `id` | `gpu-highfid` |
+| `family` | `highfid` |
+| `available` | `true` |
+| `offlineOnly` | `true` |
+
+`getAvailableTB303Models()` hides it from the real-time selector.
+`normalizeTB303Model('gpu-highfid')` → `stock-open303` so song load never
+routes it onto AudioWorklet.
+
+## Fallback chain
+
+```
+GPU high-fid (this module)  →  highfid-cpu  →  stock Open303 / JC-303  →  JS
+```
+
+Surfaced via `meta.fallbackReason` / telemetry `gpuFallbackReason` when WebGPU
+is missing, shader compile fails, allocation fails, or read-back errors.
+No crash on browsers without WebGPU.
+
+## Telemetry
+
+| Field | Meaning |
+|-------|---------|
+| `gpuRenderLatencyMs` | Wall time of last GPU/fallback render |
+| `gpuReadbackBytes` | Bytes copied from GPU (0 on CPU fallback) |
+| `gpuFallbackReason` | Human-readable fallback cause (null if GPU used) |
+| `gpuUsedGpu` | Whether WGSL path ran |
+
+Target latency: **≤ 150–300 ms** for multi-second patterns depending on length
+and hardware (CPU fallback in headless CI is slower and still acceptable).
+
+## Host harness
+
+```bash
+# Writes 1 s mono WAV via CPU-equivalent path (WebGPU optional in browser)
+pnpm exec vite-node scripts/render_gpu_highfid_wav.mjs
+# → /tmp/gpu-highfid_1s.wav
+```
+
+## Tests
+
+```bash
+CI=true pnpm exec vitest run --pool forks src/__tests__/WebGpu303Engine.test.ts
+```
+
+Covers: registry offline-only, WGSL source shape, deterministic CPU fallback,
+OfflineRenderer wiring, telemetry fields.
+
+## Related
+
+- [HIGHFID_CPU_303.md](./HIGHFID_CPU_303.md) (Phase-2)
+- [303-authenticity-gaps.md](./303-authenticity-gaps.md) (Phase-0 thresholds)
+- [OFFLINE_303_OVERSAMPLE.md](./OFFLINE_303_OVERSAMPLE.md) (Phase-1)
+- [303-voices.md](./303-voices.md)
+- Epic #972 / Phase-3 #976

--- a/docs/audio-engine/HIGHFID_CPU_303.md
+++ b/docs/audio-engine/HIGHFID_CPU_303.md
@@ -100,9 +100,12 @@ Numbers live in `303-baseline-spectra/baseline_metrics.json`.
 GPU high-fid  →  highfid-cpu (this module)  →  stock Open303 / JC-303  →  JS
 ```
 
+Phase-3 WGSL path: [`GPU_HIGHFID_303.md`](./GPU_HIGHFID_303.md).
+
 ## Related
 
 - [303-authenticity-gaps.md](./303-authenticity-gaps.md) (Phase-0)
 - [OFFLINE_303_OVERSAMPLE.md](./OFFLINE_303_OVERSAMPLE.md) (Phase-1)
+- [GPU_HIGHFID_303.md](./GPU_HIGHFID_303.md) (Phase-3)
 - [303-voices.md](./303-voices.md)
-- Epic #972 / Phase-2 #975
+- Epic #972 / Phase-2 #975 / Phase-3 #976

--- a/scripts/render_gpu_highfid_wav.mjs
+++ b/scripts/render_gpu_highfid_wav.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Host-side harness (Phase-3 / #976): render ~1 s of the gpu-highfid topology
+ * (CPU oracle — same DSP as WGSL; Node has no WebGPU) and write a mono WAV.
+ *
+ * Usage:
+ *   pnpm exec vite-node scripts/render_gpu_highfid_wav.mjs
+ *   pnpm exec vite-node scripts/render_gpu_highfid_wav.mjs --out /tmp/gpu-highfid_1s.wav
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { renderOfflineHighFid303Pattern } from '../src/audio/offline/OfflineHighFid303Engine.ts';
+
+function parseArgs(argv) {
+  const out = { outPath: '/tmp/gpu-highfid_1s.wav' };
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === '--out' && argv[i + 1]) {
+      out.outPath = resolve(argv[++i]);
+    }
+  }
+  return out;
+}
+
+function floatTo16BitWav(samples, sampleRate) {
+  const numSamples = samples.length;
+  const dataSize = numSamples * 2;
+  const buffer = Buffer.alloc(44 + dataSize);
+  buffer.write('RIFF', 0);
+  buffer.writeUInt32LE(36 + dataSize, 4);
+  buffer.write('WAVE', 8);
+  buffer.write('fmt ', 12);
+  buffer.writeUInt32LE(16, 16);
+  buffer.writeUInt16LE(1, 20);
+  buffer.writeUInt16LE(1, 22);
+  buffer.writeUInt32LE(sampleRate, 24);
+  buffer.writeUInt32LE(sampleRate * 2, 28);
+  buffer.writeUInt16LE(2, 32);
+  buffer.writeUInt16LE(16, 34);
+  buffer.write('data', 36);
+  buffer.writeUInt32LE(dataSize, 40);
+  let peak = 0;
+  for (let i = 0; i < numSamples; i++) {
+    const s = Math.max(-1, Math.min(1, samples[i]));
+    const a = Math.abs(s);
+    if (a > peak) peak = a;
+    buffer.writeInt16LE((s * 32767) | 0, 44 + i * 2);
+  }
+  return { buffer, peak };
+}
+
+const args = parseArgs(process.argv);
+const sampleRate = 44100;
+const pattern = {
+  steps: [
+    { note: 36, velocity: 90 },
+    { note: 36, accent: true, slide: true, velocity: 120 },
+    { note: 39, velocity: 90 },
+    { note: 43, accent: true, slide: true, velocity: 120 },
+    { note: 36, velocity: 90 },
+    { note: 41, accent: true, slide: true, velocity: 120 },
+    { note: 39, velocity: 90 },
+    { note: 36, accent: true, slide: true, velocity: 120 },
+  ],
+  stepDurationSec: 0.125,
+  params: {
+    cutoff: 0.35,
+    resonance: 0.7,
+    envMod: 0.55,
+    decay: 0.5,
+    accent: 0.7,
+    volume: 0.8,
+    waveform: 0,
+  },
+};
+
+const t0 = performance.now();
+const samples = renderOfflineHighFid303Pattern(pattern, {
+  oversample: 4,
+  sampleRate,
+});
+const latencyMs = performance.now() - t0;
+const { buffer, peak } = floatTo16BitWav(samples, sampleRate);
+
+mkdirSync(dirname(args.outPath), { recursive: true });
+writeFileSync(args.outPath, buffer);
+
+console.log(
+  JSON.stringify(
+    {
+      engine: 'gpu-highfid topology via highfid-cpu oracle (Node harness)',
+      outPath: args.outPath,
+      frames: samples.length,
+      sampleRate,
+      oversample: 4,
+      latencyMs: Math.round(latencyMs * 100) / 100,
+      peak,
+      note: 'Browser WebGpu303Engine uses WGSL when navigator.gpu is present',
+    },
+    null,
+    2,
+  ),
+);

--- a/src/__tests__/WebGpu303Engine.test.ts
+++ b/src/__tests__/WebGpu303Engine.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Phase-3 (#976) gpu-highfid WebGPU 303 voice engine tests.
+ *
+ * happy-dom has no WebGPU — verifies graceful fallback to highfid-cpu,
+ * registry offline-only entry, deterministic output, and telemetry hooks.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  GPU_HIGHFID_MODEL_ID,
+  WebGpu303Engine,
+  isGpuHighFidModel,
+  renderGpuHighFid303,
+  resetSharedWebGpu303Engine,
+  float32ToAudioBuffer,
+} from '@/engines/WebGpu303Engine';
+import { VOICE_303_WGSL } from '@/webgpu/shaders/303Voice.wgsl';
+import { bufferHasNonFinite } from '@/audio/offline/OfflineOpen303Engine';
+import { renderOfflineHighFid303Pattern } from '@/audio/offline/OfflineHighFid303Engine';
+import {
+  makeCanonical64StepPattern,
+  render303OfflineWithMeta,
+  terminateOffline303Pool,
+} from '@/audio/OfflineRenderer';
+import {
+  getAvailableTB303Models,
+  getTB303Model,
+  normalizeTB303Model,
+  tb303ModelFamily,
+} from '@/engines/TB303Models';
+import { EngineTelemetry } from '@/utils/engineTelemetry';
+
+describe('gpu-highfid registry', () => {
+  it('is catalogued as offline-only highfid family', () => {
+    const m = getTB303Model('gpu-highfid');
+    expect(m).toMatchObject({
+      id: 'gpu-highfid',
+      family: 'highfid',
+      available: true,
+      offlineOnly: true,
+    });
+    expect(tb303ModelFamily('gpu-highfid')).toBe('highfid');
+  });
+
+  it('is hidden from realtime selector by default', () => {
+    expect(getAvailableTB303Models().some((m) => m.id === 'gpu-highfid')).toBe(
+      false,
+    );
+    expect(
+      getAvailableTB303Models({ includeOfflineOnly: true }).some(
+        (m) => m.id === 'gpu-highfid',
+      ),
+    ).toBe(true);
+  });
+
+  it('normalizeTB303Model falls back to stock for offline-only voices', () => {
+    expect(normalizeTB303Model('gpu-highfid')).toBe('stock-open303');
+  });
+});
+
+describe('WGSL 303 shader source', () => {
+  it('exports a non-empty WGSL module with expected entry points', () => {
+    expect(VOICE_303_WGSL.length).toBeGreaterThan(500);
+    expect(VOICE_303_WGSL).toContain('fn render303');
+    expect(VOICE_303_WGSL).toContain('diodeShape');
+    expect(VOICE_303_WGSL).toContain('polyBlep');
+    expect(VOICE_303_WGSL).toContain('@compute');
+    expect(VOICE_303_WGSL).toContain('workgroup_size(1)');
+  });
+});
+
+describe('WebGpu303Engine fallback', () => {
+  afterEach(() => {
+    resetSharedWebGpu303Engine();
+  });
+
+  it('identifies gpu model ids', () => {
+    expect(isGpuHighFidModel(GPU_HIGHFID_MODEL_ID)).toBe(true);
+    expect(isGpuHighFidModel('gpu-highfid')).toBe(true);
+    expect(isGpuHighFidModel('highfid-cpu')).toBe(false);
+  });
+
+  it('falls back to highfid-cpu without crashing when WebGPU is missing', async () => {
+    const eng = new WebGpu303Engine();
+    const ok = await eng.init();
+    // happy-dom: no navigator.gpu
+    expect(ok).toBe(false);
+    expect(eng.isSupported).toBe(false);
+
+    const pattern = {
+      steps: [
+        { note: 36, velocity: 90 },
+        { note: 36, accent: true, slide: true, velocity: 120 },
+        { note: 39, velocity: 90 },
+        { note: 43, accent: true, slide: true, velocity: 120 },
+      ],
+      stepDurationSec: 0.15,
+      params: {
+        cutoff: 0.35,
+        resonance: 0.7,
+        envMod: 0.55,
+        decay: 0.5,
+        accent: 0.7,
+        volume: 0.8,
+      },
+    };
+
+    const meta = await eng.renderPatternWithMeta(pattern, { oversample: 1 });
+    expect(meta.usedGpu).toBe(false);
+    expect(meta.fallbackReason).toBeTruthy();
+    expect(bufferHasNonFinite(meta.buffer)).toBe(false);
+    expect(meta.buffer.length).toBeGreaterThan(100);
+
+    const cpu = renderOfflineHighFid303Pattern(pattern, { oversample: 1 });
+    expect(meta.buffer.length).toBe(cpu.length);
+    for (let i = 0; i < cpu.length; i++) {
+      expect(meta.buffer[i]).toBe(cpu[i]);
+    }
+    eng.destroy();
+  });
+
+  it('forceCpuFallback yields deterministic bit-identical output', async () => {
+    const pattern = {
+      steps: [
+        { note: 36, velocity: 90 },
+        { note: 43, accent: true, velocity: 120 },
+      ],
+      stepDurationSec: 0.1,
+      params: { cutoff: 0.4, resonance: 0.65, volume: 0.8 },
+    };
+    const a = await renderGpuHighFid303(pattern, {
+      oversample: 2,
+      forceCpuFallback: true,
+    });
+    const b = await renderGpuHighFid303(pattern, {
+      oversample: 2,
+      forceCpuFallback: true,
+    });
+    expect(a.usedGpu).toBe(false);
+    expect(a.buffer.length).toBe(b.buffer.length);
+    for (let i = 0; i < a.buffer.length; i++) {
+      expect(a.buffer[i]).toBe(b.buffer[i]);
+    }
+  });
+
+  it('render303 sustained note API works via fallback', async () => {
+    const eng = new WebGpu303Engine();
+    const buf = await eng.render303(
+      { cutoff: 0.3, resonance: 0.5, volume: 0.7 },
+      4410,
+      { forceCpuFallback: true, midiNote: 40, velocity: 100 },
+    );
+    expect(buf.length).toBe(4410);
+    expect(bufferHasNonFinite(buf)).toBe(false);
+    eng.destroy();
+  });
+
+  it('float32ToAudioBuffer builds a playable AudioBuffer', () => {
+    const samples = new Float32Array(128);
+    samples[0] = 0.5;
+    const channel = new Float32Array(128);
+    const ctx = {
+      sampleRate: 44100,
+      createBuffer: (_ch: number, length: number, _sr: number) => ({
+        length,
+        numberOfChannels: 1,
+        sampleRate: 44100,
+        copyToChannel: (src: Float32Array, _c: number) => {
+          channel.set(src);
+        },
+        getChannelData: () => channel,
+      }),
+    } as unknown as BaseAudioContext;
+    const audioBuf = float32ToAudioBuffer(ctx, samples, 44100);
+    expect(audioBuf.length).toBe(128);
+    expect(audioBuf.numberOfChannels).toBe(1);
+    expect(audioBuf.getChannelData(0)[0]).toBeCloseTo(0.5);
+  });
+});
+
+describe('render303Offline gpu-highfid path', () => {
+  beforeEach(() => {
+    terminateOffline303Pool();
+    resetSharedWebGpu303Engine();
+  });
+
+  afterEach(() => {
+    terminateOffline303Pool();
+    resetSharedWebGpu303Engine();
+  });
+
+  it('renders via OfflineRenderer (CPU fallback in test env)', async () => {
+    const pattern = makeCanonical64StepPattern(130);
+    const meta = await render303OfflineWithMeta('gpu-highfid', pattern, {
+      oversample: 2,
+      sync: true,
+    });
+    expect(meta.oversample).toBe(2);
+    expect(meta.buffer.length).toBeGreaterThan(10_000);
+    expect(bufferHasNonFinite(meta.buffer)).toBe(false);
+    expect(meta.latencyMs).toBeLessThan(8_000);
+  });
+
+  it('async path also falls back gracefully', async () => {
+    const pattern = {
+      steps: [
+        { note: 36, velocity: 90 },
+        { note: 39, accent: true, slide: true, velocity: 120 },
+      ],
+      stepDurationSec: 0.12,
+      params: { cutoff: 0.35, resonance: 0.7, volume: 0.8 },
+    };
+    const meta = await render303OfflineWithMeta('gpu-highfid', pattern, {
+      oversample: 1,
+    });
+    expect(bufferHasNonFinite(meta.buffer)).toBe(false);
+    expect(meta.buffer.length).toBeGreaterThan(100);
+  });
+});
+
+describe('gpu-highfid telemetry', () => {
+  it('recordGpu303Render populates runtime snapshot fields', () => {
+    const t = new EngineTelemetry();
+    t.recordGpu303Render({
+      latencyMs: 42.5,
+      readbackBytes: 176400,
+      fallbackReason: 'navigator.gpu unavailable',
+      usedGpu: false,
+    });
+    const snap = t.getRuntimeSnapshot();
+    expect(snap.gpuRenderLatencyMs).toBe(42.5);
+    expect(snap.gpuReadbackBytes).toBe(176400);
+    expect(snap.gpuFallbackReason).toBe('navigator.gpu unavailable');
+    expect(snap.gpuUsedGpu).toBe(false);
+  });
+});

--- a/src/audio/OfflineRenderer.ts
+++ b/src/audio/OfflineRenderer.ts
@@ -1,15 +1,16 @@
 /**
- * Thin API + worker pool for offline 303 rendering (Phase-1 / #974).
+ * Thin API + worker pool for offline 303 rendering
+ * (Phase-1 / #974 + Phase-2 / #975 + Phase-3 / #976).
  *
  * ```ts
- * const buf = await render303Offline('stock-open303', pattern, {
+ * const buf = await render303Offline('gpu-highfid', pattern, {
  *   oversample: 4,
- *   threadCount: 4,
  * });
  * ```
  *
  * Real-time AudioWorklet path is never used. Telemetry records
- * offlineRenderThreadCount / offlineRenderOversample / offlineRenderLatencyMs.
+ * offlineRenderThreadCount / offlineRenderOversample / offlineRenderLatencyMs
+ * and (for gpu-highfid) gpuRenderLatencyMs / gpuReadbackBytes / gpuFallbackReason.
  */
 
 import { engineTelemetry } from '@/utils/engineTelemetry';
@@ -25,10 +26,15 @@ import {
   isHighFidCpuModel,
   renderOfflineHighFid303Pattern,
 } from '@/audio/offline/OfflineHighFid303Engine';
+import {
+  isGpuHighFidModel,
+  renderGpuHighFid303,
+} from '@/engines/WebGpu303Engine';
 
 export type { Offline303PatternData, OversampleFactor };
 export type { Offline303Params, Offline303Step } from '@/audio/offline/OfflineOpen303Engine';
 export { HIGHFID_CPU_MODEL_ID } from '@/audio/offline/OfflineHighFid303Engine';
+export { GPU_HIGHFID_MODEL_ID } from '@/engines/WebGpu303Engine';
 
 export interface Offline303VoiceJob {
   modelId: string;
@@ -198,17 +204,19 @@ function syncRender(
     typeof performance !== 'undefined' ? performance.now() : Date.now();
   const oversample = clampOversample(options.oversample);
   const threadCount = Math.max(1, options.threadCount ?? 1);
-  const buffer = isHighFidCpuModel(modelId)
-    ? renderOfflineHighFid303Pattern(pattern, {
-        oversample,
-        sampleRate: options.sampleRate,
-        blockSize: options.blockSize,
-      })
-    : renderOffline303Pattern(modelId, pattern, {
-        oversample,
-        sampleRate: options.sampleRate,
-        blockSize: options.blockSize,
-      });
+  // gpu-highfid sync path uses highfid-cpu (WebGPU is async-only here).
+  const buffer =
+    isHighFidCpuModel(modelId) || isGpuHighFidModel(modelId)
+      ? renderOfflineHighFid303Pattern(pattern, {
+          oversample,
+          sampleRate: options.sampleRate,
+          blockSize: options.blockSize,
+        })
+      : renderOffline303Pattern(modelId, pattern, {
+          oversample,
+          sampleRate: options.sampleRate,
+          blockSize: options.blockSize,
+        });
   if (bufferHasNonFinite(buffer)) {
     throw new Error('Non-finite samples in sync offline 303 render');
   }
@@ -236,6 +244,24 @@ export async function render303OfflineWithMeta(
   pattern: Offline303PatternData,
   options: Render303OfflineOptions = {},
 ): Promise<Offline303RenderMeta> {
+  // GPU path prefers main-thread WebGPU (workers may lack navigator.gpu).
+  // Falls back to highfid-cpu inside WebGpu303Engine when unavailable.
+  if (isGpuHighFidModel(modelId) && !options.sync) {
+    const oversample = clampOversample(options.oversample);
+    const meta = await renderGpuHighFid303(pattern, {
+      oversample,
+      sampleRate: options.sampleRate,
+    });
+    const out: Offline303RenderMeta = {
+      buffer: meta.buffer,
+      latencyMs: meta.latencyMs,
+      threadCount: meta.usedGpu ? 1 : Math.max(1, options.threadCount ?? 1),
+      oversample: meta.oversample,
+    };
+    recordTelemetry(out);
+    return out;
+  }
+
   if (options.sync || typeof Worker === 'undefined') {
     const meta = syncRender(modelId, pattern, options);
     recordTelemetry(meta);
@@ -291,7 +317,7 @@ export async function render303OfflineMultiWithMeta(
     const oversample = clampOversample(options.oversample);
     const threadCount = Math.max(1, options.threadCount ?? voices.length);
     const rendered = voices.map((v) =>
-      isHighFidCpuModel(v.modelId)
+      isHighFidCpuModel(v.modelId) || isGpuHighFidModel(v.modelId)
         ? renderOfflineHighFid303Pattern(v.pattern, {
             oversample,
             sampleRate: options.sampleRate,

--- a/src/components/EngineHUD.tsx
+++ b/src/components/EngineHUD.tsx
@@ -71,10 +71,23 @@ if (typeof window !== 'undefined' && !document.getElementById(CONTAINER_ID)) {
     const offlineOs = runtime.offlineRenderOversample != null ? `${runtime.offlineRenderOversample}×` : '—';
     const offlineThreads = runtime.offlineRenderThreadCount != null ? String(runtime.offlineRenderThreadCount) : '—';
     const offlineLat = runtime.offlineRenderLatencyMs != null ? `${runtime.offlineRenderLatencyMs.toFixed(1)} ms` : '—';
+    const gpuLat = runtime.gpuRenderLatencyMs != null ? `${runtime.gpuRenderLatencyMs.toFixed(1)} ms` : '—';
+    const gpuBackend =
+      runtime.gpuUsedGpu === true
+        ? 'webgpu'
+        : runtime.gpuUsedGpu === false
+          ? 'cpu-fb'
+          : '—';
+    const gpuFb =
+      runtime.gpuFallbackReason != null
+        ? runtime.gpuFallbackReason.slice(0, 42)
+        : '—';
     const offlineSection = `<div class="subheader">Offline 303</div>
       <div class="row"><div style="flex:1">Oversample</div><div style="min-width:72px;text-align:right">${offlineOs}</div></div>
       <div class="row"><div style="flex:1">Threads</div><div style="min-width:72px;text-align:right">${offlineThreads}</div></div>
-      <div class="row"><div style="flex:1">Last render</div><div style="min-width:72px;text-align:right">${offlineLat}</div></div>`;
+      <div class="row"><div style="flex:1">Last render</div><div style="min-width:72px;text-align:right">${offlineLat}</div></div>
+      <div class="row"><div style="flex:1">GPU 303</div><div style="min-width:72px;text-align:right">${gpuBackend} ${gpuLat}</div></div>
+      <div class="row" title="${runtime.gpuFallbackReason ?? ''}"><div style="flex:1">GPU fallback</div><div style="min-width:72px;text-align:right;font-size:10px">${gpuFb}</div></div>`;
 
     const workletNames = ['clock', 'open303', 'rubberband', 'vocoder'];
     const workletRows = workletNames.map((name) => {

--- a/src/engines/MultisampleGenerator.ts
+++ b/src/engines/MultisampleGenerator.ts
@@ -5,9 +5,19 @@
  * RubberBand time-stretching in an OfflineAudioContext.
  * 
  * This allows zero-CPU playback of pitch-accurate samples in the sequencer.
+ *
+ * Phase-3 (#976): also generates high-fidelity 303 multisamples via
+ * WebGpu303Engine (GPU diode-ladder with highfid-cpu fallback).
  */
 
 import { SingingVoice } from './SingingVoice';
+import {
+  float32ToAudioBuffer,
+  renderGpuHighFid303,
+  type WebGpu303RenderOptions,
+} from './WebGpu303Engine';
+import type { Offline303Params } from '@/audio/offline/OfflineOpen303Engine';
+import { DEFAULT_OFFLINE_303_PARAMS } from '@/audio/offline/OfflineOpen303Engine';
 
 export interface MultisampleBank {
     /** Original sample buffer */
@@ -35,6 +45,19 @@ export interface MultisampleOptions {
     quality?: 'Fast' | 'Standard' | 'Elastic';
     /** Specific pitches to generate (overrides range if provided) */
     onlyPitches?: number[];
+}
+
+export interface Multisample303Options {
+  /** Sustain length in seconds per note (default: 1.0). */
+  durationSec?: number;
+  /** MIDI notes to render (default: C1..C3 chromatic-ish 303 range). */
+  midiNotes?: number[];
+  /** Classic 303 knobs (normalized 0–1 where applicable). */
+  params?: Partial<Offline303Params>;
+  /** Oversample / sample-rate / forceCpuFallback forwarded to WebGpu303Engine. */
+  render?: WebGpu303RenderOptions;
+  /** Velocity for all notes (default 90; use >100 for accent). */
+  velocity?: number;
 }
 
 export type ProgressCallback = (progress: number) => void;
@@ -68,8 +91,10 @@ async function resampleWithPlaybackRate(
 export class MultisampleGenerator {
     private rubberbandWasm: ArrayBuffer | null = null;
     private isWasmLoaded: boolean = false;
+    private audioContext: BaseAudioContext;
 
-    constructor(_audioContext: BaseAudioContext) {
+    constructor(audioContext: BaseAudioContext) {
+        this.audioContext = audioContext;
         void this.loadWasm();
     }
 
@@ -219,6 +244,50 @@ export class MultisampleGenerator {
         voice.disconnectOutput();
 
         return renderedBuffer;
+    }
+
+    /**
+     * Generate high-fidelity 303 note buffers (Phase-3 / #976).
+     *
+     * Uses WebGpu303Engine when available; falls back to highfid-cpu.
+     * Returned AudioBuffers are ready for AudioBufferSourceNode playback —
+     * never schedule the GPU render on the AudioWorklet thread.
+     */
+    async generate303HighFidMultisamples(
+        options: Multisample303Options = {},
+        onProgress: ProgressCallback = () => {},
+    ): Promise<Map<number, AudioBuffer>> {
+        const durationSec = options.durationSec ?? 1.0;
+        const velocity = options.velocity ?? 90;
+        const params = { ...DEFAULT_OFFLINE_303_PARAMS, ...options.params };
+        const midiNotes =
+            options.midiNotes ??
+            [24, 26, 28, 29, 31, 33, 35, 36, 38, 40, 41, 43, 45, 47, 48];
+        const sampleRate =
+            options.render?.sampleRate ?? this.audioContext.sampleRate ?? 44100;
+        const pitchBank = new Map<number, AudioBuffer>();
+        const total = midiNotes.length;
+
+        for (let i = 0; i < midiNotes.length; i++) {
+            const midi = midiNotes[i];
+            const meta = await renderGpuHighFid303(
+                {
+                    steps: [{ note: midi, velocity }],
+                    stepDurationSec: durationSec,
+                    params,
+                },
+                { ...options.render, sampleRate },
+            );
+            const audioBuf = float32ToAudioBuffer(
+                this.audioContext,
+                meta.buffer,
+                sampleRate,
+            );
+            pitchBank.set(midi, audioBuf);
+            onProgress((i + 1) / total);
+        }
+
+        return pitchBank;
     }
 
     /**

--- a/src/engines/TB303Models.ts
+++ b/src/engines/TB303Models.ts
@@ -35,7 +35,8 @@ export type TB303ModelId =
   | 'raveolution'
   | '1ink303-v1'        // in-house
   | 'experimental-01'  // scratchpad
-  | 'highfid-cpu';     // Phase-2 offline diode-ladder reference
+  | 'highfid-cpu'      // Phase-2 offline diode-ladder reference
+  | 'gpu-highfid';     // Phase-3 WGSL offline authenticity tier
 
 /** Catalog ids plus WASM-discovered voice strings from future builds. */
 export type TB303Model = TB303ModelId | (string & {});
@@ -64,7 +65,8 @@ export interface TB303ModelInfo {
   available: boolean;
   /**
    * When true, the voice is intended for offline / freeze / export only
-   * (Phase-2 highfid-cpu). Excluded from the real-time Voice303Selector.
+   * (Phase-2 highfid-cpu, Phase-3 gpu-highfid). Excluded from the real-time
+   * Voice303Selector.
    */
   offlineOnly?: boolean;
 }
@@ -148,6 +150,16 @@ export const TB303_MODELS: readonly TB303ModelInfo[] = [
     available: true,
     offlineOnly: true,
   },
+  {
+    id: 'gpu-highfid',
+    label: 'High-Fidelity GPU',
+    shortLabel: 'HiFi GPU',
+    description:
+      'Offline WGSL diode-ladder authenticity tier (Phase-3) — same topology as highfid-cpu, WebGPU compute with CPU fallback. Not for real-time AudioWorklet.',
+    family: 'highfid',
+    available: true,
+    offlineOnly: true,
+  },
 ];
 
 const MODEL_BY_ID: ReadonlyMap<string, TB303ModelInfo> = new Map(
@@ -161,9 +173,9 @@ export function getTB303Model(id: string | undefined): TB303ModelInfo | undefine
 
 /**
  * Models selectable in the UI (DSP profile shipped).
- * By default excludes `offlineOnly` voices (highfid-cpu) so the real-time
- * selector stays latency-safe. Pass `{ includeOfflineOnly: true }` for
- * freeze / export / offline renderer UIs (Phase-4).
+ * By default excludes `offlineOnly` voices (highfid-cpu, gpu-highfid) so the
+ * real-time selector stays latency-safe. Pass `{ includeOfflineOnly: true }`
+ * for freeze / export / offline renderer UIs (Phase-4).
  */
 export function getAvailableTB303Models(opts?: {
   includeOfflineOnly?: boolean;

--- a/src/engines/WebGpu303Engine.ts
+++ b/src/engines/WebGpu303Engine.ts
@@ -1,0 +1,606 @@
+/**
+ * WebGPU TB-303 authenticity-tier engine (Phase-3 / #976).
+ *
+ * Offline / freeze / export / multisample only. Never runs on AudioWorklet.
+ *
+ * Fallback chain (epic principle):
+ *   GPU high-fid → highfid-cpu → stock Open303 / JC-303 → JS
+ *
+ * Reuses WebGpuOscillator-style size-bucket buffer pooling and the same
+ * diode-ladder topology as OfflineHighFid303Engine for spectrogram A/B.
+ */
+
+/// <reference types="@webgpu/types" />
+
+import {
+  clampOversample,
+  type Offline303Params,
+  type Offline303PatternData,
+  type OversampleFactor,
+  DEFAULT_OFFLINE_303_PARAMS,
+  bufferHasNonFinite,
+} from '@/audio/offline/OfflineOpen303Engine';
+import { renderOfflineHighFid303Pattern } from '@/audio/offline/OfflineHighFid303Engine';
+import {
+  VOICE_303_WGSL,
+  VOICE_303_UNIFORM_BYTES,
+  NOTE_EVENT_BYTES,
+} from '@/webgpu/shaders/303Voice.wgsl';
+import { engineTelemetry, logEngineFallback } from '@/utils/engineTelemetry';
+
+export const GPU_HIGHFID_MODEL_ID = 'gpu-highfid' as const;
+
+export function isGpuHighFidModel(modelId: string): boolean {
+  return modelId === GPU_HIGHFID_MODEL_ID || modelId === 'gpu-highfid';
+}
+
+export interface WebGpu303RenderOptions {
+  oversample?: OversampleFactor;
+  sampleRate?: number;
+  /** Prefer CPU highfid immediately (tests / forced fallback). */
+  forceCpuFallback?: boolean;
+  /** Abort GPU path if estimated latency budget exceeded (ms). Soft hint only. */
+  maxLatencyMs?: number;
+}
+
+export interface WebGpu303RenderMeta {
+  buffer: Float32Array;
+  latencyMs: number;
+  oversample: OversampleFactor;
+  usedGpu: boolean;
+  fallbackReason: string | null;
+  readbackBytes: number;
+}
+
+export type WebGpu303Params = Offline303Params;
+
+type PooledBuffers = { output: GPUBuffer; read: GPUBuffer };
+
+/**
+ * Host-side WebGPU 303 renderer.
+ *
+ * Async API: `render303(params, lengthSamples, options?)` and pattern helper
+ * `renderPattern(...)`. Both fall back to highfid-cpu when WebGPU is missing
+ * or dispatch/readback fails.
+ */
+export class WebGpu303Engine {
+  device: GPUDevice | null = null;
+  adapter: GPUAdapter | null = null;
+  pipeline: GPUComputePipeline | null = null;
+  bindGroupLayout: GPUBindGroupLayout | null = null;
+  isSupported = false;
+  private initPromise: Promise<boolean> | null = null;
+  private params: WebGpu303Params = { ...DEFAULT_OFFLINE_303_PARAMS };
+
+  private bufferPool: Map<number, PooledBuffers[]> = new Map();
+  private readonly MAX_POOL_SIZE_PER_BUCKET = 4;
+  private readonly SIZE_BUCKET_BYTES = 4096;
+  /** ~30 s @ 48 kHz mono — guard against OOM on huge freeze bounces. */
+  private readonly MAX_BUFFER_SIZE = 48_000 * 30 * 4;
+
+  private lastFallbackReason: string | null = null;
+
+  async init(): Promise<boolean> {
+    if (this.initPromise) return this.initPromise;
+    this.initPromise = this.doInit();
+    return this.initPromise;
+  }
+
+  private async doInit(): Promise<boolean> {
+    if (!navigator.gpu) {
+      this.lastFallbackReason = 'navigator.gpu unavailable';
+      logEngineFallback(
+        'gpu-highfid',
+        'webgpu',
+        'navigator.gpu unavailable (browser lacks WebGPU)',
+      );
+      try {
+        engineTelemetry.recordGpu303Render({
+          latencyMs: 0,
+          readbackBytes: 0,
+          fallbackReason: this.lastFallbackReason,
+          usedGpu: false,
+        });
+      } catch {
+        /* telemetry optional */
+      }
+      return false;
+    }
+
+    try {
+      this.adapter = await navigator.gpu.requestAdapter();
+      if (!this.adapter) {
+        this.lastFallbackReason = 'requestAdapter() returned null';
+        logEngineFallback('gpu-highfid', 'webgpu', this.lastFallbackReason);
+        return false;
+      }
+
+      this.device = await this.adapter.requestDevice();
+      const module = this.device.createShaderModule({ code: VOICE_303_WGSL });
+
+      // Surface compile errors early (Chrome / Edge).
+      if (typeof module.getCompilationInfo === 'function') {
+        const info = await module.getCompilationInfo();
+        const errors = info.messages.filter((m) => m.type === 'error');
+        if (errors.length > 0) {
+          const msg = errors.map((e) => e.message).join('; ');
+          this.lastFallbackReason = `WGSL compile error: ${msg}`;
+          logEngineFallback('gpu-highfid', 'webgpu', this.lastFallbackReason);
+          this.device.destroy?.();
+          this.device = null;
+          return false;
+        }
+      }
+
+      this.bindGroupLayout = this.device.createBindGroupLayout({
+        entries: [
+          {
+            binding: 0,
+            visibility: GPUShaderStage.COMPUTE,
+            buffer: { type: 'uniform' },
+          },
+          {
+            binding: 1,
+            visibility: GPUShaderStage.COMPUTE,
+            buffer: { type: 'read-only-storage' },
+          },
+          {
+            binding: 2,
+            visibility: GPUShaderStage.COMPUTE,
+            buffer: { type: 'storage' },
+          },
+        ],
+      });
+
+      this.pipeline = this.device.createComputePipeline({
+        layout: this.device.createPipelineLayout({
+          bindGroupLayouts: [this.bindGroupLayout],
+        }),
+        compute: { module, entryPoint: 'render303' },
+      });
+
+      this.isSupported = true;
+      this.lastFallbackReason = null;
+      try {
+        engineTelemetry.registerResolution('gpu-highfid', 'webgpu', 'device-ready');
+      } catch {
+        /* optional */
+      }
+      return true;
+    } catch (e) {
+      this.lastFallbackReason =
+        e instanceof Error ? e.message : 'GPUDevice / pipeline creation failed';
+      logEngineFallback('gpu-highfid', 'webgpu', this.lastFallbackReason, e);
+      this.isSupported = false;
+      this.device = null;
+      this.pipeline = null;
+      return false;
+    }
+  }
+
+  setParams(partial: Partial<WebGpu303Params>): void {
+    this.params = { ...this.params, ...partial };
+  }
+
+  getParams(): WebGpu303Params {
+    return { ...this.params };
+  }
+
+  getLastFallbackReason(): string | null {
+    return this.lastFallbackReason;
+  }
+
+  private getSizeBucket(size: number): number {
+    return Math.ceil(size / this.SIZE_BUCKET_BYTES) * this.SIZE_BUCKET_BYTES;
+  }
+
+  private acquireBuffers(size: number): PooledBuffers | null {
+    if (!this.device) return null;
+    const bucket = this.getSizeBucket(size);
+    const pool = this.bufferPool.get(bucket);
+    if (pool && pool.length > 0) return pool.pop()!;
+    try {
+      const output = this.device.createBuffer({
+        size: bucket,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+      });
+      const read = this.device.createBuffer({
+        size: bucket,
+        usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
+      });
+      return { output, read };
+    } catch (e) {
+      logEngineFallback('gpu-highfid', 'webgpu', 'GPUBuffer allocation failed', e);
+      return null;
+    }
+  }
+
+  private releaseBuffers(buffers: PooledBuffers, size: number): void {
+    const bucket = this.getSizeBucket(size);
+    let pool = this.bufferPool.get(bucket);
+    if (!pool) {
+      pool = [];
+      this.bufferPool.set(bucket, pool);
+    }
+    if (pool.length < this.MAX_POOL_SIZE_PER_BUCKET) {
+      pool.push(buffers);
+    } else {
+      buffers.output.destroy();
+      buffers.read.destroy();
+    }
+  }
+
+  destroy(): void {
+    for (const pool of this.bufferPool.values()) {
+      for (const b of pool) {
+        b.output.destroy();
+        b.read.destroy();
+      }
+    }
+    this.bufferPool.clear();
+    try {
+      this.device?.destroy?.();
+    } catch {
+      /* ignore */
+    }
+    this.device = null;
+    this.pipeline = null;
+    this.bindGroupLayout = null;
+    this.isSupported = false;
+    this.initPromise = null;
+  }
+
+  private packUniforms(
+    sampleRate: number,
+    numSamples: number,
+    oversample: number,
+    numEvents: number,
+    params: WebGpu303Params,
+  ): ArrayBuffer {
+    const buf = new ArrayBuffer(VOICE_303_UNIFORM_BYTES);
+    const view = new DataView(buf);
+    view.setFloat32(0, sampleRate, true);
+    view.setUint32(4, numSamples, true);
+    view.setUint32(8, oversample, true);
+    view.setUint32(12, numEvents, true);
+    view.setFloat32(16, params.waveform, true);
+    view.setFloat32(20, params.cutoff, true);
+    view.setFloat32(24, params.resonance, true);
+    view.setFloat32(28, params.envMod, true);
+    view.setFloat32(32, params.decay, true);
+    view.setFloat32(36, params.accent, true);
+    view.setFloat32(40, params.volume, true);
+    view.setFloat32(44, params.slideTime, true);
+    view.setFloat32(48, params.accentDecay, true);
+    view.setFloat32(52, params.squareDrv, true);
+    return buf;
+  }
+
+  private packEvents(
+    events: Array<{
+      startSample: number;
+      midiNote: number;
+      velocity: number;
+      slide: boolean;
+    }>,
+  ): ArrayBuffer {
+    const n = Math.max(1, events.length);
+    const buf = new ArrayBuffer(n * NOTE_EVENT_BYTES);
+    const view = new DataView(buf);
+    if (events.length === 0) {
+      // Dummy event so storage buffer is non-empty (WGSL array length ≥ 1).
+      return buf;
+    }
+    for (let i = 0; i < events.length; i++) {
+      const e = events[i];
+      const o = i * NOTE_EVENT_BYTES;
+      view.setUint32(o + 0, e.startSample >>> 0, true);
+      view.setFloat32(o + 4, e.midiNote, true);
+      view.setFloat32(o + 8, e.velocity, true);
+      view.setUint32(o + 12, e.slide ? 1 : 0, true);
+    }
+    return buf;
+  }
+
+  /**
+   * Render `lengthSamples` of a sustained note (multisample / one-shot).
+   * Async; returns Float32Array or falls back to highfid-cpu.
+   */
+  async render303(
+    params: Partial<WebGpu303Params>,
+    lengthSamples: number,
+    options: WebGpu303RenderOptions & {
+      midiNote?: number;
+      velocity?: number;
+    } = {},
+  ): Promise<Float32Array> {
+    const meta = await this.render303WithMeta(params, lengthSamples, options);
+    return meta.buffer;
+  }
+
+  async render303WithMeta(
+    params: Partial<WebGpu303Params>,
+    lengthSamples: number,
+    options: WebGpu303RenderOptions & {
+      midiNote?: number;
+      velocity?: number;
+    } = {},
+  ): Promise<WebGpu303RenderMeta> {
+    const sampleRate = options.sampleRate ?? 44100;
+    const midiNote = options.midiNote ?? 36;
+    const velocity = options.velocity ?? 90;
+    const merged = { ...this.params, ...params };
+    const pattern: Offline303PatternData = {
+      steps: [{ note: midiNote, velocity }],
+      stepDurationSec: lengthSamples / sampleRate,
+      params: merged,
+    };
+    return this.renderPatternWithMeta(pattern, options);
+  }
+
+  /** Render a sequencer pattern through the GPU (or highfid-cpu fallback). */
+  async renderPattern(
+    pattern: Offline303PatternData,
+    options: WebGpu303RenderOptions = {},
+  ): Promise<Float32Array> {
+    const meta = await this.renderPatternWithMeta(pattern, options);
+    return meta.buffer;
+  }
+
+  async renderPatternWithMeta(
+    pattern: Offline303PatternData,
+    options: WebGpu303RenderOptions = {},
+  ): Promise<WebGpu303RenderMeta> {
+    const oversample = clampOversample(options.oversample);
+    const sampleRate = options.sampleRate ?? 44100;
+    const params: WebGpu303Params = {
+      ...DEFAULT_OFFLINE_303_PARAMS,
+      ...this.params,
+      ...pattern.params,
+    };
+
+    if (options.forceCpuFallback) {
+      return this.cpuFallback(pattern, oversample, sampleRate, 'forced CPU fallback');
+    }
+
+    const ok = await this.init();
+    if (!ok || !this.device || !this.pipeline || !this.bindGroupLayout) {
+      return this.cpuFallback(
+        pattern,
+        oversample,
+        sampleRate,
+        this.lastFallbackReason ?? 'WebGPU unavailable',
+      );
+    }
+
+    try {
+      const gpuMeta = await this.dispatchGpu(pattern, params, oversample, sampleRate);
+      if (
+        options.maxLatencyMs != null &&
+        gpuMeta.latencyMs > options.maxLatencyMs
+      ) {
+        // Soft budget miss — keep GPU result but record reason for HUD.
+        this.lastFallbackReason = `gpu latency ${gpuMeta.latencyMs.toFixed(1)}ms > budget ${options.maxLatencyMs}ms (result kept)`;
+        try {
+          engineTelemetry.recordGpu303Render({
+            latencyMs: gpuMeta.latencyMs,
+            readbackBytes: gpuMeta.readbackBytes,
+            fallbackReason: this.lastFallbackReason,
+            usedGpu: true,
+          });
+        } catch {
+          /* optional */
+        }
+      }
+      return gpuMeta;
+    } catch (e) {
+      const reason =
+        e instanceof Error ? e.message : 'GPU dispatch/readback failed';
+      logEngineFallback('gpu-highfid', 'webgpu', reason, e);
+      return this.cpuFallback(pattern, oversample, sampleRate, reason);
+    }
+  }
+
+  private cpuFallback(
+    pattern: Offline303PatternData,
+    oversample: OversampleFactor,
+    sampleRate: number,
+    reason: string,
+  ): WebGpu303RenderMeta {
+    this.lastFallbackReason = reason;
+    const t0 =
+      typeof performance !== 'undefined' ? performance.now() : Date.now();
+    const buffer = renderOfflineHighFid303Pattern(pattern, {
+      oversample,
+      sampleRate,
+    });
+    const t1 =
+      typeof performance !== 'undefined' ? performance.now() : Date.now();
+    const latencyMs = t1 - t0;
+    if (bufferHasNonFinite(buffer)) {
+      throw new Error('Non-finite samples in highfid-cpu fallback');
+    }
+    try {
+      engineTelemetry.recordGpu303Render({
+        latencyMs,
+        readbackBytes: 0,
+        fallbackReason: reason,
+        usedGpu: false,
+      });
+      engineTelemetry.registerResolution('gpu-highfid', 'highfid-cpu', reason);
+    } catch {
+      /* optional */
+    }
+    return {
+      buffer,
+      latencyMs,
+      oversample,
+      usedGpu: false,
+      fallbackReason: reason,
+      readbackBytes: 0,
+    };
+  }
+
+  private async dispatchGpu(
+    pattern: Offline303PatternData,
+    params: WebGpu303Params,
+    oversample: OversampleFactor,
+    sampleRate: number,
+  ): Promise<WebGpu303RenderMeta> {
+    const device = this.device!;
+    const tempo = pattern.tempo ?? 120;
+    const stepDur = pattern.stepDurationSec ?? 60 / tempo / 4;
+    const framesPerStep = Math.max(1, Math.round(stepDur * sampleRate));
+    const numSamples = framesPerStep * pattern.steps.length;
+    const bufferSize = numSamples * 4;
+
+    if (bufferSize > this.MAX_BUFFER_SIZE) {
+      throw new Error(
+        `gpu-highfid buffer ${bufferSize}B exceeds max ${this.MAX_BUFFER_SIZE}B`,
+      );
+    }
+
+    const events: Array<{
+      startSample: number;
+      midiNote: number;
+      velocity: number;
+      slide: boolean;
+    }> = [];
+    for (let i = 0; i < pattern.steps.length; i++) {
+      const step = pattern.steps[i];
+      events.push({
+        startSample: i * framesPerStep,
+        midiNote: step.note,
+        velocity: step.velocity ?? (step.accent ? 120 : 90),
+        slide: !!step.slide,
+      });
+    }
+
+    const t0 =
+      typeof performance !== 'undefined' ? performance.now() : Date.now();
+
+    const buffers = this.acquireBuffers(bufferSize);
+    if (!buffers) {
+      throw new Error('GPUBuffer allocation failed');
+    }
+
+    const uniformData = this.packUniforms(
+      sampleRate,
+      numSamples,
+      oversample,
+      events.length,
+      params,
+    );
+    const eventData = this.packEvents(events);
+
+    const uniformBuffer = device.createBuffer({
+      size: VOICE_303_UNIFORM_BYTES,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    const eventBuffer = device.createBuffer({
+      size: Math.max(NOTE_EVENT_BYTES, eventData.byteLength),
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    });
+
+    device.queue.writeBuffer(uniformBuffer, 0, uniformData);
+    device.queue.writeBuffer(eventBuffer, 0, eventData);
+
+    const bindGroup = device.createBindGroup({
+      layout: this.bindGroupLayout!,
+      entries: [
+        { binding: 0, resource: { buffer: uniformBuffer } },
+        { binding: 1, resource: { buffer: eventBuffer } },
+        { binding: 2, resource: { buffer: buffers.output } },
+      ],
+    });
+
+    const encoder = device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(this.pipeline!);
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatchWorkgroups(1);
+    pass.end();
+    encoder.copyBufferToBuffer(buffers.output, 0, buffers.read, 0, bufferSize);
+    device.queue.submit([encoder.finish()]);
+
+    await buffers.read.mapAsync(GPUMapMode.READ);
+    const mapped = new Float32Array(buffers.read.getMappedRange(), 0, numSamples);
+    const result = new Float32Array(mapped);
+    buffers.read.unmap();
+
+    this.releaseBuffers(buffers, bufferSize);
+    uniformBuffer.destroy();
+    eventBuffer.destroy();
+
+    const t1 =
+      typeof performance !== 'undefined' ? performance.now() : Date.now();
+    const latencyMs = t1 - t0;
+    const readbackBytes = bufferSize;
+
+    if (bufferHasNonFinite(result)) {
+      throw new Error('Non-finite samples in GPU 303 render');
+    }
+
+    this.lastFallbackReason = null;
+    try {
+      engineTelemetry.recordGpu303Render({
+        latencyMs,
+        readbackBytes,
+        fallbackReason: null,
+        usedGpu: true,
+      });
+      engineTelemetry.recordLatency('gpu-highfid', latencyMs);
+      engineTelemetry.registerResolution('gpu-highfid', 'webgpu', 'render-ok');
+    } catch {
+      /* optional */
+    }
+
+    return {
+      buffer: result,
+      latencyMs,
+      oversample,
+      usedGpu: true,
+      fallbackReason: null,
+      readbackBytes,
+    };
+  }
+}
+
+/** Singleton helper for OfflineRenderer / MultisampleGenerator. */
+let sharedEngine: WebGpu303Engine | null = null;
+
+export function getSharedWebGpu303Engine(): WebGpu303Engine {
+  if (!sharedEngine) sharedEngine = new WebGpu303Engine();
+  return sharedEngine;
+}
+
+export function resetSharedWebGpu303Engine(): void {
+  sharedEngine?.destroy();
+  sharedEngine = null;
+}
+
+/**
+ * Render via GPU high-fid with automatic highfid-cpu fallback.
+ * Preferred entry for freeze / export / MultisampleGenerator.
+ */
+export async function renderGpuHighFid303(
+  pattern: Offline303PatternData,
+  options: WebGpu303RenderOptions = {},
+): Promise<WebGpu303RenderMeta> {
+  return getSharedWebGpu303Engine().renderPatternWithMeta(pattern, options);
+}
+
+/**
+ * Wrap a mono Float32 render into an AudioBuffer for AudioBufferSourceNode
+ * playback (never schedule GPU work on the audio thread).
+ */
+export function float32ToAudioBuffer(
+  ctx: BaseAudioContext,
+  samples: Float32Array,
+  sampleRate?: number,
+): AudioBuffer {
+  const sr = sampleRate ?? ctx.sampleRate;
+  const buf = ctx.createBuffer(1, samples.length, sr);
+  buf.copyToChannel(samples, 0);
+  return buf;
+}

--- a/src/utils/__tests__/engineTelemetry.test.ts
+++ b/src/utils/__tests__/engineTelemetry.test.ts
@@ -46,6 +46,10 @@ const fakeRuntime = {
   offlineRenderThreadCount: null as number | null,
   offlineRenderOversample: null as number | null,
   offlineRenderLatencyMs: null as number | null,
+  gpuRenderLatencyMs: null as number | null,
+  gpuReadbackBytes: null as number | null,
+  gpuFallbackReason: null as string | null,
+  gpuUsedGpu: null as boolean | null,
 };
 
 describe('serializeEngineReport', () => {

--- a/src/utils/engineTelemetry.ts
+++ b/src/utils/engineTelemetry.ts
@@ -45,6 +45,14 @@ type RuntimeTelemetry = {
   offlineRenderThreadCount: number | null;
   offlineRenderOversample: number | null;
   offlineRenderLatencyMs: number | null;
+  /** Phase-3 / #976 — last GPU 303 render wall latency (ms). */
+  gpuRenderLatencyMs: number | null;
+  /** Phase-3 — bytes read back from GPU on last successful gpu-highfid render. */
+  gpuReadbackBytes: number | null;
+  /** Phase-3 — why GPU path fell back to highfid-cpu (null if GPU used). */
+  gpuFallbackReason: string | null;
+  /** Phase-3 — whether the last gpu-highfid attempt used the WGSL path. */
+  gpuUsedGpu: boolean | null;
 };
 
 function emptyData(): TelemetryData {
@@ -148,6 +156,14 @@ export interface RuntimeSnapshot {
   offlineRenderOversample: number | null;
   /** Last offline 303 render wall latency in ms. */
   offlineRenderLatencyMs: number | null;
+  /** Last GPU 303 render latency in ms (Phase-3 / #976). */
+  gpuRenderLatencyMs: number | null;
+  /** Last GPU 303 readback size in bytes. */
+  gpuReadbackBytes: number | null;
+  /** Why GPU 303 fell back to highfid-cpu (null if GPU succeeded). */
+  gpuFallbackReason: string | null;
+  /** Whether last gpu-highfid render used WebGPU. */
+  gpuUsedGpu: boolean | null;
 }
 
 export interface EngineReport {
@@ -222,6 +238,10 @@ export class EngineTelemetry {
     offlineRenderThreadCount: null,
     offlineRenderOversample: null,
     offlineRenderLatencyMs: null,
+    gpuRenderLatencyMs: null,
+    gpuReadbackBytes: null,
+    gpuFallbackReason: null,
+    gpuUsedGpu: null,
   };
   private lastUnderrunByWorklet = new Map<string, number>();
 
@@ -296,6 +316,23 @@ export class EngineTelemetry {
     );
   }
 
+  /**
+   * Record metrics from a GPU high-fid 303 render (Phase-3 / #976).
+   * Does not affect the real-time audio-thread budget.
+   */
+  recordGpu303Render(meta: {
+    latencyMs: number;
+    readbackBytes: number;
+    fallbackReason: string | null;
+    usedGpu: boolean;
+  }): void {
+    this.runtime.gpuRenderLatencyMs = meta.latencyMs;
+    this.runtime.gpuReadbackBytes = meta.readbackBytes;
+    this.runtime.gpuFallbackReason = meta.fallbackReason;
+    this.runtime.gpuUsedGpu = meta.usedGpu;
+    this.recordLatency('gpu-highfid', meta.latencyMs);
+  }
+
   private recomputeMasterBudget(): void {
     let sum = 0;
     for (const w of this.runtime.worklets.values()) {
@@ -325,6 +362,10 @@ export class EngineTelemetry {
       offlineRenderThreadCount: this.runtime.offlineRenderThreadCount,
       offlineRenderOversample: this.runtime.offlineRenderOversample,
       offlineRenderLatencyMs: this.runtime.offlineRenderLatencyMs,
+      gpuRenderLatencyMs: this.runtime.gpuRenderLatencyMs,
+      gpuReadbackBytes: this.runtime.gpuReadbackBytes,
+      gpuFallbackReason: this.runtime.gpuFallbackReason,
+      gpuUsedGpu: this.runtime.gpuUsedGpu,
     };
   }
 

--- a/src/webgpu/shaders/303Voice.wgsl.ts
+++ b/src/webgpu/shaders/303Voice.wgsl.ts
@@ -1,0 +1,377 @@
+/**
+ * WGSL TB-303 authenticity-tier voice (Phase-3 / #976).
+ *
+ * Topology mirrors OfflineHighFid303Engine / highfid303_wrapper.cpp:
+ *   PolyBLEP saw / soft-driven square → diode-ladder (feedback HP @ 150 Hz,
+ *   cubic soft-clip) → coupled accent envelope → VCA.
+ *
+ * Recursive filter state forces sequential sample processing inside one
+ * compute invocation (workgroup_size 1). Parallelism is across independent
+ * notes / multisample slots (dispatchWorkgroups), never inside the IIR.
+ *
+ * Offline / freeze / export only — never on the AudioWorklet thread.
+ */
+
+export const VOICE_303_WGSL = /* wgsl */ `
+struct VoiceUniforms {
+  sampleRate: f32,
+  numSamples: u32,
+  oversample: u32,
+  numEvents: u32,
+  waveform: f32,
+  cutoff: f32,
+  resonance: f32,
+  envMod: f32,
+  decay: f32,
+  accent: f32,
+  volume: f32,
+  slideTime: f32,
+  accentDecay: f32,
+  squareDrv: f32,
+  _pad0: f32,
+  _pad1: f32,
+};
+
+struct NoteEvent {
+  startSample: u32,
+  midiNote: f32,
+  velocity: f32,
+  slide: u32,
+};
+
+@group(0) @binding(0) var<uniform> u: VoiceUniforms;
+@group(0) @binding(1) var<storage, read> events: array<NoteEvent>;
+@group(0) @binding(2) var<storage, read_write> audioOut: array<f32>;
+
+const PI: f32 = 3.141592653589793;
+const TWO_PI: f32 = 6.283185307179586;
+const SQRT2: f32 = 1.41421356237;
+const ACCENT_VEL: f32 = 100.0;
+const FEEDBACK_HP_HZ: f32 = 150.0;
+
+fn clampf(x: f32, lo: f32, hi: f32) -> f32 {
+  return max(lo, min(hi, x));
+}
+
+fn fastTanh(x: f32) -> f32 {
+  let x2 = x * x;
+  return (x * (27.0 + x2)) / (27.0 + 9.0 * x2);
+}
+
+fn diodeShape(xIn: f32) -> f32 {
+  let x = clampf(xIn, -SQRT2, SQRT2);
+  return x - (x * x * x) / 6.0;
+}
+
+fn polyBlep(tIn: f32, dt: f32) -> f32 {
+  if (dt <= 0.0) { return 0.0; }
+  var t = tIn;
+  if (t < dt) {
+    t = t / dt;
+    return t + t - t * t - 1.0;
+  }
+  if (t > 1.0 - dt) {
+    t = (t - 1.0) / dt;
+    return t * t + t + t + 1.0;
+  }
+  return 0.0;
+}
+
+fn midiToFreq(midi: f32) -> f32 {
+  return 440.0 * pow(2.0, (midi - 69.0) / 12.0);
+}
+
+struct HpState {
+  b0: f32,
+  b1: f32,
+  a1: f32,
+  x1: f32,
+  y1: f32,
+};
+
+fn hpInit(hz: f32, sr: f32) -> HpState {
+  let h = clampf(hz, 1.0, sr * 0.45);
+  let wc = (TWO_PI * h) / sr;
+  let t = tan(wc * 0.5);
+  let c = (1.0 - t) / (1.0 + t);
+  return HpState((1.0 + c) * 0.5, -(1.0 + c) * 0.5, c, 0.0, 0.0);
+}
+
+fn hpProcess(st: ptr<function, HpState>, x: f32) -> f32 {
+  let y = (*st).b0 * x + (*st).b1 * (*st).x1 + (*st).a1 * (*st).y1;
+  (*st).x1 = x;
+  (*st).y1 = y;
+  return y;
+}
+
+struct LadderState {
+  y1: f32,
+  y2: f32,
+  y3: f32,
+  y4: f32,
+  b0: f32,
+  k: f32,
+  g: f32,
+  oscLpY: f32,
+  oscLpCoeff: f32,
+  hp: HpState,
+};
+
+fn ladderReset(st: ptr<function, LadderState>, sr: f32) {
+  (*st).y1 = 0.0;
+  (*st).y2 = 0.0;
+  (*st).y3 = 0.0;
+  (*st).y4 = 0.0;
+  (*st).oscLpY = 0.0;
+  (*st).oscLpCoeff = 0.5;
+  (*st).b0 = 0.5;
+  (*st).k = 0.0;
+  (*st).g = 1.0;
+  (*st).hp = hpInit(FEEDBACK_HP_HZ, sr);
+}
+
+fn ladderSetCutoff(st: ptr<function, LadderState>, cutoffHz: f32, resonance01: f32, sr: f32) {
+  let cut = clampf(cutoffHz, 40.0, sr * 0.45);
+  let r = clampf(resonance01, 0.0, 1.0);
+  let resonanceSkewed = (1.0 - exp(-3.0 * r)) / (1.0 - exp(-3.0));
+  let wc = (TWO_PI * cut) / sr;
+  let fx = (wc * 0.7071067811865476) / TWO_PI;
+
+  (*st).b0 =
+    (0.00045522346 + 6.1922189 * fx) /
+    (1.0 + 12.358354 * fx + 4.4156345 * (fx * fx));
+
+  let kScale =
+    fx *
+      (fx *
+        (fx * (fx * (fx * (fx + 7198.6997) - 5837.7917) - 476.47308) + 614.95611) +
+        213.87126) +
+    16.998792;
+  var g = kScale * 0.058823529411764705;
+  g = (g - 1.0) * resonanceSkewed + 1.0;
+  g = g * (1.0 + resonanceSkewed);
+  (*st).g = g;
+  (*st).k = kScale * resonanceSkewed;
+
+  let lpHz = clampf(cut * 2.5, 200.0, sr * 0.4);
+  let lpWc = (TWO_PI * lpHz) / sr;
+  (*st).oscLpCoeff = lpWc / (1.0 + lpWc);
+}
+
+fn ladderProcess(st: ptr<function, LadderState>, inputIn: f32) -> f32 {
+  (*st).oscLpY += (*st).oscLpCoeff * (inputIn - (*st).oscLpY);
+  let input = (*st).oscLpY;
+
+  let fb = hpProcess(&(*st).hp, (*st).k * diodeShape((*st).y4));
+  let y0 = input - fb;
+  (*st).y1 += 2.0 * (*st).b0 * (y0 - (*st).y1 + (*st).y2);
+  (*st).y2 += (*st).b0 * ((*st).y1 - 2.0 * (*st).y2 + (*st).y3);
+  (*st).y3 += (*st).b0 * ((*st).y2 - 2.0 * (*st).y3 + (*st).y4);
+  (*st).y4 += (*st).b0 * ((*st).y3 - 2.0 * (*st).y4);
+  (*st).y1 = clampf((*st).y1, -8.0, 8.0);
+  (*st).y2 = clampf((*st).y2, -8.0, 8.0);
+  (*st).y3 = clampf((*st).y3, -8.0, 8.0);
+  (*st).y4 = clampf((*st).y4, -8.0, 8.0);
+  let out = 2.0 * (*st).g * (*st).y4;
+  if (!(out == out)) {
+    ladderReset(st, 44100.0);
+    return 0.0;
+  }
+  return out;
+}
+
+struct VoiceState {
+  phase: f32,
+  currentFreq: f32,
+  targetFreq: f32,
+  slideCoeff: f32,
+  envLevel: f32,
+  envDecayRate: f32,
+  accentEnv: f32,
+  accentAttackRate: f32,
+  accentDecayRate: f32,
+  accentAttacking: u32,
+  accented: u32,
+  gateOpen: u32,
+  ladder: LadderState,
+};
+
+fn updateRates(vs: ptr<function, VoiceState>, sr: f32) {
+  var timeS = 0.05 + u.decay * 1.95;
+  if ((*vs).accented == 1u) {
+    timeS *= 0.05 + u.accentDecay * 0.95;
+  }
+  (*vs).envDecayRate = exp(-1.0 / (sr * timeS));
+  (*vs).accentAttackRate = 1.0 - exp(-1.0 / (sr * 0.003));
+  let accDecS = 0.04 + u.accent * 0.08;
+  (*vs).accentDecayRate = exp(-1.0 / (sr * accDecS));
+}
+
+fn updateFilter(vs: ptr<function, VoiceState>, sr: f32) {
+  var envBoost = u.envMod * (*vs).envLevel;
+  if ((*vs).accented == 1u) {
+    envBoost += u.accent * 0.45 * (*vs).accentEnv;
+  }
+  let total = clampf(u.cutoff + envBoost, 0.0, 1.0);
+  let hz = 200.0 * pow(4500.0 / 200.0, total);
+  ladderSetCutoff(&(*vs).ladder, hz, u.resonance, sr);
+}
+
+fn noteOn(vs: ptr<function, VoiceState>, midi: f32, velocity: f32, slide: bool, sr: f32) {
+  let freq = midiToFreq(midi);
+  (*vs).targetFreq = freq;
+  if ((*vs).gateOpen == 1u && u.slideTime > 0.0 && (*vs).currentFreq > 0.0 && slide) {
+    let slideSeconds = 0.01 + u.slideTime * 0.49;
+    let ratio = (*vs).targetFreq / (*vs).currentFreq;
+    if (ratio > 0.0 && ratio != 1.0) {
+      (*vs).slideCoeff = pow(ratio, 1.0 / (slideSeconds * sr));
+    } else {
+      (*vs).slideCoeff = 1.0;
+      (*vs).currentFreq = (*vs).targetFreq;
+    }
+  } else {
+    (*vs).currentFreq = freq;
+    (*vs).slideCoeff = 1.0;
+  }
+  (*vs).accented = select(0u, 1u, velocity > ACCENT_VEL);
+  (*vs).gateOpen = 1u;
+  (*vs).envLevel = 1.0;
+  if ((*vs).accented == 1u) {
+    (*vs).accentEnv = 0.0;
+    (*vs).accentAttacking = 1u;
+  } else {
+    (*vs).accentEnv = 0.0;
+    (*vs).accentAttacking = 0u;
+  }
+  updateRates(vs, sr);
+  updateFilter(vs, sr);
+}
+
+fn noteOff(vs: ptr<function, VoiceState>) {
+  (*vs).gateOpen = 0u;
+}
+
+fn renderOsc(vs: ptr<function, VoiceState>, sr: f32) -> f32 {
+  let phaseInc = (*vs).currentFreq / sr;
+  (*vs).phase += phaseInc;
+  if ((*vs).phase >= 1.0) {
+    (*vs).phase -= 1.0;
+  }
+
+  if (u.waveform < 0.5) {
+    var osc = 2.0 * (*vs).phase - 1.0;
+    osc -= polyBlep((*vs).phase, phaseInc);
+    return osc;
+  }
+  var sq = select(-1.0, 1.0, (*vs).phase < 0.5);
+  sq += polyBlep((*vs).phase, phaseInc);
+  var t2 = (*vs).phase + 0.5;
+  if (t2 >= 1.0) { t2 -= 1.0; }
+  sq -= polyBlep(t2, phaseInc);
+  let drive = 1.0 + u.squareDrv * 2.5;
+  return fastTanh(sq * drive);
+}
+
+fn renderSample(vs: ptr<function, VoiceState>, sr: f32) -> f32 {
+  if ((*vs).slideCoeff != 1.0) {
+    (*vs).currentFreq *= (*vs).slideCoeff;
+    let reached = select(
+      (*vs).currentFreq <= (*vs).targetFreq,
+      (*vs).currentFreq >= (*vs).targetFreq,
+      (*vs).slideCoeff > 1.0,
+    );
+    if (reached) {
+      (*vs).currentFreq = (*vs).targetFreq;
+      (*vs).slideCoeff = 1.0;
+    }
+  }
+
+  (*vs).envLevel *= (*vs).envDecayRate;
+  if ((*vs).envLevel < 1e-6) { (*vs).envLevel = 0.0; }
+
+  if ((*vs).accented == 1u) {
+    if ((*vs).accentAttacking == 1u) {
+      (*vs).accentEnv += (1.0 - (*vs).accentEnv) * (*vs).accentAttackRate;
+      if ((*vs).accentEnv > 0.995) {
+        (*vs).accentEnv = 1.0;
+        (*vs).accentAttacking = 0u;
+      }
+    } else {
+      (*vs).accentEnv *= (*vs).accentDecayRate;
+      if ((*vs).accentEnv < 1e-6) { (*vs).accentEnv = 0.0; }
+    }
+  }
+
+  updateFilter(vs, sr);
+  let osc = renderOsc(vs, sr);
+  let filtered = ladderProcess(&(*vs).ladder, osc);
+  var gain = u.volume;
+  if ((*vs).accented == 1u) {
+    gain *= 1.0 + u.accent * 0.35 * (*vs).accentEnv;
+  }
+  var out = filtered * gain * 0.55;
+  if (!(out == out)) {
+    ladderReset(&(*vs).ladder, sr);
+    return 0.0;
+  }
+  return clampf(out, -1.5, 1.5);
+}
+
+@compute @workgroup_size(1)
+fn render303(@builtin(workgroup_id) wid: vec3<u32>) {
+  // Single-voice sequential render (wid.x must be 0 for pattern mode).
+  if (wid.x != 0u) { return; }
+
+  let nSamples = u.numSamples;
+  let os = max(u.oversample, 1u);
+  let srBase = u.sampleRate;
+  let srEff = srBase * f32(os);
+
+  var vs: VoiceState;
+  vs.phase = 0.0;
+  vs.currentFreq = 440.0;
+  vs.targetFreq = 440.0;
+  vs.slideCoeff = 1.0;
+  vs.envLevel = 0.0;
+  vs.envDecayRate = 0.999;
+  vs.accentEnv = 0.0;
+  vs.accentAttackRate = 0.0;
+  vs.accentDecayRate = 0.0;
+  vs.accentAttacking = 0u;
+  vs.accented = 0u;
+  vs.gateOpen = 0u;
+  ladderReset(&vs.ladder, srEff);
+  updateRates(&vs, srEff);
+  updateFilter(&vs, srEff);
+
+  var nextEvent: u32 = 0u;
+  let invOs = 1.0 / f32(os);
+
+  for (var i: u32 = 0u; i < nSamples; i++) {
+    // Fire all events scheduled at this sample index.
+    loop {
+      if (nextEvent >= u.numEvents) { break; }
+      let ev = events[nextEvent];
+      if (ev.startSample != i) { break; }
+      let isSlide = ev.slide != 0u;
+      if (!isSlide && vs.gateOpen == 1u) {
+        noteOff(&vs);
+      }
+      noteOn(&vs, ev.midiNote, ev.velocity, isSlide, srEff);
+      nextEvent += 1u;
+    }
+
+    var acc = 0.0;
+    for (var s: u32 = 0u; s < os; s++) {
+      acc += renderSample(&vs, srEff);
+    }
+    audioOut[i] = acc * invOs;
+  }
+}
+`;
+
+/** Byte size of VoiceUniforms (16 × f32/u32 with padding). */
+export const VOICE_303_UNIFORM_BYTES = 64;
+
+/** Byte size of one NoteEvent (4 × 4 bytes). */
+export const NOTE_EVENT_BYTES = 16;

--- a/src/workers/Offline303Renderer.worker.ts
+++ b/src/workers/Offline303Renderer.worker.ts
@@ -1,5 +1,5 @@
 /**
- * Offline 303 renderer worker (Phase-1 / #974 + Phase-2 / #975).
+ * Offline 303 renderer worker (Phase-1 / #974 + Phase-2 / #975 + Phase-3 / #976).
  *
  * Protocol (postMessage):
  *   → { type: 'render', requestId, modelId, pattern, options? }
@@ -8,7 +8,9 @@
  *   ← { type: 'error', requestId, error }
  *
  * Engines: OfflineOpen303Engine (open303-family) and OfflineHighFid303Engine
- * (`highfid-cpu` diode-ladder). Real-time AudioWorklet path is untouched.
+ * (`highfid-cpu` / `gpu-highfid` fallback). Real WebGPU stays on the main
+ * thread via WebGpu303Engine — workers fall back to the CPU diode-ladder.
+ * Real-time AudioWorklet path is untouched.
  */
 
 import {
@@ -23,6 +25,7 @@ import {
   isHighFidCpuModel,
   renderOfflineHighFid303Pattern,
 } from '../audio/offline/OfflineHighFid303Engine';
+import { isGpuHighFidModel } from '../engines/WebGpu303Engine';
 
 export interface Offline303RenderOptions {
   oversample?: OversampleFactor;
@@ -82,7 +85,8 @@ function renderModel(
   oversample: OversampleFactor,
   options: Offline303RenderOptions | undefined,
 ): Float32Array {
-  if (isHighFidCpuModel(modelId)) {
+  // Worker has no reliable WebGPU; gpu-highfid → highfid-cpu diode-ladder.
+  if (isHighFidCpuModel(modelId) || isGpuHighFidModel(modelId)) {
     return renderOfflineHighFid303Pattern(pattern, {
       oversample,
       sampleRate: options?.sampleRate,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase-3 / #976** of the TB-303 authenticity epic (#972): an offline WebGPU (`gpu-highfid`) diode-ladder voice that mirrors the Phase-2 `highfid-cpu` topology for multisamples, freeze/export, and high-fid renders — without touching the AudioWorklet path.

## What’s included

- **WGSL shader** (`src/webgpu/shaders/303Voice.wgsl.ts`): PolyBLEP saw/square, 4-pole diode-ladder + 150 Hz feedback HP, coupled accent envelopes, slide, optional 1|2|4× oversample. Sequential `@workgroup_size(1)` (IIR-safe).
- **`WebGpu303Engine`**: buffer pooling (size-bucketed like `WebGpuOscillator`), `render303` / `renderPattern` async API, compile-error surfacing, automatic **highfid-cpu** fallback when WebGPU is missing or dispatch fails.
- **Registry**: `gpu-highfid` offline-only `highfid` family voice; hidden from realtime selector; `normalizeTB303Model` → stock.
- **Integration**: `render303Offline('gpu-highfid', …)`, worker CPU fallback, `MultisampleGenerator.generate303HighFidMultisamples`, `float32ToAudioBuffer` for `AudioBufferSourceNode` playback.
- **Telemetry**: `gpuRenderLatencyMs`, `gpuReadbackBytes`, `gpuFallbackReason`, `gpuUsedGpu` (+ Engine HUD).
- **Harness**: `pnpm exec vite-node scripts/render_gpu_highfid_wav.mjs`
- **Docs**: `docs/audio-engine/GPU_HIGHFID_303.md`

## Tests

```bash
CI=true pnpm exec vitest run --pool forks src/__tests__/WebGpu303Engine.test.ts
```

Covers registry, WGSL source shape, deterministic CPU fallback (= highfid-cpu), OfflineRenderer wiring, telemetry.

## Notes

- Headless CI has no WebGPU — tests intentionally verify **graceful fallback** (bit-identical to highfid-cpu).
- Spectrogram A/B vs soft oracle uses the same Phase-0/2 thresholds; full hardware gate remains Phase-5.
- Parent: #972 · Blocked by: #975 (merged)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2825b298-c85c-4274-979a-30b4773d0ddf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2825b298-c85c-4274-979a-30b4773d0ddf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

