### PR TITLE
feat: implement per-phoneme formant glide

### DIFF
--- a/.Jules/agent_plan.md
+++ b/.Jules/agent_plan.md
@@ -11,8 +11,9 @@
 - [x] Implement Lyric Track parsing
 - [x] Implement Vowel-Preserving Time Stretch for TTS voices
 - [x] Implement per-phoneme pitch drift/vibrato
-- [ ] Add Formant Modulation LFO
-- [ ] Add Formant Glide per phoneme
+- [x] Add Formant Modulation LFO
+- [x] Add Formant Glide per phoneme
 - [ ] Add granular random jitter per phoneme
+- [ ] Optimize Voice Manager state syncing
 
 ## Roadmap

--- a/src/engines/singing-voice/playback.ts
+++ b/src/engines/singing-voice/playback.ts
@@ -267,6 +267,79 @@ export const PlaybackMixin = {
    *
    * @param targetDuration Optional target duration for stretch calculation
    */
+  schedulePhonemeFormantGlides(
+    this: SingingVoiceHost,
+    targetDuration: number,
+    triggerTime: number,
+    baseFormantShift: number,
+    userPhonemes?: PhonemeData[],
+  ): void {
+    if (
+      !this.config.enableFormantShifting ||
+      !this.lastAlignment ||
+      !this.phonemeAligner ||
+      !userPhonemes ||
+      userPhonemes.length === 0
+    ) {
+      return;
+    }
+
+    const phonemes = this.lastAlignment.phonemes;
+    const sampleRate = this.audioContext.sampleRate;
+
+    // We only care if there is any user phoneme with a formant shift
+    const hasFormantShift = userPhonemes.some(
+      (p) => p.formantShift !== undefined && p.formantShift !== 0,
+    );
+    if (!hasFormantShift) {
+      return;
+    }
+
+    // Calculate absolute stretch map
+    const ratios = this.phonemeAligner.calculateStretchRatios(
+      phonemes,
+      targetDuration,
+    );
+
+    let currentTimeSeconds = triggerTime;
+    let prevShift = baseFormantShift;
+
+    for (let i = 0; i < phonemes.length; i++) {
+      const p = phonemes[i];
+      const ratio = ratios[i] || 1.0;
+      const originalDurationSec = (p.end - p.start) / sampleRate;
+      const stretchedDurationSec = originalDurationSec * ratio;
+
+      const userP = userPhonemes[i];
+      let targetShift = baseFormantShift;
+      if (userP && userP.formantShift !== undefined) {
+        targetShift += userP.formantShift;
+      }
+
+      if (prevShift !== targetShift) {
+        // Ramp duration bounded by the segment length
+        // We use a quick ramp, but bounded to the phoneme length so it doesn't bleed too far
+        const rampDuration = Math.min(0.05, stretchedDurationSec);
+
+        // Using existing setFormantGlide:
+        // Note setFormantGlide ramps from startSemitones to endSemitones over duration.
+        // If we want it to glide during this phoneme segment:
+        this.setFormantGlide(
+          prevShift,
+          targetShift,
+          currentTimeSeconds,
+          rampDuration
+        );
+      } else {
+        // Ensure we hold the target shift
+        this.setFormantShift(targetShift, currentTimeSeconds, 0);
+      }
+
+      prevShift = targetShift;
+      currentTimeSeconds += stretchedDurationSec;
+    }
+  },
+
   sendPhonemeDataToWorklet(
     this: SingingVoiceHost,
     targetDuration?: number,

--- a/src/hooks/audioEngine/samplerPlayback.ts
+++ b/src/hooks/audioEngine/samplerPlayback.ts
@@ -523,6 +523,9 @@ export function createSamplerPlayback(
         // 3. Phoneme Awareness (from Jules branch)
         if (ctx.alignment) {
             voice.setAlignment(ctx.alignment);
+            if (ctx.noteParams?.phonemes?.length) {
+                voice.schedulePhonemeFormantGlides(targetDuration, triggerTime, finalFormantShift, ctx.noteParams.phonemes);
+            }
             voice.sendPhonemeDataToWorklet(targetDuration, ctx.noteParams?.phonemes);
         }
 


### PR DESCRIPTION
This PR implements the "Formant Glide per phoneme" feature from the Innovation Lab backlog.

When synthesizing TTS or playback samples, we use a Web Audio AudioWorklet (RubberBand) for time stretching, but the FormantShifter is implemented as a biquad filter graph on the main thread. To avoid coupling the two, we use a new helper `schedulePhonemeFormantGlides` that uses the exact same time stretching ratios that the worklet uses. This ensures the formant automations stay completely in sync with the stretched playback timeline without injecting Web Audio automation logic into the worklet messaging path.

The `formantShift` parameter in the `PhonemeData` array acts as a relative offset to the note/bank-level base formant shift, which preserves natural compositional semantics.

---
*PR created automatically by Jules for task [16390458379098428469](https://jules.google.com/task/16390458379098428469) started by @ford442*