### PR TITLE
Phase-4: High-fid 303 registry, UI selector & degradation (#977)

### DIFF
--- a/docs/audio-engine/303-voices.md
+++ b/docs/audio-engine/303-voices.md
@@ -286,8 +286,15 @@ normalization all read the registry.
 - `gpu-highfid` — WGSL WebGPU path with automatic highfid-cpu fallback
   ([GPU_HIGHFID_303.md](./GPU_HIGHFID_303.md)).
 
-Keep both out of the real-time selector (`getAvailableTB303Models()` excludes
-`offlineOnly` by default). See Phase-4 for freeze/export UI selection.
+`Voice303Selector` lists them with an **Offline** badge (Phase-4 /
+`includeOfflineOnly: true`). Tooltips explain they are best for freeze /
+export / multisample; live playback stays on Stock Open303 via
+`resolveRealtimeTB303Model`. Choosing `gpu-highfid` without WebGPU keeps the
+persisted id and falls back offline to `highfid-cpu` through
+`resolveHighFidModelSelection` (Engine HUD + degradation banner).
+
+`getAvailableTB303Models()` (no opts) still excludes offline voices for
+realtime-only call sites.
 
 ## Out of scope for v1
 

--- a/docs/audio-engine/GPU_HIGHFID_303.md
+++ b/docs/audio-engine/GPU_HIGHFID_303.md
@@ -79,9 +79,12 @@ await multisampleGenerator.generate303HighFidMultisamples({
 | `available` | `true` |
 | `offlineOnly` | `true` |
 
-`getAvailableTB303Models()` hides it from the real-time selector.
-`normalizeTB303Model('gpu-highfid')` → `stock-open303` so song load never
-routes it onto AudioWorklet.
+`getAvailableTB303Models()` hides it from realtime-only call sites.
+`Voice303Selector` includes it via `{ includeOfflineOnly: true }` (Phase-4).
+`normalizeTB303Model('gpu-highfid')` keeps the id for persistence;
+`resolveRealtimeTB303Model` / `resolveHighFidModelSelection` map realtime to
+stock and, without WebGPU, offline render to `highfid-cpu` with user-visible
+feedback.
 
 ## Fallback chain
 

--- a/docs/audio-engine/HIGHFID_CPU_303.md
+++ b/docs/audio-engine/HIGHFID_CPU_303.md
@@ -47,11 +47,12 @@ Parameter IDs match `Open303Param` / `Open303Params.ts`.
 | `available` | `true` |
 | `offlineOnly` | `true` |
 
-`getAvailableTB303Models()` hides it from the real-time selector.
-`getAvailableTB303Models({ includeOfflineOnly: true })` exposes it for
-freeze/export UIs (Phase-4).
-`normalizeTB303Model('highfid-cpu')` → `stock-open303` so song load never
-routes it onto AudioWorklet.
+`getAvailableTB303Models()` hides it from realtime-only call sites.
+`getAvailableTB303Models({ includeOfflineOnly: true })` exposes it in
+`Voice303Selector` (Phase-4) with an Offline badge.
+`normalizeTB303Model('highfid-cpu')` keeps the id for song persistence;
+`resolveRealtimeTB303Model('highfid-cpu')` → `stock-open303` so AudioWorklet
+never receives it.
 
 ## Offline worker
 

--- a/src/__tests__/HighFid303Offline.test.ts
+++ b/src/__tests__/HighFid303Offline.test.ts
@@ -43,8 +43,8 @@ describe('highfid-cpu registry', () => {
     ).toBe(true);
   });
 
-  it('normalizeTB303Model falls back to stock for offline-only voices', () => {
-    expect(normalizeTB303Model('highfid-cpu')).toBe('stock-open303');
+  it('normalizeTB303Model preserves offline-only high-fid ids', () => {
+    expect(normalizeTB303Model('highfid-cpu')).toBe('highfid-cpu');
   });
 });
 

--- a/src/__tests__/TB303Models.test.ts
+++ b/src/__tests__/TB303Models.test.ts
@@ -19,6 +19,9 @@ import {
     getAvailableTB303Models,
     normalizeTB303Model,
     reportTB303ModelFallback,
+    resolveHighFidModelSelection,
+    resolveRealtimeTB303Model,
+    legacyEngine303ForModel,
     tb303ModelFamily,
     stockModelForFamily,
 } from '../engines/TB303Models';
@@ -80,6 +83,15 @@ describe('TB303_MODELS registry', () => {
         const available = getAvailableTB303Models();
         expect(available.length).toBeGreaterThanOrEqual(4);
         expect(available.every((m) => m.available)).toBe(true);
+        expect(available.every((m) => !m.offlineOnly)).toBe(true);
+    });
+
+    it('includeOfflineOnly exposes highfid-cpu and gpu-highfid', () => {
+        const withOffline = getAvailableTB303Models({ includeOfflineOnly: true });
+        expect(withOffline.some((m) => m.id === 'highfid-cpu')).toBe(true);
+        expect(withOffline.some((m) => m.id === 'gpu-highfid')).toBe(true);
+        expect(getTB303Model('highfid-cpu')?.label).toContain('offline');
+        expect(getTB303Model('gpu-highfid')?.label).toContain('offline');
     });
 
     it('every model has a label and a description (used for UI tooltips)', () => {
@@ -124,6 +136,11 @@ describe('normalizeTB303Model()', () => {
         expect(normalizeTB303Model('raveolution')).toBe('raveolution');
     });
 
+    it('preserves available offline-only high-fid ids for persistence', () => {
+        expect(normalizeTB303Model('highfid-cpu')).toBe('highfid-cpu');
+        expect(normalizeTB303Model('gpu-highfid')).toBe('gpu-highfid');
+    });
+
     it('falls back for unknown ids from future song versions', () => {
         expect(normalizeTB303Model('some-future-voice')).toBe('stock-open303');
         expect(normalizeTB303Model('some-future-voice', 'jc303')).toBe('jc303');
@@ -141,10 +158,55 @@ describe('normalizeTB303Model()', () => {
     });
 });
 
+describe('resolveRealtimeTB303Model()', () => {
+    it('maps offline high-fid voices to stock for AudioWorklet', () => {
+        expect(resolveRealtimeTB303Model('highfid-cpu')).toBe('stock-open303');
+        expect(resolveRealtimeTB303Model('gpu-highfid')).toBe('stock-open303');
+    });
+
+    it('passes through realtime voices', () => {
+        expect(resolveRealtimeTB303Model('experimental-01')).toBe('experimental-01');
+        expect(resolveRealtimeTB303Model('jc303')).toBe('jc303');
+    });
+});
+
+describe('resolveHighFidModelSelection()', () => {
+    it('falls back gpu-highfid → highfid-cpu when WebGPU is missing', () => {
+        const sel = resolveHighFidModelSelection('gpu-highfid', undefined, {
+            gpuAvailable: false,
+            report: false,
+        });
+        expect(sel.persisted).toBe('gpu-highfid');
+        expect(sel.realtime).toBe('stock-open303');
+        expect(sel.offlineEngine).toBe('highfid-cpu');
+        expect(sel.fallbackReason).toMatch(/WebGPU unavailable/i);
+    });
+
+    it('keeps gpu-highfid offline engine when WebGPU is available', () => {
+        const sel = resolveHighFidModelSelection('gpu-highfid', undefined, {
+            gpuAvailable: true,
+            report: false,
+        });
+        expect(sel.offlineEngine).toBe('gpu-highfid');
+        expect(sel.fallbackReason).toBeNull();
+        expect(sel.realtime).toBe('stock-open303');
+    });
+
+    it('selects highfid-cpu without GPU fallback noise', () => {
+        const sel = resolveHighFidModelSelection('highfid-cpu', undefined, {
+            gpuAvailable: false,
+            report: false,
+        });
+        expect(sel.offlineEngine).toBe('highfid-cpu');
+        expect(sel.fallbackReason).toBeNull();
+    });
+});
+
 describe('family helpers', () => {
     it('tb303ModelFamily resolves families and defaults to open303', () => {
         expect(tb303ModelFamily('jc303')).toBe('jc303');
         expect(tb303ModelFamily('experimental-01')).toBe('open303');
+        expect(tb303ModelFamily('highfid-cpu')).toBe('highfid');
         expect(tb303ModelFamily('nope')).toBe('open303');
         expect(tb303ModelFamily(undefined)).toBe('open303');
     });
@@ -152,6 +214,13 @@ describe('family helpers', () => {
     it('stockModelForFamily returns the stock voice per family', () => {
         expect(stockModelForFamily('open303')).toBe('stock-open303');
         expect(stockModelForFamily('jc303')).toBe('jc303');
+        expect(stockModelForFamily('highfid')).toBe('highfid-cpu');
+    });
+
+    it('legacyEngine303ForModel mirrors highfid → open303 for old song readers', () => {
+        expect(legacyEngine303ForModel('gpu-highfid')).toBe('open303');
+        expect(legacyEngine303ForModel('jc303')).toBe('jc303');
+        expect(legacyEngine303ForModel('1ink303-v1')).toBe('open303');
     });
 });
 
@@ -194,6 +263,15 @@ describe('Open303Oscillator.setModel303()', () => {
 
     it('normalizes unknown model ids to stock-open303', () => {
         oscillator.setModel303('definitely-not-a-voice');
+        expect(mockPostMessage).toHaveBeenCalledWith({
+            type: 'set-303-model',
+            data: { model: 'stock-open303', engine: 'open303' },
+        });
+        expect(oscillator.getModel303()).toBe('stock-open303');
+    });
+
+    it('maps offline high-fid voices to stock on the worklet', () => {
+        oscillator.setModel303('gpu-highfid');
         expect(mockPostMessage).toHaveBeenCalledWith({
             type: 'set-303-model',
             data: { model: 'stock-open303', engine: 'open303' },
@@ -323,10 +401,18 @@ describe('model303 persistence', () => {
         expect(normalizeTB303Model(undefined, (legacyB as { engine303?: string }).engine303)).toBe('stock-open303');
     });
 
-    it('every available model id round-trips as a TB303ModelId', () => {
+    it('every available realtime model id round-trips as a TB303ModelId', () => {
         for (const m of getAvailableTB303Models()) {
             const restored = JSON.parse(JSON.stringify({ model303: m.id })) as { model303: TB303ModelId };
             expect(normalizeTB303Model(restored.model303)).toBe(m.id);
+        }
+    });
+
+    it('offline high-fid ids survive JSON round-trip and normalize', () => {
+        for (const id of ['highfid-cpu', 'gpu-highfid'] as const) {
+            const restored = JSON.parse(JSON.stringify({ model303: id })) as { model303: TB303ModelId };
+            expect(normalizeTB303Model(restored.model303)).toBe(id);
+            expect(resolveRealtimeTB303Model(restored.model303)).toBe('stock-open303');
         }
     });
 });

--- a/src/__tests__/WebGpu303Engine.test.ts
+++ b/src/__tests__/WebGpu303Engine.test.ts
@@ -53,8 +53,8 @@ describe('gpu-highfid registry', () => {
     ).toBe(true);
   });
 
-  it('normalizeTB303Model falls back to stock for offline-only voices', () => {
-    expect(normalizeTB303Model('gpu-highfid')).toBe('stock-open303');
+  it('normalizeTB303Model preserves gpu-highfid for persistence', () => {
+    expect(normalizeTB303Model('gpu-highfid')).toBe('gpu-highfid');
   });
 });
 

--- a/src/components/EngineHUD.tsx
+++ b/src/components/EngineHUD.tsx
@@ -82,10 +82,22 @@ if (typeof window !== 'undefined' && !document.getElementById(CONTAINER_ID)) {
       runtime.gpuFallbackReason != null
         ? runtime.gpuFallbackReason.slice(0, 42)
         : '—';
+    const gpuAvail =
+      runtime.gpuAvailable === true ? 'yes' : runtime.gpuAvailable === false ? 'no' : '—';
+    const hfReq = runtime.highFidRequested ?? '—';
+    const hfActive = runtime.highFidActiveEngine ?? '—';
+    const hfSelFb =
+      runtime.highFidFallbackReason != null
+        ? runtime.highFidFallbackReason.slice(0, 42)
+        : '—';
     const offlineSection = `<div class="subheader">Offline 303</div>
       <div class="row"><div style="flex:1">Oversample</div><div style="min-width:72px;text-align:right">${offlineOs}</div></div>
       <div class="row"><div style="flex:1">Threads</div><div style="min-width:72px;text-align:right">${offlineThreads}</div></div>
       <div class="row"><div style="flex:1">Last render</div><div style="min-width:72px;text-align:right">${offlineLat}</div></div>
+      <div class="row"><div style="flex:1">WebGPU</div><div style="min-width:72px;text-align:right">${gpuAvail}</div></div>
+      <div class="row"><div style="flex:1">HiFi select</div><div style="min-width:72px;text-align:right;font-size:10px" title="${runtime.highFidRequested ?? ''}">${hfReq}</div></div>
+      <div class="row"><div style="flex:1">HiFi active</div><div style="min-width:72px;text-align:right;font-size:10px">${hfActive}</div></div>
+      <div class="row" title="${runtime.highFidFallbackReason ?? ''}"><div style="flex:1">HiFi fallback</div><div style="min-width:72px;text-align:right;font-size:10px">${hfSelFb}</div></div>
       <div class="row"><div style="flex:1">GPU 303</div><div style="min-width:72px;text-align:right">${gpuBackend} ${gpuLat}</div></div>
       <div class="row" title="${runtime.gpuFallbackReason ?? ''}"><div style="flex:1">GPU fallback</div><div style="min-width:72px;text-align:right;font-size:10px">${gpuFb}</div></div>`;
 

--- a/src/components/Voice303Selector.tsx
+++ b/src/components/Voice303Selector.tsx
@@ -1,6 +1,12 @@
 import React, { memo } from 'react';
 import type { TB303ModelId } from '../types';
-import { getAvailableTB303Models, tb303ModelFamily } from '../engines/TB303Models';
+import {
+    getAvailableTB303Models,
+    isOfflineOnlyTB303Model,
+    resolveHighFidModelSelection,
+    tb303ModelFamily,
+} from '../engines/TB303Models';
+import { getBrowserCapabilities } from '../utils/engineTelemetry';
 import { HelpIconButton, HelpTip } from './help/HelpTip';
 
 interface Voice303SelectorProps {
@@ -10,6 +16,13 @@ interface Voice303SelectorProps {
     onChange: (model: TB303ModelId) => void;
     /** Accent colour matching the rack module (default: 'pink'). */
     accentColor?: 'pink' | 'cyan';
+    /**
+     * Include offline-only high-fid voices (default true — Phase-4).
+     * Pass false for realtime-only surfaces.
+     */
+    includeOfflineOnly?: boolean;
+    /** Override WebGPU probe (tests). Defaults to getBrowserCapabilities().webgpu. */
+    gpuAvailable?: boolean;
 }
 
 /**
@@ -19,20 +32,33 @@ interface Voice303SelectorProps {
  * dynamically from the TB303_MODELS registry (src/engines/TB303Models.ts),
  * so new voices added to the C++ registry + TS mirror appear here without
  * touching this component. Each track picks its voice independently.
+ *
+ * Offline high-fid voices (highfid-cpu / gpu-highfid) are listed with an
+ * OFFLINE badge; selecting GPU without WebGPU reports a CPU fallback via
+ * resolveHighFidModelSelection while still persisting the requested id.
  */
 export const Voice303Selector: React.FC<Voice303SelectorProps> = memo(({
     model,
     onChange,
     accentColor = 'pink',
+    includeOfflineOnly = true,
+    gpuAvailable: gpuAvailableProp,
 }) => {
-    const models = getAvailableTB303Models();
+    const models = getAvailableTB303Models({ includeOfflineOnly });
     const activeFamily = tb303ModelFamily(model);
+    const gpuAvailable = gpuAvailableProp ?? getBrowserCapabilities().webgpu;
 
-    // Themed by engine family (open303 = emerald, jc303 = teal), matching the
-    // established osc-type visual treatment. Part accent (cyan/pink) is used
-    // for the header label/badge.
+    const selectionHint = isOfflineOnlyTB303Model(model)
+        ? resolveHighFidModelSelection(model, undefined, {
+            gpuAvailable,
+            report: false,
+          })
+        : null;
+
+    // Themed by engine family (open303 = emerald, jc303 = teal, highfid = amber).
     const openActive = 'bg-gradient-to-b from-emerald-500 to-emerald-600 text-white border-emerald-400 shadow-[0_0_12px_rgba(16,185,129,0.5),inset_0_1px_0_rgba(255,255,255,0.2)]';
     const jcActive = 'bg-gradient-to-b from-teal-500 to-teal-600 text-white border-teal-400 shadow-[0_0_12px_rgba(20,184,166,0.5),inset_0_1px_0_rgba(255,255,255,0.2)]';
+    const highfidActive = 'bg-gradient-to-b from-amber-500 to-amber-700 text-white border-amber-400 shadow-[0_0_12px_rgba(245,158,11,0.45),inset_0_1px_0_rgba(255,255,255,0.2)]';
     const inactiveStyle = 'bg-gradient-to-b from-zinc-800 to-zinc-900 text-zinc-400 border-zinc-700 hover:text-zinc-200 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]';
 
     const badgeColorStyle = accentColor === 'cyan'
@@ -46,6 +72,32 @@ export const Voice303Selector: React.FC<Voice303SelectorProps> = memo(({
     const borderColorStyle = accentColor === 'cyan'
         ? 'border-cyan-500/20'
         : 'border-pink-500/20';
+
+    const familyBadgeLabel =
+        activeFamily === 'jc303' ? 'JC303' : activeFamily === 'highfid' ? 'HIFID' : 'OPEN303';
+    const familyBadgeAria =
+        activeFamily === 'jc303'
+            ? 'JC303 engine family active'
+            : activeFamily === 'highfid'
+              ? 'High-fidelity offline engine family active'
+              : 'Open303 engine family active';
+    const familyBadgeTitle =
+        activeFamily === 'jc303'
+            ? 'Active engine family: authentic rosic::Open303 (jc303)'
+            : activeFamily === 'highfid'
+              ? 'Active engine family: offline high-fidelity (freeze / export / multisample)'
+              : 'Active engine family: custom Open303';
+
+    const handleSelect = (id: TB303ModelId) => {
+        if (isOfflineOnlyTB303Model(id)) {
+            resolveHighFidModelSelection(id, undefined, {
+                gpuAvailable,
+                report: true,
+                subsystem: 'voice303-selector',
+            });
+        }
+        onChange(id);
+    };
 
     return (
         <HelpTip topicId="engine-303-switch" showOnFirstUse position="right" className="w-full">
@@ -62,35 +114,80 @@ export const Voice303Selector: React.FC<Voice303SelectorProps> = memo(({
                 <div className="flex items-center gap-1">
                     <span
                         className={`text-[7px] font-bold uppercase tracking-widest px-1.5 py-0.5 rounded-full border ${badgeColorStyle}`}
-                        title={`Active engine family: ${activeFamily === 'jc303' ? 'authentic rosic::Open303 (jc303)' : 'custom Open303'}`}
-                        aria-label={`${activeFamily === 'jc303' ? 'JC303' : 'Open303'} engine family active`}
+                        title={familyBadgeTitle}
+                        aria-label={familyBadgeAria}
                     >
-                        {activeFamily === 'jc303' ? 'JC303' : 'OPEN303'}
+                        {familyBadgeLabel}
                     </span>
+                    {!gpuAvailable && includeOfflineOnly && (
+                        <span
+                            className="text-[7px] font-bold uppercase tracking-widest px-1.5 py-0.5 rounded-full border bg-zinc-900 text-amber-300 border-amber-500/50"
+                            title="WebGPU unavailable — GPU High-Fidelity falls back to High-Fidelity CPU for offline render"
+                            aria-label="WebGPU unavailable; GPU high-fidelity will fall back to CPU"
+                        >
+                            No GPU
+                        </span>
+                    )}
                     <HelpIconButton topicId="engine-303-switch" />
                 </div>
             </div>
 
             {models.map((m) => {
                 const isActive = m.id === model;
+                const activeClass =
+                    m.family === 'jc303'
+                        ? jcActive
+                        : m.family === 'highfid'
+                          ? highfidActive
+                          : openActive;
+                const tooltip = m.offlineOnly
+                    ? `${m.description} (offline only – best for freeze / export / multisample)`
+                    : m.description;
                 return (
                     <button
                         type="button"
                         key={m.id}
-                        onClick={() => onChange(m.id)}
-                        title={m.description}
+                        onClick={() => handleSelect(m.id)}
+                        title={tooltip}
                         aria-pressed={isActive}
                         aria-label={`Select ${m.label} voice`}
-                        className={`px-3 py-1.5 text-[9px] font-bold rounded-md transition-all border focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 ${
-                            isActive
-                                ? (m.family === 'jc303' ? jcActive : openActive)
-                                : inactiveStyle
+                        className={`px-3 py-1.5 text-[9px] font-bold rounded-md transition-all border focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 flex items-center justify-between gap-2 ${
+                            isActive ? activeClass : inactiveStyle
                         }`}
                     >
-                        {m.label}
+                        <span className="text-left leading-tight">{m.label}</span>
+                        {m.offlineOnly && (
+                            <span
+                                className={`shrink-0 text-[7px] font-bold uppercase tracking-wider px-1 py-0.5 rounded border ${
+                                    isActive
+                                        ? 'bg-black/25 border-white/30 text-white'
+                                        : 'bg-amber-950/80 border-amber-600/50 text-amber-300'
+                                }`}
+                            >
+                                Offline
+                            </span>
+                        )}
                     </button>
                 );
             })}
+
+            {selectionHint?.fallbackReason && (
+                <p
+                    className="text-[8px] text-amber-300/90 font-mono leading-snug mt-0.5"
+                    role="status"
+                    aria-live="polite"
+                >
+                    {selectionHint.fallbackReason}
+                </p>
+            )}
+            {selectionHint && !selectionHint.fallbackReason && isOfflineOnlyTB303Model(model) && (
+                <p
+                    className="text-[8px] text-zinc-500 font-mono leading-snug mt-0.5"
+                    role="status"
+                >
+                    Offline engine: {selectionHint.offlineEngine} · live uses Stock Open303
+                </p>
+            )}
         </div>
         </HelpTip>
     );

--- a/src/components/__tests__/Voice303Selector.test.tsx
+++ b/src/components/__tests__/Voice303Selector.test.tsx
@@ -2,11 +2,13 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { Voice303Selector } from '../Voice303Selector';
 import { getAvailableTB303Models } from '../../engines/TB303Models';
+import { engineDegradationStore } from '../../stores/engineDegradationStore';
+import { engineTelemetry } from '../../utils/engineTelemetry';
 
 describe('Voice303Selector', () => {
-    it('renders one button per available voice from the registry', () => {
-        render(<Voice303Selector model="stock-open303" onChange={vi.fn()} />);
-        for (const m of getAvailableTB303Models()) {
+    it('renders one button per available voice including offline high-fid', () => {
+        render(<Voice303Selector model="stock-open303" onChange={vi.fn()} gpuAvailable />);
+        for (const m of getAvailableTB303Models({ includeOfflineOnly: true })) {
             expect(screen.getByRole('button', { name: `Select ${m.label} voice` })).toBeInTheDocument();
         }
     });
@@ -26,12 +28,22 @@ describe('Voice303Selector', () => {
         expect(onChange).toHaveBeenCalledWith('jc303');
     });
 
-    it('exposes the voice description as a tooltip', () => {
-        render(<Voice303Selector model="stock-open303" onChange={vi.fn()} />);
-        for (const m of getAvailableTB303Models()) {
-            expect(screen.getByRole('button', { name: `Select ${m.label} voice` }))
-                .toHaveAttribute('title', m.description);
+    it('exposes the voice description as a tooltip (offline voices mention freeze/export)', () => {
+        render(<Voice303Selector model="stock-open303" onChange={vi.fn()} gpuAvailable />);
+        for (const m of getAvailableTB303Models({ includeOfflineOnly: true })) {
+            const btn = screen.getByRole('button', { name: `Select ${m.label} voice` });
+            const title = btn.getAttribute('title') ?? '';
+            expect(title).toContain(m.description.slice(0, 24));
+            if (m.offlineOnly) {
+                expect(title.toLowerCase()).toMatch(/offline|freeze|export|multisample/);
+            }
         }
+    });
+
+    it('shows Offline badges on high-fid voices', () => {
+        render(<Voice303Selector model="stock-open303" onChange={vi.fn()} gpuAvailable />);
+        const offlineBadges = screen.getAllByText('Offline');
+        expect(offlineBadges.length).toBeGreaterThanOrEqual(2);
     });
 
     it('shows the OPEN303 family badge for open303-family voices', () => {
@@ -42,6 +54,41 @@ describe('Voice303Selector', () => {
     it('shows the JC303 family badge when a jc303-family voice is active', () => {
         render(<Voice303Selector model="jc303" onChange={vi.fn()} />);
         expect(screen.getByLabelText('JC303 engine family active')).toBeInTheDocument();
+    });
+
+    it('shows HIFID badge and status when a high-fid voice is active', () => {
+        render(
+            <Voice303Selector model="highfid-cpu" onChange={vi.fn()} gpuAvailable={false} />,
+        );
+        expect(screen.getByLabelText('High-fidelity offline engine family active')).toBeInTheDocument();
+        expect(screen.getByText(/Offline engine: highfid-cpu/i)).toBeInTheDocument();
+    });
+
+    it('shows No GPU badge and fallback message when selecting gpu-highfid without WebGPU', () => {
+        engineDegradationStore.clear('gpu-highfid-selection');
+        const onChange = vi.fn();
+        render(
+            <Voice303Selector model="stock-open303" onChange={onChange} gpuAvailable={false} />,
+        );
+        expect(screen.getByLabelText(/WebGPU unavailable/i)).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: /Select GPU High-Fidelity/i }));
+        expect(onChange).toHaveBeenCalledWith('gpu-highfid');
+
+        const snap = engineTelemetry.getRuntimeSnapshot();
+        expect(snap.highFidRequested).toBe('gpu-highfid');
+        expect(snap.highFidActiveEngine).toBe('highfid-cpu');
+        expect(snap.highFidFallbackReason).toMatch(/WebGPU unavailable/i);
+        expect(engineDegradationStore.getIssue('gpu-highfid-selection')?.activeBackend).toBe(
+            'highfid-cpu',
+        );
+    });
+
+    it('persists gpu-highfid selection and shows CPU fallback status when GPU is unavailable', () => {
+        render(
+            <Voice303Selector model="gpu-highfid" onChange={vi.fn()} gpuAvailable={false} />,
+        );
+        expect(screen.getByRole('status')).toHaveTextContent(/WebGPU unavailable/i);
     });
 
     it('is grouped and labelled for assistive tech', () => {

--- a/src/engines/Open303Oscillator.ts
+++ b/src/engines/Open303Oscillator.ts
@@ -1,7 +1,13 @@
 import type { Open303Params, Open303Config } from './Open303Params';
 import { DEFAULT_303_PARAMS } from './Open303Params';
 import type { TB303ModelId } from './TB303Models';
-import { normalizeTB303Model, reportTB303ModelFallback, stockModelForFamily, tb303ModelFamily } from './TB303Models';
+import {
+    legacyEngine303ForModel,
+    normalizeTB303Model,
+    reportTB303ModelFallback,
+    resolveRealtimeTB303Model,
+    stockModelForFamily,
+} from './TB303Models';
 import { FallbackBassSynth } from './FallbackBassSynth';
 import {
     engineTelemetry,
@@ -291,12 +297,21 @@ export class Open303Oscillator {
      */
     setModel303(model: TB303ModelId | string): void {
         const requested = typeof model === 'string' ? model.trim() : model;
-        const resolved = normalizeTB303Model(requested);
+        // Persist the catalog id when known; AudioWorklet only receives realtime-safe voices.
+        const persisted = normalizeTB303Model(requested);
+        const resolved = resolveRealtimeTB303Model(persisted, undefined, { reportFallback: false });
         if (requested && resolved !== requested) {
-            reportTB303ModelFallback(requested, resolved, 'runtime apply', 'open303-model');
+            reportTB303ModelFallback(
+                requested,
+                resolved,
+                persisted !== requested
+                    ? 'runtime apply'
+                    : 'offline-only high-fid voice (realtime uses stock)',
+                'open303-model',
+            );
         }
         this.model303 = resolved;
-        this.engine303 = tb303ModelFamily(this.model303);
+        this.engine303 = legacyEngine303ForModel(this.model303);
         this.applyModel303();
     }
 

--- a/src/engines/TB303Models.ts
+++ b/src/engines/TB303Models.ts
@@ -8,11 +8,17 @@
  *    Models in this family are coefficient profiles applied to the same DSP
  *    topology (filter curves, envelope ranges, accent punch, waveshaping).
  *  - 'jc303' family — authentic rosic::Open303 (emscripten/jc303_wrapper.cpp).
+ *  - 'highfid' family — offline-only diode-ladder engines (highfid-cpu /
+ *    gpu-highfid). Never routed to AudioWorklet; used for freeze / export /
+ *    multisample (Phase-2+).
  *
- * This registry is mirrored by `k303Models[]` in emscripten/open303_wrapper.cpp.
+ * This registry is mirrored by `k303Models[]` in emscripten/open303_wrapper.cpp
+ * for open303-family coefficient profiles. High-fid engines live in separate
+ * wrappers (`highfid303_wrapper.cpp` / WGSL) and are catalogued here only.
+ *
  * Adding a new voice:
  *   1. Add a profile row to `k303Models[]` in open303_wrapper.cpp and rebuild
- *      the WASM (`pnpm run build:emcc`).
+ *      the WASM (`pnpm run build:emcc`) — open303-family only.
  *   2. Add a matching entry here with `available: true`.
  * Every call site (UI selector, worklet routing, song load/save) picks the new
  * voice up from this list — no other changes required.
@@ -23,8 +29,14 @@
  * with the exact stock sound they were saved with.
  */
 
-/** Which WASM API family a model is built on. Matches the legacy Engine303 type. */
+import { engineTelemetry } from '../utils/engineTelemetry';
+import { engineDegradationStore } from '../stores/engineDegradationStore';
+
+/** Which WASM API family a model is built on. Matches the legacy Engine303 type (+ highfid). */
 export type Engine303Family = 'open303' | 'jc303' | 'highfid';
+
+/** Legacy persisted mirror — only open303 | jc303 (older song readers). */
+export type LegacyEngine303 = 'open303' | 'jc303';
 
 export type TB303ModelId =
   | 'stock-open303'
@@ -65,8 +77,8 @@ export interface TB303ModelInfo {
   available: boolean;
   /**
    * When true, the voice is intended for offline / freeze / export only
-   * (Phase-2 highfid-cpu, Phase-3 gpu-highfid). Excluded from the real-time
-   * Voice303Selector.
+   * (Phase-2 highfid-cpu, Phase-3 gpu-highfid). Realtime AudioWorklet falls
+   * back via `resolveRealtimeTB303Model`; offline renderers use the id as-is.
    */
   offlineOnly?: boolean;
 }
@@ -142,20 +154,20 @@ export const TB303_MODELS: readonly TB303ModelInfo[] = [
   },
   {
     id: 'highfid-cpu',
-    label: 'High-Fidelity CPU',
+    label: 'High-Fidelity CPU (offline)',
     shortLabel: 'HiFi CPU',
     description:
-      'Offline diode-ladder reference (Phase-2) — feedback HP, per-loop soft diodes, PolyBLEP osc, coupled accent. Not for real-time AudioWorklet.',
+      'Offline only — best for freeze / export / multisample. Diode-ladder CPU reference (Phase-2). Live playback uses Stock Open303.',
     family: 'highfid',
     available: true,
     offlineOnly: true,
   },
   {
     id: 'gpu-highfid',
-    label: 'High-Fidelity GPU',
+    label: 'GPU High-Fidelity (offline)',
     shortLabel: 'HiFi GPU',
     description:
-      'Offline WGSL diode-ladder authenticity tier (Phase-3) — same topology as highfid-cpu, WebGPU compute with CPU fallback. Not for real-time AudioWorklet.',
+      'Offline only — best for freeze / export / multisample. WGSL diode-ladder (Phase-3); falls back to High-Fidelity CPU when WebGPU is unavailable. Live playback uses Stock Open303.',
     family: 'highfid',
     available: true,
     offlineOnly: true,
@@ -171,11 +183,15 @@ export function getTB303Model(id: string | undefined): TB303ModelInfo | undefine
   return id ? MODEL_BY_ID.get(id) : undefined;
 }
 
+export function isOfflineOnlyTB303Model(id: string | undefined): boolean {
+  return !!getTB303Model(id)?.offlineOnly;
+}
+
 /**
  * Models selectable in the UI (DSP profile shipped).
- * By default excludes `offlineOnly` voices (highfid-cpu, gpu-highfid) so the
- * real-time selector stays latency-safe. Pass `{ includeOfflineOnly: true }`
- * for freeze / export / offline renderer UIs (Phase-4).
+ * By default excludes `offlineOnly` voices so callers that only drive the
+ * AudioWorklet stay latency-safe. Pass `{ includeOfflineOnly: true }` for the
+ * voice selector / freeze / export UIs (Phase-4).
  */
 export function getAvailableTB303Models(opts?: {
   includeOfflineOnly?: boolean;
@@ -188,6 +204,14 @@ export function getAvailableTB303Models(opts?: {
 /** The engine family a model runs on ('open303' for anything unknown). */
 export function tb303ModelFamily(id: string | undefined): Engine303Family {
   return getTB303Model(id)?.family ?? 'open303';
+}
+
+/**
+ * Legacy `engine303` mirror for song save. High-fid voices map to `open303`
+ * so older builds still load a valid realtime engine field.
+ */
+export function legacyEngine303ForModel(id: string | undefined): LegacyEngine303 {
+  return tb303ModelFamily(id) === 'jc303' ? 'jc303' : 'open303';
 }
 
 /** Stock (default) model id for an engine family. */
@@ -210,10 +234,7 @@ export function reportTB303ModelFallback(
   const msg = `[TB303] Model "${requested}" unavailable (${reason}) — using "${resolved}"`;
   console.warn(msg);
   try {
-    // Lazy import avoids pulling DOM code into every unit test.
-    void import('../utils/engineTelemetry').then(({ engineTelemetry }) => {
-      engineTelemetry.registerResolution(subsystem, resolved, `${requested}: ${reason}`);
-    });
+    engineTelemetry.registerResolution(subsystem, resolved, `${requested}: ${reason}`);
   } catch {
     /* telemetry optional */
   }
@@ -222,10 +243,13 @@ export function reportTB303ModelFallback(
 /**
  * Resolve a persisted model/engine pair to a valid, available model id.
  *
- *  - A known, available `model303` wins.
+ *  - A known, available `model303` wins (including offline-only high-fid ids).
  *  - A known-but-unavailable model falls back to its family's stock voice.
  *  - Otherwise the legacy `engine303` field decides ('jc303' → 'jc303').
  *  - Default: 'stock-open303'.
+ *
+ * Offline-only ids are preserved for persistence / UI / offline render.
+ * Use `resolveRealtimeTB303Model` before posting to AudioWorklet.
  *
  * When `reportFallback` is true and the resolved id differs from the requested
  * string, `reportTB303ModelFallback` is invoked (song load / runtime apply).
@@ -238,20 +262,6 @@ export function normalizeTB303Model(
   const requested = model303?.trim();
   const model = getTB303Model(requested);
   if (model) {
-    // Offline-only high-fid voices are not routed to AudioWorklet yet (Phase-4).
-    // Song load / realtime apply falls back to stock so latency stays unchanged.
-    if (model.offlineOnly) {
-      const resolved: TB303ModelId = 'stock-open303';
-      if (options?.reportFallback && requested && resolved !== requested) {
-        reportTB303ModelFallback(
-          requested,
-          resolved,
-          'offline-only high-fid voice',
-          options.subsystem,
-        );
-      }
-      return resolved;
-    }
     const resolved = model.available ? model.id : stockModelForFamily(model.family);
     if (options?.reportFallback && requested && resolved !== requested) {
       reportTB303ModelFallback(requested, resolved, 'catalogued but not shipped', options.subsystem);
@@ -263,4 +273,135 @@ export function normalizeTB303Model(
     reportTB303ModelFallback(requested, resolved, 'unknown id', options.subsystem);
   }
   return resolved;
+}
+
+/**
+ * Map a (possibly offline-only) model to one safe for AudioWorklet routing.
+ * Offline high-fid voices → stock-open303 so realtime latency is unchanged.
+ */
+export function resolveRealtimeTB303Model(
+  model303?: string,
+  engine303?: string,
+  options?: { reportFallback?: boolean; subsystem?: string },
+): TB303ModelId {
+  const normalized = normalizeTB303Model(model303, engine303);
+  const info = getTB303Model(normalized);
+  if (info?.offlineOnly) {
+    const resolved: TB303ModelId = 'stock-open303';
+    if (options?.reportFallback !== false) {
+      reportTB303ModelFallback(
+        normalized,
+        resolved,
+        'offline-only high-fid voice (realtime uses stock)',
+        options?.subsystem ?? 'tb303-realtime',
+      );
+    }
+    return resolved;
+  }
+  return normalized;
+}
+
+export type HighFidOfflineEngine = 'gpu-highfid' | 'highfid-cpu' | 'stock-open303';
+
+export interface HighFidModelSelection {
+  /** User / song requested id (after normalize). */
+  requested: TB303ModelId;
+  /** Id to persist in SynthParams.model303. */
+  persisted: TB303ModelId;
+  /** Id for AudioWorklet (never offline-only). */
+  realtime: TB303ModelId;
+  /** Effective offline render engine after capability checks. */
+  offlineEngine: HighFidOfflineEngine;
+  /** Why offlineEngine differs from a GPU request (null if no degradation). */
+  fallbackReason: string | null;
+  gpuAvailable: boolean;
+}
+
+function detectWebGpuAvailable(): boolean {
+  try {
+    return typeof navigator !== 'undefined' && !!(navigator as Navigator & { gpu?: unknown }).gpu;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Central factory for high-fid / general model selection + fallback.
+ *
+ * Choosing `gpu-highfid` without WebGPU → offline path uses `highfid-cpu`
+ * (persisted id stays `gpu-highfid` so songs round-trip). Realtime always
+ * uses stock for offline-only voices.
+ */
+export function resolveHighFidModelSelection(
+  model303?: string,
+  engine303?: string,
+  options?: {
+    gpuAvailable?: boolean;
+    report?: boolean;
+    subsystem?: string;
+  },
+): HighFidModelSelection {
+  const requested = normalizeTB303Model(model303, engine303);
+  const gpuAvailable = options?.gpuAvailable ?? detectWebGpuAvailable();
+  const realtime = resolveRealtimeTB303Model(requested, engine303, {
+    reportFallback: false,
+    subsystem: options?.subsystem,
+  });
+
+  let offlineEngine: HighFidOfflineEngine = 'stock-open303';
+  let fallbackReason: string | null = null;
+
+  if (requested === 'gpu-highfid') {
+    if (gpuAvailable) {
+      offlineEngine = 'gpu-highfid';
+    } else {
+      offlineEngine = 'highfid-cpu';
+      fallbackReason = 'WebGPU unavailable — using High-Fidelity CPU for offline render';
+    }
+  } else if (requested === 'highfid-cpu') {
+    offlineEngine = 'highfid-cpu';
+  }
+  // Non-highfid models: offlineEngine stays stock-open303 as a sentinel;
+  // OfflineRenderer still uses the persisted model id for open303/jc303 paths.
+
+  const selection: HighFidModelSelection = {
+    requested,
+    persisted: requested,
+    realtime,
+    offlineEngine,
+    fallbackReason,
+    gpuAvailable,
+  };
+
+  if (options?.report !== false) {
+    try {
+      engineTelemetry.recordHighFidSelection({
+        requested: selection.requested,
+        activeOffline: selection.offlineEngine,
+        realtime: selection.realtime,
+        gpuAvailable: selection.gpuAvailable,
+        fallbackReason: selection.fallbackReason,
+      });
+      if (selection.fallbackReason) {
+        engineDegradationStore.reportHighFidFallback({
+          requested: selection.requested,
+          active: selection.offlineEngine,
+          reason: selection.fallbackReason,
+          gpuAvailable: selection.gpuAvailable,
+        });
+        reportTB303ModelFallback(
+          selection.requested,
+          selection.offlineEngine === 'highfid-cpu' ? 'highfid-cpu' : selection.realtime,
+          selection.fallbackReason,
+          options?.subsystem ?? 'gpu-highfid',
+        );
+      } else if (selection.requested === 'gpu-highfid' || selection.requested === 'highfid-cpu') {
+        engineDegradationStore.resolve('gpu-highfid-selection');
+      }
+    } catch {
+      /* telemetry optional */
+    }
+  }
+
+  return selection;
 }

--- a/src/hooks/appState/useHardwarePanels.tsx
+++ b/src/hooks/appState/useHardwarePanels.tsx
@@ -1,6 +1,13 @@
 import { useMemo } from 'react'
 import { Voice303Selector } from '../../components/Voice303Selector'
-import { normalizeTB303Model, stockModelForFamily, tb303ModelFamily } from '../../engines/TB303Models'
+import {
+    legacyEngine303ForModel,
+    normalizeTB303Model,
+    resolveHighFidModelSelection,
+    resolveRealtimeTB303Model,
+    stockModelForFamily,
+    tb303ModelFamily,
+} from '../../engines/TB303Models'
 import { ProphecyPanel } from '../../components/ProphecyPanel'
 import { CppPanel } from '../../components/CppPanel'
 import { OscillatorTypeSelector } from '../../components/OscillatorTypeSelector'
@@ -56,16 +63,27 @@ export function useHardwarePanels(deps: {
         const is303 = synthA.waveform === '303-saw' || synthA.waveform === '303-sqr';
         const isProphecy = synthA.waveform?.startsWith('prophecy-') ?? false;
         const modelA = normalizeTB303Model(synthA.model303, synthA.engine303);
-        const currentTypeA: OscillatorType = waveformToOscillatorType(synthA.waveform, tb303ModelFamily(modelA));
+        const realtimeA = resolveRealtimeTB303Model(modelA, synthA.engine303, { reportFallback: false });
+        const currentTypeA: OscillatorType = waveformToOscillatorType(
+            synthA.waveform,
+            legacyEngine303ForModel(realtimeA),
+        );
         const panelClassesA = getOscillatorPanelClasses(currentTypeA);
 
         const handleSynthAVoiceChange = (m: TB303ModelId) => {
-            // engine303 is mirrored for older builds loading the saved song.
-            updateSynthA({ model303: m, engine303: tb303ModelFamily(m) });
+            const selection = resolveHighFidModelSelection(m, undefined, {
+                report: true,
+                subsystem: 'synthA-model303',
+            });
+            // Persist requested id (incl. offline high-fid); mirror legacy engine303.
+            updateSynthA({
+                model303: selection.persisted,
+                engine303: legacyEngine303ForModel(selection.persisted),
+            });
             const mgr = audioEngine?.open303Engine;
-            if (mgr && 'setLead303Model' in mgr) (mgr as any).setLead303Model(m);
-            else if (mgr && 'setLead303Engine' in mgr) (mgr as any).setLead303Engine(tb303ModelFamily(m));
-            engineTelemetry.registerResolution('synthA-model303', m, 'user-initiated');
+            if (mgr && 'setLead303Model' in mgr) (mgr as any).setLead303Model(selection.realtime);
+            else if (mgr && 'setLead303Engine' in mgr) (mgr as any).setLead303Engine(legacyEngine303ForModel(selection.realtime));
+            engineTelemetry.registerResolution('synthA-model303', selection.persisted, 'user-initiated');
         };
 
         const handleSynthATypeChange = (newType: OscillatorType) => {
@@ -134,15 +152,26 @@ export function useHardwarePanels(deps: {
         const is303 = synthB.waveform === '303-saw' || synthB.waveform === '303-sqr';
         const isProphecy = synthB.waveform?.startsWith('prophecy-') ?? false;
         const modelB = normalizeTB303Model(synthB.model303, synthB.engine303);
-        const currentTypeB: OscillatorType = waveformToOscillatorType(synthB.waveform, tb303ModelFamily(modelB));
+        const realtimeB = resolveRealtimeTB303Model(modelB, synthB.engine303, { reportFallback: false });
+        const currentTypeB: OscillatorType = waveformToOscillatorType(
+            synthB.waveform,
+            legacyEngine303ForModel(realtimeB),
+        );
         const panelClassesB = getOscillatorPanelClasses(currentTypeB);
 
         const handleSynthBVoiceChange = (m: TB303ModelId) => {
-            updateSynthB({ model303: m, engine303: tb303ModelFamily(m) });
+            const selection = resolveHighFidModelSelection(m, undefined, {
+                report: true,
+                subsystem: 'synthB-model303',
+            });
+            updateSynthB({
+                model303: selection.persisted,
+                engine303: legacyEngine303ForModel(selection.persisted),
+            });
             const mgr = audioEngine?.open303Engine;
-            if (mgr && 'setBass1Model' in mgr) (mgr as any).setBass1Model(m);
-            else if (mgr && 'setBass1Engine' in mgr) mgr.setBass1Engine(tb303ModelFamily(m));
-            engineTelemetry.registerResolution('synthB-model303', m, 'user-initiated');
+            if (mgr && 'setBass1Model' in mgr) (mgr as any).setBass1Model(selection.realtime);
+            else if (mgr && 'setBass1Engine' in mgr) mgr.setBass1Engine(legacyEngine303ForModel(selection.realtime));
+            engineTelemetry.registerResolution('synthB-model303', selection.persisted, 'user-initiated');
         };
 
         const handleSynthBTypeChange = (newType: OscillatorType) => {
@@ -210,11 +239,18 @@ export function useHardwarePanels(deps: {
     const bass2Child = useMemo(() => {
         const modelB2 = normalizeTB303Model(bass2.model303, bass2.engine303);
         const handleBass2VoiceChange = (m: TB303ModelId) => {
-            updateBass2({ model303: m, engine303: tb303ModelFamily(m) });
+            const selection = resolveHighFidModelSelection(m, undefined, {
+                report: true,
+                subsystem: 'bass2-model303',
+            });
+            updateBass2({
+                model303: selection.persisted,
+                engine303: legacyEngine303ForModel(selection.persisted),
+            });
             const mgr = audioEngine?.open303Engine;
-            if (mgr && 'setBass2Model' in mgr) (mgr as any).setBass2Model(m);
-            else if (mgr && 'setBass2Engine' in mgr) mgr.setBass2Engine(tb303ModelFamily(m));
-            engineTelemetry.registerResolution('bass2-model303', m, 'user-initiated');
+            if (mgr && 'setBass2Model' in mgr) (mgr as any).setBass2Model(selection.realtime);
+            else if (mgr && 'setBass2Engine' in mgr) mgr.setBass2Engine(legacyEngine303ForModel(selection.realtime));
+            engineTelemetry.registerResolution('bass2-model303', selection.persisted, 'user-initiated');
         };
         const bass2Type: OscillatorType = tb303ModelFamily(modelB2) === 'jc303' ? 'jc303' : 'open303';
         return (

--- a/src/hooks/useAppState.tsx
+++ b/src/hooks/useAppState.tsx
@@ -12,7 +12,7 @@ import { SupertonicService } from '../services/Supertonic'
 import { automationStore } from '../stores/automationStore';
 import { AutomationScheduler } from '../audio/automation/AutomationScheduler';
 import type { PcfEffect } from '../engines/PcfEffect';
-import { normalizeTB303Model } from '../engines/TB303Models';
+import { resolveRealtimeTB303Model } from '../engines/TB303Models';
 import type { MainSequencerHandle } from '../components/MainSequencer'
 
 import {
@@ -219,19 +219,19 @@ export function useAppState() {
     useEffect(() => {
         const mgr = (audioEngine as any)?.open303Engine;
         if (!mgr) return;
-        // normalizeTB303Model resolves the persisted model303, falling back to
-        // the legacy engine303 field for songs saved before the voices update.
+        // normalize + realtime resolve: persist high-fid ids in song state, but
+        // AudioWorklet always gets a realtime-safe voice (stock for offline-only).
         if (typeof mgr.syncModel303Settings === 'function') {
             mgr.syncModel303Settings({
-                lead: normalizeTB303Model(synthA.model303, synthA.engine303, {
+                lead: resolveRealtimeTB303Model(synthA.model303, synthA.engine303, {
                     reportFallback: true,
                     subsystem: 'synthA-model303',
                 }),
-                bass1: normalizeTB303Model(synthB.model303, synthB.engine303, {
+                bass1: resolveRealtimeTB303Model(synthB.model303, synthB.engine303, {
                     reportFallback: true,
                     subsystem: 'synthB-model303',
                 }),
-                bass2: normalizeTB303Model(bass2.model303, bass2.engine303, {
+                bass2: resolveRealtimeTB303Model(bass2.model303, bass2.engine303, {
                     reportFallback: true,
                     subsystem: 'bass2-model303',
                 }),

--- a/src/stores/__tests__/engineDegradationStore.test.ts
+++ b/src/stores/__tests__/engineDegradationStore.test.ts
@@ -72,4 +72,19 @@ describe('engineDegradationStore', () => {
         expect(issue?.activeBackend).toBe('js-fallback');
         expect(issue?.requestedBackend).toBe('wasm');
     });
+
+    it('reports high-fid selection fallback (Phase-4)', () => {
+        engineDegradationStore.clear('gpu-highfid-selection');
+        engineDegradationStore.reportHighFidFallback({
+            requested: 'gpu-highfid',
+            active: 'highfid-cpu',
+            reason: 'WebGPU unavailable — using High-Fidelity CPU for offline render',
+            gpuAvailable: false,
+        });
+        const issue = engineDegradationStore.getIssue('gpu-highfid-selection');
+        expect(issue?.category).toBe('gpu');
+        expect(issue?.activeBackend).toBe('highfid-cpu');
+        expect(issue?.requestedBackend).toBe('gpu-highfid');
+        expect(issue?.retryable).toBe(true);
+    });
 });

--- a/src/stores/engineDegradationStore.ts
+++ b/src/stores/engineDegradationStore.ts
@@ -144,6 +144,29 @@ class EngineDegradationStore {
         });
     }
 
+    /**
+     * Phase-4: user selected GPU high-fid (or similar) but the offline path
+     * must degrade (e.g. no WebGPU → highfid-cpu).
+     */
+    reportHighFidFallback(meta: {
+        requested: string;
+        active: string;
+        reason: string;
+        gpuAvailable: boolean;
+    }): void {
+        this.report({
+            id: 'gpu-highfid-selection',
+            subsystem: 'gpu-highfid',
+            category: 'gpu',
+            message: `High-fid 303 using ${meta.active}`,
+            reason: meta.reason,
+            status: 'active',
+            activeBackend: meta.active,
+            requestedBackend: meta.requested,
+            retryable: !meta.gpuAvailable,
+        });
+    }
+
     private maybeToast(issue: DegradationIssue, type: 'info' | 'warning' | 'error' = 'warning'): void {
         if (!this.toastHandler) return;
         const now = Date.now();

--- a/src/utils/__tests__/engineTelemetry.test.ts
+++ b/src/utils/__tests__/engineTelemetry.test.ts
@@ -50,6 +50,11 @@ const fakeRuntime = {
   gpuReadbackBytes: null as number | null,
   gpuFallbackReason: null as string | null,
   gpuUsedGpu: null as boolean | null,
+  gpuAvailable: null as boolean | null,
+  highFidRequested: null as string | null,
+  highFidActiveEngine: null as string | null,
+  highFidRealtimeModel: null as string | null,
+  highFidFallbackReason: null as string | null,
 };
 
 describe('serializeEngineReport', () => {
@@ -117,6 +122,23 @@ describe('EngineTelemetry.snapshot', () => {
     const t = new EngineTelemetry();
     for (let i = 0; i < 300; i++) t.recordLatency('sampler', i);
     expect(t.snapshot().sampler.sampleCount).toBe(256);
+  });
+
+  it('records high-fid selection into the runtime snapshot (Phase-4)', () => {
+    const t = new EngineTelemetry();
+    t.recordHighFidSelection({
+      requested: 'gpu-highfid',
+      activeOffline: 'highfid-cpu',
+      realtime: 'stock-open303',
+      gpuAvailable: false,
+      fallbackReason: 'WebGPU unavailable',
+    });
+    const runtime = t.getRuntimeSnapshot();
+    expect(runtime.gpuAvailable).toBe(false);
+    expect(runtime.highFidRequested).toBe('gpu-highfid');
+    expect(runtime.highFidActiveEngine).toBe('highfid-cpu');
+    expect(runtime.highFidRealtimeModel).toBe('stock-open303');
+    expect(runtime.highFidFallbackReason).toBe('WebGPU unavailable');
   });
 });
 

--- a/src/utils/engineTelemetry.ts
+++ b/src/utils/engineTelemetry.ts
@@ -53,6 +53,16 @@ type RuntimeTelemetry = {
   gpuFallbackReason: string | null;
   /** Phase-3 — whether the last gpu-highfid attempt used the WGSL path. */
   gpuUsedGpu: boolean | null;
+  /** Phase-4 — navigator.gpu (or last selection probe) availability. */
+  gpuAvailable: boolean | null;
+  /** Phase-4 — last requested high-fid / model303 selection. */
+  highFidRequested: string | null;
+  /** Phase-4 — effective offline engine after fallback (gpu-highfid | highfid-cpu | …). */
+  highFidActiveEngine: string | null;
+  /** Phase-4 — realtime worklet model used while a high-fid voice is selected. */
+  highFidRealtimeModel: string | null;
+  /** Phase-4 — selection-time fallback reason (distinct from last render). */
+  highFidFallbackReason: string | null;
 };
 
 function emptyData(): TelemetryData {
@@ -164,6 +174,16 @@ export interface RuntimeSnapshot {
   gpuFallbackReason: string | null;
   /** Whether last gpu-highfid render used WebGPU. */
   gpuUsedGpu: boolean | null;
+  /** Whether WebGPU was available at last high-fid selection / probe. */
+  gpuAvailable: boolean | null;
+  /** Last requested high-fid / model303 id. */
+  highFidRequested: string | null;
+  /** Effective offline high-fid engine after selection fallback. */
+  highFidActiveEngine: string | null;
+  /** Realtime worklet model while high-fid is selected. */
+  highFidRealtimeModel: string | null;
+  /** Selection-time high-fid fallback reason. */
+  highFidFallbackReason: string | null;
 }
 
 export interface EngineReport {
@@ -242,6 +262,11 @@ export class EngineTelemetry {
     gpuReadbackBytes: null,
     gpuFallbackReason: null,
     gpuUsedGpu: null,
+    gpuAvailable: null,
+    highFidRequested: null,
+    highFidActiveEngine: null,
+    highFidRealtimeModel: null,
+    highFidFallbackReason: null,
   };
   private lastUnderrunByWorklet = new Map<string, number>();
 
@@ -333,6 +358,34 @@ export class EngineTelemetry {
     this.recordLatency('gpu-highfid', meta.latencyMs);
   }
 
+  /**
+   * Record a high-fid model selection (Phase-4 / #977) — GPU availability,
+   * requested vs effective offline engine, and realtime fallback target.
+   */
+  recordHighFidSelection(meta: {
+    requested: string;
+    activeOffline: string;
+    realtime: string;
+    gpuAvailable: boolean;
+    fallbackReason: string | null;
+  }): void {
+    this.runtime.gpuAvailable = meta.gpuAvailable;
+    this.runtime.highFidRequested = meta.requested;
+    this.runtime.highFidActiveEngine = meta.activeOffline;
+    this.runtime.highFidRealtimeModel = meta.realtime;
+    this.runtime.highFidFallbackReason = meta.fallbackReason;
+    this.registerResolution(
+      'highfid-selection',
+      meta.activeOffline,
+      meta.fallbackReason
+        ? `${meta.requested}: ${meta.fallbackReason}`
+        : meta.requested,
+    );
+    if (meta.fallbackReason) {
+      this.recordDegradation('highfid-selection', true, meta.fallbackReason);
+    }
+  }
+
   private recomputeMasterBudget(): void {
     let sum = 0;
     for (const w of this.runtime.worklets.values()) {
@@ -366,6 +419,11 @@ export class EngineTelemetry {
       gpuReadbackBytes: this.runtime.gpuReadbackBytes,
       gpuFallbackReason: this.runtime.gpuFallbackReason,
       gpuUsedGpu: this.runtime.gpuUsedGpu,
+      gpuAvailable: this.runtime.gpuAvailable,
+      highFidRequested: this.runtime.highFidRequested,
+      highFidActiveEngine: this.runtime.highFidActiveEngine,
+      highFidRealtimeModel: this.runtime.highFidRealtimeModel,
+      highFidFallbackReason: this.runtime.highFidFallbackReason,
     };
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase-4 / #977** (epic #972): make `highfid-cpu` and `gpu-highfid` discoverable, selectable, and persisted like other `model303` voices, with clear offline tooling and GPU→CPU fallback feedback.

## Changes

- **Registry** (`TB303Models.ts`): offline labels/tooltips; `normalizeTB303Model` keeps high-fid IDs; `resolveRealtimeTB303Model` + `resolveHighFidModelSelection` factory; `legacyEngine303ForModel` for song mirror
- **UI** (`Voice303Selector`): lists offline voices with Offline badge, No GPU badge, fallback status; hardware panels persist requested id and apply realtime stock to worklets
- **Telemetry / HUD**: `recordHighFidSelection`, `reportHighFidFallback`, Engine HUD rows for WebGPU / HiFi select / active / fallback
- **Docs**: `303-voices.md`, `HIGHFID_CPU_303.md`, `GPU_HIGHFID_303.md` updated for Phase-4 semantics

## Acceptance

- [x] New models in voice selector with offline tooltips
- [x] GPU model without WebGPU falls back to highfid-cpu with user-visible feedback
- [x] Saved high-fid IDs round-trip via `normalizeTB303Model`
- [x] Engine HUD reflects selection + fallback
- [x] Tests for selection, persistence, degradation

## Test plan

- [x] `CI=true pnpm exec vitest run --pool forks` on TB303Models, Voice303Selector, HighFid/WebGpu, degradation, telemetry, engine303 roundtrip
- [ ] Manual: open SYNTH A/B 303 wave → select HiFi CPU / GPU → confirm Offline badge, No GPU when applicable, live still uses stock; Ctrl+Shift+E HUD shows HiFi rows
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48430f68-922f-462e-8010-f3b349fa207b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48430f68-922f-462e-8010-f3b349fa207b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline high-fidelity TB-303 voices for freeze and export workflows.
  * Added Offline badges, tooltips, GPU availability indicators, and fallback status messaging.
  * GPU-based voices now fall back to CPU high-fidelity processing when WebGPU is unavailable.
  * Added runtime diagnostics and telemetry for high-fidelity voice selection and fallback behavior.

* **Documentation**
  * Updated voice selection and model registry documentation to clarify offline, realtime, persistence, and fallback behavior.

* **Bug Fixes**
  * Preserved offline voice selections while safely mapping them for realtime playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->