### PR TITLE
docs(303): Phase-6 high-fid architecture, changelog & help (#979)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -651,6 +651,7 @@ Only the **Vite dev server on port 5173** is required for interactive developmen
 ## Resources
 
 - **303 Voices catalog**: [docs/audio-engine/303-voices.md](docs/audio-engine/303-voices.md) — selectable TB-303 models, WASM registry, migration, tests
+- **High-fid 303 path**: [docs/audio-engine/303-gpu-highfid.md](docs/audio-engine/303-gpu-highfid.md) — offline CPU/GPU authenticity tier, fallback, FAQ (epic #972)
 - **Supertonic TTS**: https://github.com/supertone-inc/supertonic
 - **Rubberband Library**: https://breakfastquay.com/rubberband/
 - **JC-303 / Open303 / Prophecy wrappers**: `emscripten/open303_wrapper.cpp`, `emscripten/jc303_wrapper.cpp`, `emscripten/prophecy_wrapper.cpp`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### High-fidelity TB-303 offline path (epic #972 / Phase-6 #979)
+- **Multi-core offline rendering**: OpenMP oversampling (`1` / `2` / `4`) and a worker pool for freeze / export / multisample — real-time AudioWorklet latency unchanged ([OFFLINE_303_OVERSAMPLE.md](docs/audio-engine/OFFLINE_303_OVERSAMPLE.md)).
+- **High-Fidelity CPU** (`highfid-cpu`): diode-ladder offline reference with PolyBLEP oscillators and coupled accent ([HIGHFID_CPU_303.md](docs/audio-engine/HIGHFID_CPU_303.md)).
+- **GPU High-Fidelity** (`gpu-highfid`): WGSL WebGPU authenticity tier with automatic fallback to CPU when WebGPU is unavailable ([GPU_HIGHFID_303.md](docs/audio-engine/GPU_HIGHFID_303.md)).
+- **UI**: Voice303Selector lists offline voices with **HIFID** / **Offline** / **No GPU** badges; live play stays on Stock Open303 while the selected id is persisted for export.
+- **Quality gates**: spectrogram / RMS tests, offline benchmarks, cross-browser Playwright matrix, and stress tests ([303-A-B-checklist.md](docs/audio-engine/303-A-B-checklist.md)).
+- **Docs**: architecture & FAQ — [303-gpu-highfid.md](docs/audio-engine/303-gpu-highfid.md).
+
 ### In-app discoverability (closes #632, #633, #634)
 - Searchable **Help** modal (`?` key): Search · Guides · Shortcuts tabs
 - Dismissible **What's New** checklist for major workflows

--- a/DOCS.md
+++ b/DOCS.md
@@ -40,6 +40,7 @@ Only these markdown files may live at the repository root. `pnpm run check:root`
 | [docs/features-implementation.md](docs/features-implementation.md) | Feature implementation tracking notes |
 | [docs/plan.md](docs/plan.md) | High-level project planning notes |
 | [docs/automation.md](docs/automation.md) | Automation scheduler + RBS import architecture |
+| [docs/PERFORMANCE_BUDGET.md](docs/PERFORMANCE_BUDGET.md) | Audio-thread budget, auto-degrade order, offline 303 metrics |
 
 ---
 
@@ -50,7 +51,9 @@ Only these markdown files may live at the repository root. `pnpm run check:root`
 | [HARMONIZER_IMPLEMENTATION.md](docs/audio-engine/HARMONIZER_IMPLEMENTATION.md) | Vocal harmonizer engine design |
 | [JC303_STACK_OVERFLOW_FIX.md](docs/audio-engine/JC303_STACK_OVERFLOW_FIX.md) | JC-303 WASM stack overflow fix |
 | [303-voices.md](docs/audio-engine/303-voices.md) | Selectable TB-303 voice catalog, WASM registry, migration, and tests |
+| [303-gpu-highfid.md](docs/audio-engine/303-gpu-highfid.md) | High-fid 303 architecture, enablement, fallback, FAQ & roadmap (epic #972 / Phase-6) |
 | [303-authenticity-gaps.md](docs/audio-engine/303-authenticity-gaps.md) | Phase-0 TB-303 authenticity gap audit, thresholds, and baseline links (epic #972) |
+| [303-A-B-checklist.md](docs/audio-engine/303-A-B-checklist.md) | Manual + automated high-fid A/B checklist (Phase-5) |
 | [303-baseline/](docs/audio-engine/303-baseline/) | Canonical-pattern engine baseline WAVs + hardware capture protocol |
 | [303-baseline-spectra/](docs/audio-engine/303-baseline-spectra/) | Spectrogram PNGs and RMS/band metrics for Phase-0 baselines |
 | [jc303-prophecy.md](docs/audio-engine/jc303-prophecy.md) | Open303/JC303 switching and Prophecy routing |

--- a/docs/PERFORMANCE_BUDGET.md
+++ b/docs/PERFORMANCE_BUDGET.md
@@ -59,19 +59,23 @@ Implementation: `src/utils/performanceBudget.ts` (`DEGRADE_ORDER`).
 
 ## Offline 303 rendering (does not affect audio-thread budget)
 
-Heavy offline jobs (freeze, export, multisample, 4× oversampled 303) run on a
-**worker pool** (`src/audio/OfflineRenderer.ts`). Telemetry fields:
+Heavy offline jobs (freeze, export, multisample, 4× oversampled 303, and
+high-fid CPU/GPU authenticity tiers) run on a **worker pool** /
+`WebGpu303Engine` (`src/audio/OfflineRenderer.ts`). Telemetry fields:
 
 | Field | Meaning |
 |-------|---------|
 | `offlineRenderOversample` | Last render factor (`1` / `2` / `4`) |
 | `offlineRenderThreadCount` | Worker / OpenMP thread hint used |
 | `offlineRenderLatencyMs` | Wall-clock latency of last offline render |
+| `gpuRenderLatencyMs` / `gpuReadbackBytes` / `gpuUsedGpu` | GPU high-fid path (Phase-3) |
+| `gpuFallbackReason` | Why GPU fell back to `highfid-cpu` (null if GPU used) |
 
 These are shown in Engine HUD under **Offline 303**. They never feed
 `masterBudgetPercent` — only AudioWorklet `process()` cost does.
 
-See `docs/audio-engine/OFFLINE_303_OVERSAMPLE.md`.
+See [OFFLINE_303_OVERSAMPLE.md](audio-engine/OFFLINE_303_OVERSAMPLE.md) and
+[303-gpu-highfid.md](audio-engine/303-gpu-highfid.md).
 
 ## Synthetic stress test
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ For a quick-start overview see the root [README.md](../README.md).
 | File | Summary |
 |------|---------|
 | [automation.md](automation.md) | Current automation scheduler + RBS import architecture and testing touchpoints |
+| [PERFORMANCE_BUDGET.md](PERFORMANCE_BUDGET.md) | Audio-thread budget, auto-degrade order, offline 303 metrics |
 
 ---
 
@@ -22,9 +23,12 @@ For a quick-start overview see the root [README.md](../README.md).
 | [HARMONIZER_IMPLEMENTATION.md](audio-engine/HARMONIZER_IMPLEMENTATION.md) | Vocal harmonizer engine design and implementation details |
 | [JC303_STACK_OVERFLOW_FIX.md](audio-engine/JC303_STACK_OVERFLOW_FIX.md) | Fix for stack overflow in the JC-303 TB-303 clone WASM build |
 | [303-voices.md](audio-engine/303-voices.md) | Selectable TB-303 voice catalog, WASM registry, migration, and tests |
+| [303-gpu-highfid.md](audio-engine/303-gpu-highfid.md) | High-fid 303 architecture, enablement, fallback, FAQ & roadmap (epic #972 / Phase-6) |
 | [303-authenticity-gaps.md](audio-engine/303-authenticity-gaps.md) | Phase-0 TB-303 authenticity gap audit, thresholds, and baseline links (epic #972) |
+| [303-A-B-checklist.md](audio-engine/303-A-B-checklist.md) | Manual + automated high-fid A/B checklist (Phase-5) |
 | [303-baseline/](audio-engine/303-baseline/) | Canonical-pattern engine baseline WAVs + hardware capture protocol |
 | [303-baseline-spectra/](audio-engine/303-baseline-spectra/) | Spectrogram PNGs and RMS/band metrics for Phase-0 baselines |
+| [OFFLINE_303_OVERSAMPLE.md](audio-engine/OFFLINE_303_OVERSAMPLE.md) | Phase-1 offline 303 oversampling + worker pool |
 | [HIGHFID_CPU_303.md](audio-engine/HIGHFID_CPU_303.md) | Phase-2 diode-ladder highfid-cpu offline reference |
 | [GPU_HIGHFID_303.md](audio-engine/GPU_HIGHFID_303.md) | Phase-3 WGSL gpu-highfid offline authenticity tier |
 | [jc303-prophecy.md](audio-engine/jc303-prophecy.md) | Current per-voice Open303/JC303 switching and Prophecy integration notes |

--- a/docs/audio-engine/303-A-B-checklist.md
+++ b/docs/audio-engine/303-A-B-checklist.md
@@ -125,6 +125,7 @@ Before merging high-fid engine changes:
 
 | Doc | Role |
 |-----|------|
+| [303-gpu-highfid.md](./303-gpu-highfid.md) | Architecture, enablement, FAQ, roadmap (Phase-6) |
 | [303-authenticity-gaps.md](./303-authenticity-gaps.md) | Gap catalog G1–G7 + acceptance thresholds |
 | [HIGHFID_CPU_303.md](./HIGHFID_CPU_303.md) | Phase-2 diode-ladder CPU reference |
 | [GPU_HIGHFID_303.md](./GPU_HIGHFID_303.md) | Phase-3 WGSL offline path |

--- a/docs/audio-engine/303-gpu-highfid.md
+++ b/docs/audio-engine/303-gpu-highfid.md
@@ -1,0 +1,307 @@
+# High-Fidelity TB-303 Path — Architecture & Usage
+
+**Epic**: [#972](https://github.com/ford442/web_sequencer/issues/972) — Multi-core + WGSL High-Fidelity TB-303  
+**Phase-6**: [#979](https://github.com/ford442/web_sequencer/issues/979) — Docs, changelog & rollout  
+
+This is the **public architecture / usage guide** for Hyphon’s high-fidelity
+303 option. Per-phase implementation notes live in the linked docs below;
+start here for how the pieces fit together.
+
+| Audience | Read |
+|----------|------|
+| Users / producers | [Enable a high-fid voice](#how-to-enable), [UI badges](#ui-badges--status), [FAQ](#faq) |
+| Maintainers | [Architecture](#architecture), [Fallback chain](#fallback-chain), [Performance & memory](#performance--memory) |
+| Contributors | Per-phase docs in [Related](#related-docs) + [Roadmap](#roadmap--next-steps) |
+
+---
+
+## What “high-fidelity” means here
+
+Hyphon keeps the **real-time AudioWorklet** path (Open303 / JC-303) latency-safe
+and unchanged. Higher authenticity models run **offline only** — freeze,
+WAV/XM export, and multisample generation — with a clear UI story and automatic
+fallback when WebGPU or heavy CPU is unavailable.
+
+| Model id | Label (UI) | Where it runs | Family badge |
+|----------|------------|---------------|--------------|
+| `highfid-cpu` | High-Fidelity CPU (offline) | Worker / OpenMP diode-ladder | **HIFID** + amber **Offline** |
+| `gpu-highfid` | GPU High-Fidelity (offline) | WebGPU WGSL compute (else CPU) | **HIFID** + **Offline** (+ **No GPU** if needed) |
+
+Realtime playback of a part that has a high-fid model selected still uses
+**Stock Open303** via `resolveRealtimeTB303Model`. The requested id is
+persisted in the song so freeze/export pick up the authenticity tier later.
+
+---
+
+## Architecture
+
+### Real-time vs offline
+
+```mermaid
+flowchart TB
+  subgraph UI["UI / song state"]
+    SEL["Voice303Selector\nmodel303 persisted"]
+  end
+
+  subgraph RT["Real-time path (AudioWorklet)"]
+    RES["resolveRealtimeTB303Model"]
+    WL["open303-processor\nstock-open303 / jc303 / profiles"]
+    RES --> WL
+    WL --> OUT["Speakers / master bus"]
+  end
+
+  subgraph OFF["Offline path (freeze / export / multisample)"]
+    HF["resolveHighFidModelSelection"]
+    GPU["WebGpu303Engine\ngpu-highfid WGSL"]
+    CPU["OfflineHighFid303Engine\nhighfid-cpu diode-ladder"]
+    OS["Open303 offline + OVERSAMPLE 1/2/4\nworker pool / OpenMP"]
+    HF -->|WebGPU OK| GPU
+    HF -->|no WebGPU / error| CPU
+    HF -->|stock / jc303 / profiles| OS
+    GPU --> WAV["AudioBuffer / WAV / multisamples"]
+    CPU --> WAV
+    OS --> WAV
+  end
+
+  SEL -->|play| RES
+  SEL -->|freeze / export| HF
+```
+
+### Stack by phase
+
+```mermaid
+flowchart LR
+  P0["Phase-0\nBaselines & gaps"] --> P1["Phase-1\nOversample + workers"]
+  P1 --> P2["Phase-2\nhighfid-cpu"]
+  P2 --> P3["Phase-3\ngpu-highfid WGSL"]
+  P3 --> P4["Phase-4\nRegistry / UI / HUD"]
+  P4 --> P5["Phase-5\nSpectrogram + E2E"]
+  P5 --> P6["Phase-6\nDocs & release"]
+```
+
+| Phase | Deliverable | Doc |
+|-------|-------------|-----|
+| 0 | Soft-oracle baselines + gap thresholds | [303-authenticity-gaps.md](./303-authenticity-gaps.md) |
+| 1 | Offline oversampling + worker pool | [OFFLINE_303_OVERSAMPLE.md](./OFFLINE_303_OVERSAMPLE.md) |
+| 2 | Diode-ladder CPU oracle | [HIGHFID_CPU_303.md](./HIGHFID_CPU_303.md) |
+| 3 | WGSL GPU authenticity tier | [GPU_HIGHFID_303.md](./GPU_HIGHFID_303.md) |
+| 4 | Registry, selector badges, degradation | [303-voices.md](./303-voices.md) |
+| 5 | Spectrogram gates, benchmarks, Playwright | [303-A-B-checklist.md](./303-A-B-checklist.md) |
+| 6 | This guide + changelog | *(you are here)* |
+
+---
+
+## How to enable
+
+### In the app
+
+1. Initialize audio (**INITIALIZE SYSTEM**).
+2. Open **SYNTH A**, **SYNTH B**, or **BASS 2** and select a `303-*` waveform.
+3. In **303 Voice**, pick **High-Fidelity CPU (offline)** or **GPU High-Fidelity (offline)**.
+4. Live play uses Stock Open303; status line shows  
+   `Offline engine: highfid-cpu|gpu-highfid · live uses Stock Open303`.
+5. Use freeze / export / multisample to hear the authenticity tier.
+
+### From code
+
+```ts
+import { render303Offline } from '@/audio/OfflineRenderer';
+import { makeCanonical64StepPattern } from '@/audio/OfflineRenderer';
+
+// CPU diode-ladder @ 4× oversample (sync path for tests / no Worker)
+await render303Offline('highfid-cpu', makeCanonical64StepPattern(), {
+  oversample: 4,
+  sync: true,
+});
+
+// GPU path — falls back to highfid-cpu when WebGPU is missing
+await render303Offline('gpu-highfid', makeCanonical64StepPattern(), {
+  oversample: 4,
+});
+```
+
+Registry helpers (`src/engines/TB303Models.ts`):
+
+| Helper | Role |
+|--------|------|
+| `normalizeTB303Model` | Persist requested id (incl. offline high-fid) |
+| `resolveRealtimeTB303Model` | Map high-fid → `stock-open303` for AudioWorklet |
+| `resolveHighFidModelSelection` | Pick offline engine + optional fallback reason |
+| `getAvailableTB303Models({ includeOfflineOnly: true })` | Selector list |
+
+---
+
+## Fallback chain
+
+```
+gpu-highfid  →  highfid-cpu  →  stock Open303 / JC-303  →  JS DSP
+```
+
+| Condition | Behaviour | User-visible |
+|-----------|-----------|--------------|
+| WebGPU present, shader OK | Offline render on WGSL | Status: `Offline engine: gpu-highfid` |
+| No WebGPU / compile / alloc / readback fail | Offline render on diode-ladder CPU | **No GPU** badge + amber status / degradation banner |
+| High-fid selected for live play | AudioWorklet stays on Stock Open303 | Status mentions live uses Stock Open303 |
+| Worker has no WebGPU | Worker always uses highfid-cpu for `gpu-highfid` jobs | Telemetry `gpuFallbackReason` / `gpuUsedGpu: false` |
+
+Never crashes the AudioWorklet when WebGPU is absent (Firefox / Safari / headless CI).
+
+---
+
+## UI badges & status
+
+Matches `Voice303Selector` and [303-A-B-checklist.md](./303-A-B-checklist.md):
+
+| Indicator | Meaning |
+|-----------|---------|
+| **OPEN303** / **JC303** | Realtime engine family |
+| **HIFID** | Offline high-fidelity family selected |
+| Amber **Offline** pill on a voice row | Voice is freeze/export/multisample only |
+| **No GPU** | WebGPU unavailable; GPU High-Fidelity falls back to CPU |
+| Status line | Effective offline engine + live Stock Open303 reminder |
+| Engine HUD (**Ctrl+Shift+E**) → Offline 303 | Oversample, thread count, latency, GPU telemetry |
+
+In-app Help (`?`) → **High-fidelity 303 (offline)** and the updated **303 Voice selector** topic.
+
+---
+
+## Performance & memory
+
+Guidelines (order-of-magnitude on a modern laptop). Soft budgets — not hard CI
+fails unless noted in Phase-5 jobs.
+
+| Workload | Soft budget | Notes |
+|----------|-------------|-------|
+| Stock Open303 offline, 64-step @ 4× | ~200–400 ms | [OFFLINE_303_OVERSAMPLE.md](./OFFLINE_303_OVERSAMPLE.md) |
+| `highfid-cpu` canonical 4-step @ 4× | &lt; 500 ms | Benchmark script |
+| `highfid-cpu` 64-step stress @ 4× | &lt; 3 s | Worker pool OK |
+| `gpu-highfid` multi-second pattern | ~150–300 ms GPU wall (device-dependent) | CPU fallback slower in CI |
+| Concurrent offline renders | 8× highfid-cpu without OOM | `Offline303Stress.test.ts` |
+
+**Memory tips**
+
+- Prefer worker pool over main-thread sync for long exports.
+- GPU path allocates a readback buffer; oversized jobs fall back to CPU
+  (`MAX_BUFFER_SIZE` in `WebGpu303Engine`).
+- Offline metrics **do not** feed `masterBudgetPercent` — see
+  [PERFORMANCE_BUDGET.md](../PERFORMANCE_BUDGET.md).
+
+```bash
+pnpm exec vite-node scripts/benchmark_offline303.mjs
+bash scripts/benchmark_highfid303.sh
+CI=true pnpm exec vitest run src/__tests__/Offline303Stress.test.ts --pool forks
+```
+
+---
+
+## FAQ
+
+### Why offline only?
+
+The diode-ladder and WGSL paths are recursive / heavy. Running them on the
+AudioWorklet would risk underruns and violate epic principle #1: **real-time
+latency must not regress**. Offline jobs run on workers / OpenMP / GPU with
+telemetry outside the master audio-thread budget.
+
+### Why WebGPU?
+
+WebGPU compute is the browser path for a full nonlinear voice without blocking
+audio. Chrome/Edge typically expose it; Firefox/Safari often do not yet — hence
+the automatic **highfid-cpu** fallback and **No GPU** badge.
+
+### Will my song sound different when I reopen it?
+
+The **persisted** `model303` stays `gpu-highfid` or `highfid-cpu`. Live play
+still uses Stock Open303 until you freeze/export. On a machine without WebGPU,
+offline render of `gpu-highfid` silently uses CPU (same topology) so exports
+remain usable.
+
+### How does this relate to JC303 / character voices?
+
+JC303 and open303 coefficient profiles (`rebirth-*`, `mb33-mkii`, …) remain
+realtime-capable. High-fid is a separate authenticity **tier** for offline
+renders, not a replacement for those voices. Catalog:
+[303-voices.md](./303-voices.md).
+
+### How do I A/B authenticity?
+
+1. Automated: `TB303SpectrogramQuality.test.ts` + baseline WAVs in
+   `303-baseline/`.
+2. Manual: [303-A-B-checklist.md](./303-A-B-checklist.md).
+3. Optional local render: `pnpm exec vite-node scripts/render_gpu_highfid_wav.mjs`.
+
+### Can I edit diode-ladder coefficients in the UI?
+
+Not yet — see [Roadmap](#roadmap--next-steps).
+
+---
+
+## Demo renders (optional)
+
+Committed Phase-0/2 baselines already cover the canonical 4-step pattern:
+
+| File | Engine |
+|------|--------|
+| `docs/audio-engine/303-baseline/stock-open303_canonical.wav` | Stock |
+| `docs/audio-engine/303-baseline/jc303_canonical.wav` | Soft oracle |
+| `docs/audio-engine/303-baseline/highfid-cpu_canonical.wav` | High-fid CPU |
+
+Generate a 1 s GPU/CPU-equivalent clip locally (not committed — regenerable):
+
+```bash
+pnpm exec vite-node scripts/render_gpu_highfid_wav.mjs
+# → /tmp/gpu-highfid_1s.wav
+```
+
+Regenerate spectrograms / metrics after engine changes:
+
+```bash
+bash scripts/generate_303_baselines.sh
+```
+
+---
+
+## Roadmap / next steps
+
+Stable for freeze/export. Future work (not blocking epic close):
+
+1. **Real-time GPU audio** when browsers offer low-latency WebGPU ↔ AudioWorklet
+   bridging without underruns.
+2. **Live A/B** — two synced instances (stock vs high-fid) for audition.
+3. **User-editable coefficients** for the diode-ladder oracle.
+4. **Hardware TB-303 reference WAV** to replace the jc303 soft oracle in
+   absolute gates ([303-authenticity-gaps.md](./303-authenticity-gaps.md)).
+
+---
+
+## Epic completeness review (#972)
+
+| Phase | Issue | PR (merged) | Status |
+|-------|-------|-------------|--------|
+| 0 Gap audit & baselines | #973 | #1001 / #1002 | Done |
+| 1 Oversample + workers | #974 | #1004 | Done |
+| 2 highfid-cpu | #975 | #1005 | Done |
+| 3 gpu-highfid WGSL | #976 | #1006 | Done |
+| 4 Registry / UI / degradation | #977 | #1010 | Done |
+| 5 Spectrogram / E2E / stress | #978 | #1011 | Code merged — close issue after verify |
+| 6 Docs / changelog / rollout | #979 | *(this change)* | Docs + help + CHANGELOG |
+
+**Close criteria for the epic:** merge Phase-6 docs; confirm UI badges match this guide;
+close #978 / #979 / #972. Remaining roadmap items (live GPU audio, live A/B,
+editable coefficients, hardware reference WAV) are **follow-ups**, not blockers.
+
+---
+
+## Related docs
+
+| Doc | Role |
+|-----|------|
+| [303-voices.md](./303-voices.md) | Full voice catalog + registry contract |
+| [303-authenticity-gaps.md](./303-authenticity-gaps.md) | Gap audit G1–G7 + thresholds |
+| [OFFLINE_303_OVERSAMPLE.md](./OFFLINE_303_OVERSAMPLE.md) | Oversample + worker pool |
+| [HIGHFID_CPU_303.md](./HIGHFID_CPU_303.md) | CPU diode-ladder |
+| [GPU_HIGHFID_303.md](./GPU_HIGHFID_303.md) | WGSL engine API |
+| [303-A-B-checklist.md](./303-A-B-checklist.md) | Manual + automated release checklist |
+| [OPENMP_IMPLEMENTATION.md](./OPENMP_IMPLEMENTATION.md) | OpenMP DSP helpers |
+| [PERFORMANCE_BUDGET.md](../PERFORMANCE_BUDGET.md) | Audio-thread budget vs offline metrics |
+| [CHANGELOG.md](../../CHANGELOG.md) | Release notes |

--- a/docs/audio-engine/303-voices.md
+++ b/docs/audio-engine/303-voices.md
@@ -32,7 +32,7 @@ songs — **never rename** a shipped id.
 | `highfid-cpu` | High-Fidelity CPU (offline) | `highfid` | Phase-2 diode-ladder reference @ 4× OS — **offline only** | TB-303 authenticity tier |
 | `gpu-highfid` | GPU High-Fidelity (offline) | `highfid` | Phase-3 WGSL diode-ladder — **offline only**; falls back to CPU without WebGPU | TB-303 authenticity tier |
 
-**Status badges** (Voice303Selector): realtime voices show **OPEN303** / **JC303**; offline high-fid shows **HIFID** + amber **Offline** pill. When WebGPU is unavailable, a **No GPU** badge appears and offline render uses `highfid-cpu`. See [303-A-B-checklist.md](./303-A-B-checklist.md) for manual verification and [303-authenticity-gaps.md](./303-authenticity-gaps.md) for automated thresholds.
+**Status badges** (Voice303Selector): realtime voices show **OPEN303** / **JC303**; offline high-fid shows **HIFID** + amber **Offline** pill. When WebGPU is unavailable, a **No GPU** badge appears and offline render uses `highfid-cpu`. See the architecture guide [303-gpu-highfid.md](./303-gpu-highfid.md), [303-A-B-checklist.md](./303-A-B-checklist.md) for manual verification, and [303-authenticity-gaps.md](./303-authenticity-gaps.md) for automated thresholds.
 
 Catalogued-but-unshipped voices are hidden from the UI and normalize to the
 stock voice of their family when loaded from a song.
@@ -284,7 +284,8 @@ normalization all read the registry.
 ### Offline-only high-fidelity voices (Phase-2+)
 
 `highfid-cpu` and `gpu-highfid` are special cases: `family: 'highfid'`,
-`offlineOnly: true`.
+`offlineOnly: true`. Full architecture, enablement, FAQ, and roadmap:
+**[303-gpu-highfid.md](./303-gpu-highfid.md)**.
 
 - `highfid-cpu` — C++ / TS diode-ladder oracle ([HIGHFID_CPU_303.md](./HIGHFID_CPU_303.md)).
 - `gpu-highfid` — WGSL WebGPU path with automatic highfid-cpu fallback
@@ -296,6 +297,16 @@ export / multisample; live playback stays on Stock Open303 via
 `resolveRealtimeTB303Model`. Choosing `gpu-highfid` without WebGPU keeps the
 persisted id and falls back offline to `highfid-cpu` through
 `resolveHighFidModelSelection` (Engine HUD + degradation banner).
+
+Tooltip / status copy (must stay aligned with docs):
+
+| Surface | Copy |
+|---------|------|
+| `highfid-cpu` description | Offline only — best for freeze / export / multisample. Diode-ladder CPU reference (Phase-2). Live playback uses Stock Open303. |
+| `gpu-highfid` description | Offline only — best for freeze / export / multisample. WGSL diode-ladder (Phase-3); falls back to High-Fidelity CPU when WebGPU is unavailable. Live playback uses Stock Open303. |
+| **No GPU** badge title | WebGPU unavailable — GPU High-Fidelity falls back to High-Fidelity CPU for offline render |
+| Status (no fallback) | `Offline engine: {id} · live uses Stock Open303` |
+| Status (GPU→CPU) | `WebGPU unavailable — using High-Fidelity CPU for offline render` |
 
 `getAvailableTB303Models()` (no opts) still excludes offline voices for
 realtime-only call sites.

--- a/docs/audio-engine/GPU_HIGHFID_303.md
+++ b/docs/audio-engine/GPU_HIGHFID_303.md
@@ -127,6 +127,7 @@ OfflineRenderer wiring, telemetry fields.
 
 ## Related
 
+- [303-gpu-highfid.md](./303-gpu-highfid.md) — architecture / usage / FAQ (Phase-6)
 - [HIGHFID_CPU_303.md](./HIGHFID_CPU_303.md) (Phase-2)
 - [303-authenticity-gaps.md](./303-authenticity-gaps.md) (Phase-0 thresholds)
 - [OFFLINE_303_OVERSAMPLE.md](./OFFLINE_303_OVERSAMPLE.md) (Phase-1)

--- a/docs/audio-engine/HIGHFID_CPU_303.md
+++ b/docs/audio-engine/HIGHFID_CPU_303.md
@@ -105,6 +105,7 @@ Phase-3 WGSL path: [`GPU_HIGHFID_303.md`](./GPU_HIGHFID_303.md).
 
 ## Related
 
+- [303-gpu-highfid.md](./303-gpu-highfid.md) — architecture / usage / FAQ (Phase-6)
 - [303-authenticity-gaps.md](./303-authenticity-gaps.md) (Phase-0)
 - [OFFLINE_303_OVERSAMPLE.md](./OFFLINE_303_OVERSAMPLE.md) (Phase-1)
 - [GPU_HIGHFID_303.md](./GPU_HIGHFID_303.md) (Phase-3)

--- a/docs/audio-engine/OFFLINE_303_OVERSAMPLE.md
+++ b/docs/audio-engine/OFFLINE_303_OVERSAMPLE.md
@@ -84,6 +84,7 @@ a typical multi-core laptop (sync path). Worker overhead is small relative to DS
 
 ## Related
 
+- [303-gpu-highfid.md](./303-gpu-highfid.md) — architecture / usage / FAQ (Phase-6)
 - [OPENMP_IMPLEMENTATION.md](./OPENMP_IMPLEMENTATION.md)
 - [303-voices.md](./303-voices.md)
 - [303-authenticity-gaps.md](./303-authenticity-gaps.md) (Phase-0)

--- a/docs/audio-engine/OPENMP_IMPLEMENTATION.md
+++ b/docs/audio-engine/OPENMP_IMPLEMENTATION.md
@@ -98,11 +98,17 @@ Potential additions to leverage OpenMP further:
 
 ### Phase-1 offline 303 (done)
 
-See [OFFLINE_303_OVERSAMPLE.md](./OFFLINE_303_OVERSAMPLE.md):
+See [OFFLINE_303_OVERSAMPLE.md](./OFFLINE_303_OVERSAMPLE.md) and the umbrella
+guide [303-gpu-highfid.md](./303-gpu-highfid.md):
 
 - Per-instance `OVERSAMPLE_FACTOR` (1|2|4) on Open303
 - `mixVoiceBuffers` / `downsampleBox` OpenMP helpers
 - Worker pool + `render303Offline()` for freeze/export paths
+- High-fid CPU (`highfid-cpu`) reuses the same offline/OpenMP oversample flag
+  for diode-ladder renders; GPU high-fid stays off the audio thread
+
+Real-time AudioWorklet paths keep factor `1` and do **not** call these OpenMP
+helpers from `process()`.
 
 ## Technical Details
 

--- a/docs/ui/HELP_DISCOVERY.md
+++ b/docs/ui/HELP_DISCOVERY.md
@@ -64,7 +64,10 @@ Bump `HELP_WHATS_NEW_VERSION` in the same file to re-show the banner.
 |---------------|--------------|
 | How do I automate a filter? | `automate filter` |
 | Switch to authentic 303? | `jc303` or `authentic 303` |
+| High-fidelity / GPU 303? | `high-fidelity` or `gpu-highfid` |
 | Prophecy vowels? | `prophecy formant` |
 | Record knob movement? | `rec auto` |
 | Import ReBirth? | `rbs` |
 | Sampler speech? | `tts` |
+
+High-fid architecture & badges: [303-gpu-highfid.md](../audio-engine/303-gpu-highfid.md).

--- a/src/__tests__/helpTopics.test.ts
+++ b/src/__tests__/helpTopics.test.ts
@@ -7,6 +7,16 @@ describe('helpTopics', () => {
     expect(results.some((t) => t.id === 'engine-303-switch')).toBe(true);
   });
 
+  it('finds high-fidelity offline 303 topic', () => {
+    const results = searchHelpTopics('high-fidelity offline');
+    expect(results.some((t) => t.id === 'highfid-303-offline')).toBe(true);
+  });
+
+  it('finds gpu highfid by keyword', () => {
+    const results = searchHelpTopics('gpu-highfid');
+    expect(results.some((t) => t.id === 'highfid-303-offline')).toBe(true);
+  });
+
   it('finds automation filter topic', () => {
     const results = searchHelpTopics('automate filter');
     expect(results.some((t) => t.id === 'automation-filter')).toBe(true);

--- a/src/content/helpTopics.ts
+++ b/src/content/helpTopics.ts
@@ -40,22 +40,69 @@ export const HELP_CATEGORY_LABELS: Record<HelpCategory, string> = {
 export const HELP_TOPICS: HelpTopic[] = [
   {
     id: 'engine-303-switch',
-    title: 'Switch to authentic JC303',
-    summary: 'Pick a 303 waveform, then choose Authentic JC303 in the Engine panel on the rack overlay.',
+    title: '303 Voice selector (Open303 / JC303 / high-fid)',
+    summary:
+      'Pick a 303 waveform, then choose a voice in the 303 Voice panel — Stock Open303, Authentic JC303, character profiles, or offline high-fidelity.',
     body:
-      'Each 303 voice (SYNTH A lead, SYNTH B, BASS 2) can run the built-in Open303 WASM or the authentic rosic::Open303 engine from jc303_wasm.\n\n' +
-      'Select a 303-* waveform in the oscillator variant selector. The Engine panel appears on the rack module overlay — tap Authentic JC303 for the vintage DSP path.',
+      'Each 303 track (SYNTH A lead, SYNTH B, BASS 2) picks a voice independently via the 303 Voice selector.\n\n' +
+      'Realtime voices: Stock Open303, Authentic JC303, and open303 coefficient profiles (1ink303, Experimental, ReBirth-inspired, MB33, Raveolution).\n\n' +
+      'Offline high-fid voices (amber Offline badge): High-Fidelity CPU and GPU High-Fidelity. Live playback stays on Stock Open303; the selected id is used for freeze / export / multisample. Without WebGPU, a No GPU badge appears and GPU High-Fidelity falls back to High-Fidelity CPU.',
     keywords: [
-      '303', 'jc303', 'open303', 'tb-303', 'authentic', 'engine', 'switch', 'bass', 'synth',
+      '303',
+      'jc303',
+      'open303',
+      'tb-303',
+      'authentic',
+      'engine',
+      'switch',
+      'bass',
+      'synth',
+      'voice',
+      'highfid',
+      'high-fidelity',
+      'gpu',
+      'offline',
+      'hifid',
     ],
     category: 'engine',
     steps: [
       'Select SYNTH A, SYNTH B, or BASS 2 in the rack.',
       'Choose a 303-saw or 303-sqr waveform variant.',
-      'On the overlay panel, open Engine and tap Authentic JC303.',
-      'Play a pattern — each voice keeps its own engine setting.',
+      'In 303 Voice, tap Stock Open303, Authentic JC303, a character profile, or an Offline high-fid voice.',
+      'Play for realtime; use freeze / export / multisample to hear high-fid engines.',
     ],
-    docLink: 'docs/audio-engine/jc303-prophecy.md',
+    docLink: 'docs/audio-engine/303-gpu-highfid.md',
+  },
+  {
+    id: 'highfid-303-offline',
+    title: 'High-fidelity 303 (offline)',
+    summary:
+      'Opt-in High-Fidelity CPU / GPU voices for freeze, export, and multisample — live play stays latency-safe on Stock Open303.',
+    body:
+      'High-fidelity models close authenticity gaps with a diode-ladder topology (CPU OpenMP or WebGPU WGSL). They are offline-only so the AudioWorklet never regresses.\n\n' +
+      'Select High-Fidelity CPU (offline) or GPU High-Fidelity (offline) in 303 Voice. Status shows the effective offline engine; No GPU means WebGPU is missing and GPU selections fall back to CPU. Engine HUD (Ctrl+Shift+E) shows Offline 303 oversample, threads, and GPU telemetry.',
+    keywords: [
+      'highfid',
+      'high-fidelity',
+      'gpu-highfid',
+      'webgpu',
+      'offline',
+      'freeze',
+      'export',
+      'multisample',
+      'oversample',
+      'diode',
+      'ladder',
+      '303',
+    ],
+    category: 'engine',
+    steps: [
+      'Open SYNTH A, SYNTH B, or BASS 2 and select a 303-* waveform.',
+      'In 303 Voice, choose High-Fidelity CPU (offline) or GPU High-Fidelity (offline).',
+      'Confirm the status line (offline engine + live uses Stock Open303).',
+      'Run freeze, WAV export, or 303 multisample generation to use the authenticity tier.',
+    ],
+    docLink: 'docs/audio-engine/303-gpu-highfid.md',
   },
   {
     id: 'prophecy-formants',
@@ -246,7 +293,8 @@ export function searchHelpTopics(query: string): HelpTopic[] {
 
 /** Checklist items shown in the dismissible What's New banner. */
 export const WHATS_NEW_ITEMS = [
-  { id: 'engine-303-switch', label: 'Per-voice authentic JC303 engine' },
+  { id: 'highfid-303-offline', label: 'High-fidelity 303 (offline CPU / GPU)' },
+  { id: 'engine-303-switch', label: '303 Voice selector (Open303 / JC303 / high-fid)' },
   { id: 'prophecy-formants', label: 'Prophecy formant oscillators' },
   { id: 'automation-filter', label: 'Knob automation lanes + REC AUTO' },
   { id: 'rbs-import', label: 'ReBirth .rbs import' },
@@ -256,4 +304,4 @@ export const WHATS_NEW_ITEMS = [
 ] as const;
 
 /** Bump when adding major features to re-show the What's New banner. */
-export const HELP_WHATS_NEW_VERSION = '2026.07';
+export const HELP_WHATS_NEW_VERSION = '2026.07-highfid';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes Phase-6 of epic #972 ([#979](https://github.com/ford442/web_sequencer/issues/979)): public docs, changelog, and help copy for the offline high-fidelity TB-303 path (multi-core oversampling + `highfid-cpu` / `gpu-highfid`).

Blocked-by Phase-5 (#978 / #1011) is already on `main`.

## What’s included

- **New** [`docs/audio-engine/303-gpu-highfid.md`](docs/audio-engine/303-gpu-highfid.md) — architecture (Mermaid: realtime vs offline), enablement, fallback chain, performance/memory, FAQ, demo render pointers, roadmap, epic completeness table
- **Updated** `303-voices.md` (high-fid tooltip/status copy table), OpenMP + performance budget notes, `DOCS.md` / `docs/README.md` / `AGENTS.md` indexes
- **CHANGELOG** Unreleased entry for multi-core offline + CPU/GPU high-fid
- **In-app help**: refreshed 303 Voice topic, new High-fidelity 303 topic, What’s New bump — aligned with `Voice303Selector` badges (`HIFID` / `Offline` / `No GPU`) and status lines

## Acceptance

- [x] Docs + indexes; relative links checked (0 broken among touched files)
- [x] Changelog mentions high-fid work
- [x] UI tooltips / help / status copy match the architecture guide
- [x] Epic completeness review included (close #978 / #979 / #972 after merge)

## Test plan

- [x] `CI=true pnpm exec vitest run --pool forks src/__tests__/helpTopics.test.ts src/components/__tests__/Voice303Selector.test.tsx`
- [ ] Spot-check Help (`?`) → “High-fidelity 303” / “303 Voice selector”
- [ ] Spot-check Voice303Selector badges vs [303-gpu-highfid.md](docs/audio-engine/303-gpu-highfid.md) UI section

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-317255ff-483b-4871-a3df-2108a4f20216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-317255ff-483b-4871-a3df-2108a4f20216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

