### PR TITLE
feat: implement expressive note transitions for vowels

### DIFF
--- a/.Jules/agent_plan.md
+++ b/.Jules/agent_plan.md
@@ -6,8 +6,10 @@
 ## Innovation Lab
 - [x] Implement reverse TTS sample per step
 - [x] Implement Phoneme Envelope shaping per step
-- [ ] Implement Expressive Note Transitions for Vowels
+- [x] Implement Expressive Note Transitions for Vowels
 
+- [ ] Optimize TTS memory footprint
+- [ ] Add multi-voice unison detune
 - [x] Implement Lyric Track parsing
 - [x] Implement Vowel-Preserving Time Stretch for TTS voices
 - [x] Implement per-phoneme pitch drift/vibrato

--- a/src/engines/singing-voice/playback.ts
+++ b/src/engines/singing-voice/playback.ts
@@ -290,11 +290,15 @@ export const PlaybackMixin = {
     const phonemes = this.lastAlignment.phonemes;
     const sampleRate = this.audioContext.sampleRate;
 
-    // We only care if there is any user phoneme with a formant shift
+    // We only care if there is any user phoneme with a formant shift, or if there are vowel transitions to smooth out
     const hasFormantShift = userPhonemes.some(
-      (p) => false,
+      (p) => (p as any).formantShift !== undefined || p.pitchBend !== 0,
     );
-    if (!hasFormantShift) {
+
+    // We also want to run the loop to check for consecutive vowels for expressive transitions
+    const hasVowelTransitions = phonemes.filter(p => p.isVowel).length > 1;
+
+    if (!hasFormantShift && !hasVowelTransitions) {
       return;
     }
 
@@ -319,6 +323,36 @@ export const PlaybackMixin = {
         targetShift += (userP as any).formantShift;
       }
 
+      // Expressive Note Transitions for Vowels
+      // If this is a vowel, and the next phoneme is also a vowel, we can add a subtle portamento/glide
+      if (p.isVowel && i < phonemes.length - 1) {
+        const nextP = phonemes[i + 1];
+        if (nextP.isVowel) {
+          // Calculate a subtle formant transition to smooth out the vowel boundary
+          const rampDuration = Math.min(0.1, stretchedDurationSec * 0.5);
+          const transitionTime = currentTimeSeconds + stretchedDurationSec - rampDuration;
+
+          if (prevShift === targetShift) {
+             // If there's no user formant shift, we can still apply a micro-glide for expressiveness
+             // Just a slight scoop to simulate vocal tract adjustments between vowels
+             const scoopAmount = 0.5; // semitones
+             (this.formantShifter as any)?.setFormantGlide?.(
+                targetShift,
+                targetShift + scoopAmount,
+                transitionTime,
+                rampDuration
+             );
+             // Return to baseline at the start of next vowel
+             (this.formantShifter as any)?.setFormantGlide?.(
+                targetShift + scoopAmount,
+                targetShift,
+                currentTimeSeconds + stretchedDurationSec,
+                rampDuration
+             );
+          }
+        }
+      }
+
       if (prevShift !== targetShift) {
         // Ramp duration bounded by the segment length
         // We use a quick ramp, but bounded to the phoneme length so it doesn't bleed too far
@@ -334,8 +368,10 @@ export const PlaybackMixin = {
           rampDuration
         );
       } else {
-        // Ensure we hold the target shift
-        (this.formantShifter as any)?.setFormantShift?.(targetShift, currentTimeSeconds, 0);
+        // Ensure we hold the target shift (only if we didn't just schedule an expressive scoop above)
+        if (!(p.isVowel && i < phonemes.length - 1 && phonemes[i+1].isVowel && prevShift === targetShift)) {
+           (this.formantShifter as any)?.setFormantShift?.(targetShift, currentTimeSeconds, 0);
+        }
       }
 
       prevShift = targetShift;


### PR DESCRIPTION
As per the "Creative Audio Architect" task list in `agent_plan.md`, this implements "Expressive Note Transitions for Vowels".

- Updates `src/engines/singing-voice/playback.ts` to detect adjacent vowel phonemes during playback scheduling.
- Replaces a hard-coded stub with logic to trigger `setFormantGlide` for subtle scoop/portamento effects between vowels, simulating natural vocal tract adjustments.
- Updates `.Jules/agent_plan.md` to check off the task and add new items to the Innovation Lab.

---
*PR created automatically by Jules for task [8313616571043573657](https://jules.google.com/task/8313616571043573657) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expressive formant transitions for vowel sounds, creating subtle scoop-and-return movements between adjacent vowels.
  * Improved vocal expression when shifting vowel formants or singing consecutive vowels.

* **Bug Fixes**
  * Prevented redundant baseline adjustments when an expressive transition is already applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->