### PR TITLE
⚡ Bolt: Prevent main-thread UI contention in AutomationStore

### DIFF
--- a/src/stores/automationStore.ts
+++ b/src/stores/automationStore.ts
@@ -502,15 +502,26 @@ class AutomationStore {
     this.notify();
   }
 
+  // Keep track of pending rAF to debounce UI updates for live values
+  private _liveValuesRaf: number | null = null;
+
   /**
    * Update live automated values for UI display.
    * Called once per step tick with all values collected during that step.
    * Merges into existing map so stale entries remain visible until cleared.
+   * Employs rAF coalescing to prevent main-thread UI contention.
    */
   setLiveValues(values: Record<string, number>): void {
     const merged = Object.assign({}, this.state.liveAutomatedValues, values);
     this.state = { ...this.state, liveAutomatedValues: merged };
-    this.notify();
+
+    // Coalesce React notify() into the next animation frame
+    if (this._liveValuesRaf === null) {
+      this._liveValuesRaf = requestAnimationFrame(() => {
+        this.notify();
+        this._liveValuesRaf = null;
+      });
+    }
   }
 
   /**
@@ -520,6 +531,10 @@ class AutomationStore {
   clearLiveValues(): void {
     if (Object.keys(this.state.liveAutomatedValues).length === 0) return;
     this.state = { ...this.state, liveAutomatedValues: {} };
+    if (this._liveValuesRaf !== null) {
+      cancelAnimationFrame(this._liveValuesRaf);
+      this._liveValuesRaf = null;
+    }
     this.notify();
   }
 


### PR DESCRIPTION
💡 What: Throttles React state updates in `AutomationStore.setLiveValues()` using `requestAnimationFrame` coalescing.
🎯 Why: `setLiveValues` was calling `notify()` synchronously on every sequencer tick during playback, causing expensive components like `RackNode` to reconcile at 8-16Hz, creating main-thread stutter right when `onStep` runs.
📊 Impact: Decouples UI indicators from the tight sequencer loop, significantly reducing React render thrashing.
🔬 Measurement: Profile the React tree during automation playback—`RackNode` render counts should plummet.

---
*PR created automatically by Jules for task [3477481010409010637](https://jules.google.com/task/3477481010409010637) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved live automation updates by grouping rapid changes into smoother, consolidated notifications.
  * Ensured pending updates are properly cleared when live values are reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->