### PR TITLE
feat: add per-phoneme granular random jitter

### DIFF
--- a/.Jules/agent_plan.md
+++ b/.Jules/agent_plan.md
@@ -2,6 +2,8 @@
 
 ## Active Backlog
 - [x] Implement Phoneme-driven auto-rhythm generation for TTS
+- [x] Add granular random jitter per phoneme
+- [ ] Add multi-voice unison detune
 
 ## Innovation Lab
 - [x] Implement reverse TTS sample per step
@@ -9,13 +11,11 @@
 - [x] Implement Expressive Note Transitions for Vowels
 
 - [ ] Optimize TTS memory footprint
-- [ ] Add multi-voice unison detune
 - [x] Implement Lyric Track parsing
 - [x] Implement Vowel-Preserving Time Stretch for TTS voices
 - [x] Implement per-phoneme pitch drift/vibrato
 - [x] Add Formant Modulation LFO
 - [x] Add Formant Glide per phoneme
-- [ ] Add granular random jitter per phoneme
 - [ ] Optimize Voice Manager state syncing
 
 ## Roadmap

--- a/src/audio-worklets/rubberband-processor.ts
+++ b/src/audio-worklets/rubberband-processor.ts
@@ -83,7 +83,6 @@ class RubberBandProcessor extends AudioWorkletProcessor {
       { name: 'timeStretchEnvDepth', defaultValue: 0.0, minValue: -1.0, maxValue: 1.0 },
       { name: 'grainEnvDepth', defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },
       { name: 'grainJitter', defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },
-      { name: 'grainJitter', defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },
       { name: 'grainPitchEnvDepth', defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },
       { name: 'grainPitchQuantize', defaultValue: 0.0, minValue: 0.0, maxValue: 12.0 },
       { name: 'granularPitchShift', defaultValue: 0.0, minValue: -24.0, maxValue: 24.0 },
@@ -265,13 +264,13 @@ class RubberBandProcessor extends AudioWorkletProcessor {
    * Determine the phoneme parameters for the current sample position.
    * Returns [stretchRatio, volume, pitchBend, vibDepth, vibRate]
    */
-  private getPhonemeDataAtSample(currentSample: number): [number, number, number, number, number] {
-    if (!this.phonemeData || !this.phonemeRatios) return [1.0, 1.0, 0.0, -1.0, -1.0];
+  private getPhonemeDataAtSample(currentSample: number): [number, number, number, number, number, number] {
+    if (!this.phonemeData || !this.phonemeRatios) return [1.0, 1.0, 0.0, -1.0, -1.0, -1.0];
 
     const count = this.phonemeData[0];
-    // Phoneme data stride is 8 floats: start, end, isVowel, stretch(unused in buffer), volume, pitchBend, vibDepth, vibRate
+    // Phoneme data stride is 9 floats: start, end, isVowel, stretch(unused in buffer), volume, pitchBend, vibDepth, vibRate, grainJitter
     for (let i = 0; i < count; i++) {
-      const baseIndex = 1 + i * 8;
+      const baseIndex = 1 + i * 9;
       const start = this.phonemeData[baseIndex];
       const end = this.phonemeData[baseIndex + 1];
 
@@ -281,10 +280,11 @@ class RubberBandProcessor extends AudioWorkletProcessor {
         const pitchBend = this.phonemeData[baseIndex + 5] !== undefined ? this.phonemeData[baseIndex + 5] : 0.0;
         const vibDepth = this.phonemeData[baseIndex + 6] !== undefined ? this.phonemeData[baseIndex + 6] : -1.0;
         const vibRate = this.phonemeData[baseIndex + 7] !== undefined ? this.phonemeData[baseIndex + 7] : -1.0;
-        return [ratio, volume, pitchBend, vibDepth, vibRate];
+        const grainJitter = this.phonemeData[baseIndex + 8] !== undefined ? this.phonemeData[baseIndex + 8] : -1.0;
+        return [ratio, volume, pitchBend, vibDepth, vibRate, grainJitter];
       }
     }
-    return [1.0, 1.0, 0.0, -1.0, -1.0];
+    return [1.0, 1.0, 0.0, -1.0, -1.0, -1.0];
   }
 
   process(_inputs: Float32Array[][], outputs: Float32Array[][], parameters: Record<string, Float32Array>): boolean {
@@ -333,7 +333,7 @@ class RubberBandProcessor extends AudioWorkletProcessor {
     let currentVibDepth = vibDepth;
     let currentVibRate = vibRate;
     if (this.isPlaying && this.fullSampleBuffer && this.phonemeData && this.phonemeRatios) {
-        const [_, _vol, _pBend, pVibDepth, pVibRate] = this.getPhonemeDataAtSample(this.currentSamplePtr);
+        const [_, _vol, _pBend, pVibDepth, pVibRate, _gJit] = this.getPhonemeDataAtSample(this.currentSamplePtr);
         if (pVibDepth !== -1.0) currentVibDepth = pVibDepth;
         if (pVibRate !== -1.0) currentVibRate = pVibRate;
     }
@@ -378,7 +378,7 @@ class RubberBandProcessor extends AudioWorkletProcessor {
 
     // Apply Phoneme Pitch Bend (if we're streaming from a buffer and have it calculated)
     if (this.isPlaying && this.fullSampleBuffer && this.phonemeData && this.phonemeRatios) {
-        const [_, _vol, pBend, _vDepth, _vRate] = this.getPhonemeDataAtSample(this.currentSamplePtr);
+        const [_, _vol, pBend, _vDepth, _vRate, _gJit] = this.getPhonemeDataAtSample(this.currentSamplePtr);
         if (pBend !== 0.0) {
             const pitchBendRatio = Math.pow(2.0, pBend / 1200.0);
             finalPitch *= pitchBendRatio;
@@ -404,7 +404,7 @@ class RubberBandProcessor extends AudioWorkletProcessor {
         let phonemeVolume = 1.0;
         let phonemePitchBendCents = 0.0;
         if (this.phonemeData && this.phonemeRatios) {
-          const [pRatio, pVol, pBend, _vDepth, _vRate] = this.getPhonemeDataAtSample(this.currentSamplePtr);
+          const [pRatio, pVol, pBend, _vDepth, _vRate, _gJit] = this.getPhonemeDataAtSample(this.currentSamplePtr);
           ratio = pRatio;
           phonemeVolume = pVol;
           phonemePitchBendCents = pBend;
@@ -466,7 +466,16 @@ class RubberBandProcessor extends AudioWorkletProcessor {
             // Modulate grain size with envelope: louder = smaller grains for more texture
             const grainSizeSamples = Math.max(100, Math.floor(baseGrainSize * (1.0 - grainEnvDepth * envelopeValue)));
 
-            const grainJitter = parameters.grainJitter ? parameters.grainJitter[0] : 0.0;
+            let grainJitter = parameters.grainJitter ? parameters.grainJitter[0] : 0.0;
+
+            // Check for per-phoneme grainJitter override
+            if (this.phonemeData && this.phonemeRatios) {
+                const [_, _pVol, _pBend, _vDepth, _vRate, pGrainJitter] = this.getPhonemeDataAtSample(this.currentSamplePtr);
+                if (pGrainJitter !== -1.0) {
+                    grainJitter = pGrainJitter;
+                }
+            }
+
             // Jitter adds a random offset to the grain center up to +/- 50ms based on jitter amount
             const maxJitterSamples = Math.floor(0.05 * sRate * grainJitter);
             const jitterOffset = maxJitterSamples > 0 ? Math.floor((Math.random() * 2 - 1) * maxJitterSamples) : 0;
@@ -569,7 +578,7 @@ class RubberBandProcessor extends AudioWorkletProcessor {
 
         // Apply phoneme volume
         if (this.isPlaying && this.fullSampleBuffer && this.phonemeData && this.phonemeRatios) {
-            const [_, pVol, _pBend, _vDepth, _vRate] = this.getPhonemeDataAtSample(this.currentSamplePtr);
+            const [_, pVol, _pBend, _vDepth, _vRate, _gJit] = this.getPhonemeDataAtSample(this.currentSamplePtr);
             if (pVol !== 1.0) {
                 for (let i = 0; i < outputChannel.length; i++) {
                     outputChannel[i] *= pVol;

--- a/src/engines/rubberband/PhonemeAligner.ts
+++ b/src/engines/rubberband/PhonemeAligner.ts
@@ -482,8 +482,8 @@ export class PhonemeAligner {
      * @returns SharedArrayBuffer with phoneme data
      */
     createSharedPhonemeBuffer(phonemes: PhonemeSegment[], sampleRate: number, userPhonemes?: PhonemeData[]): SharedArrayBuffer {
-        // 1 int for count + 8 floats per phoneme (start, end, isVowel, stretchRatio, volume, pitchBend, vibDepth, vibRate)
-        const bufferSize = (1 + phonemes.length * 8) * 4; // 4 bytes per float32
+        // 1 int for count + 9 floats per phoneme (start, end, isVowel, stretchRatio, volume, pitchBend, vibDepth, vibRate, grainJitter)
+        const bufferSize = (1 + phonemes.length * 9) * 4; // 4 bytes per float32
         const sharedBuffer = new SharedArrayBuffer(bufferSize);
         const view = new Float32Array(sharedBuffer);
         
@@ -491,7 +491,7 @@ export class PhonemeAligner {
         
         for (let i = 0; i < phonemes.length; i++) {
             const p = phonemes[i];
-            const baseIndex = 1 + i * 8;
+            const baseIndex = 1 + i * 9;
             view[baseIndex] = p.start * sampleRate;     // Start sample
             view[baseIndex + 1] = p.end * sampleRate;   // End sample
             view[baseIndex + 2] = p.isVowel ? 1.0 : 0.0; // Boolean as float
@@ -502,6 +502,7 @@ export class PhonemeAligner {
             let pitchBend = 0.0;
             let vibDepth = -1.0; // -1 means use global
             let vibRate = -1.0;  // -1 means use global
+            let grainJitter = -1.0; // -1 means use global
 
             if (userPhonemes && userPhonemes.length > i) {
                 // If userPhonemes are provided, we map them by index.
@@ -512,11 +513,13 @@ export class PhonemeAligner {
                 if (userP.pitchBend !== undefined) pitchBend = userP.pitchBend;
                 if (userP.vibratoDepth !== undefined) vibDepth = userP.vibratoDepth;
                 if (userP.vibratoRate !== undefined) vibRate = userP.vibratoRate;
+                if (userP.grainJitter !== undefined) grainJitter = userP.grainJitter;
             }
             view[baseIndex + 4] = volume;
             view[baseIndex + 5] = pitchBend;
             view[baseIndex + 6] = vibDepth;
             view[baseIndex + 7] = vibRate;
+            view[baseIndex + 8] = grainJitter;
         }
         
         return sharedBuffer;

--- a/src/types.ts
+++ b/src/types.ts
@@ -419,6 +419,7 @@ export interface PhonemeData {
   vibratoDepth?: number;
   vibratoRate?: number;
   volume?: number;
+  grainJitter?: number;
 }
 
 export interface Note {


### PR DESCRIPTION
Implements a per-phoneme granular random jitter effect for the Web Audio DAW TTS sequencer. This allows users to apply expressive textural variations at the syllable level, which dynamically overrides the global parameter during audio worklet playback.

---
*PR created automatically by Jules for task [11463022273796681608](https://jules.google.com/task/11463022273796681608) started by @ford442*