### PR TITLE
docs: weekly plan — Fix First (E2E/CI stability + .orig purge)

### DIFF
--- a/docs/dispatch/2026-08-03.md
+++ b/docs/dispatch/2026-08-03.md
@@ -1,0 +1,346 @@
+# web_sequencer — 2026-08-03 (Monday)
+
+**Status:** Fix First day. Foundation before features — E2E is red, `src/` carries 5 `.orig` scars. Everything below routes around that.
+
+## Mode declaration
+
+**Fix First** — the CI/test foundation is cracked (Playwright E2E flaky/red on `main` per #1036; `playwright.config.ts` has no `webServer` block; 5 `.orig` merge artifacts committed in `src/`), so stabilizing it precedes any new feature work.
+
+## Context from prior sessions
+
+- **No chat-history access this run.** `recent_chats` / `conversation_search` are not available in this execution environment — so "same-day-last-week" and cross-project mention sweeps could not run. Context below is reconstructed purely from repo state + open issues. *(gap flagged)*
+- **First-ever run of this routine** — no `weekly_plan.md` existed. Created it fresh this run; Ideas section was empty (seeded 2 generated ideas for future inheritance).
+- **Repo is extremely active and healthy on the surface**: merged through PR #1043 (Aug 2), heavy automated perf/UX churn from Bolt/Palette/Copilot bots (hot-path closure elimination, setTimeout audio-glitch removal, empty-state polish).
+- **`.swarm-state.md` (2026-07-20)** shows the **unit/lint** CI gate was restored green (1280 tests, pre-push husky guard added) — but it never covered the **E2E/Playwright** matrix, which is why #1036 is still open. The green gate is real but partial.
+- **Verified live cracks:** 5 `.orig` files present (`MainSequencer.tsx.orig`, `useAudioEngine.ts.orig`, `audioPlayback.ts.orig`, `useAppState.tsx.orig`, `PhonemeAligner.ts.orig`); Playwright config lacks a `webServer` block (tests assume a manually-started dev server at :5173).
+- **Open foundation backlog** (#1030–#1039): E2E stability, `.orig` purge + mega-module splits, master limiter/LUFS, modular patch-bay epic, OscillatorBackend fallback, emcc/wasm flag audit, AudioContext negotiation. *Did not independently reproduce the red E2E run* (no dev server / heavy WASM build in this env) — treated the open issue + missing `webServer` config as sufficient signal. *(gap flagged)*
+
+## weekly_plan.md changes (written to file this run)
+
+- **Created** `weekly_plan.md` (first run).
+- **Today's focus** set: Fix First — E2E green (#1036) + `.orig` purge (#1039).
+- **Done:** archived the 2026-07-20 unit/lint CI gate restore, annotated that it did **not** cover E2E.
+- **Backlog:** reconciled from open issues #1030–#1039 + CHANGELOG follow-ups #632/#633/#634.
+- **Ideas:** was empty; seeded 3 generated ideas (master limiter/LUFS — today's Copilot lane; OscillatorBackend fallback #1035; AudioContext negotiation #1033).
+- **Last run:** stamped 2026-08-03, Fix First.
+
+## Today's focus
+
+**Restore green Playwright E2E on `main` and remove committed `.orig` merge artifacts.**
+
+Why this and not a feature: the modular patch-bay epic (#1038) and the limiter suite (#1037) both sit on top of the audio graph and the test harness. Landing them on a red E2E matrix means you can't tell a real regression from harness flake, and merge-artifact `.orig` files in `src/` are a signal the last merges weren't clean. This is a half-to-full-day stabilization pass, cleanly splittable: kimi-cli owns the E2E harness; the `.orig` purge is a 15-minute chore folded into the same lane.
+
+---
+
+# Dispatch
+
+## A. kimi-cli Swarm Task — restore green E2E (the main event)
+
+```
+OBJECTIVE
+Restore a deterministic, green Playwright end-to-end test matrix (chromium / firefox / webkit) for the web_sequencer / Hyphon DAW, and remove the committed `.orig` merge artifacts polluting the source tree. The E2E suite is currently flaky/red on `main`; the two dominant causes are (1) the Playwright config has no `webServer` block so tests race a manually-started dev server, and (2) the app's StartOverlay gate (a click-to-start audio unlock) interacts badly with WebKit launch flags and autoplay policy, so tests intermittently fail before the sequencer even mounts.
+
+WHY
+This is a browser-based audio workstation with a hybrid WebGPU/WASM/Pyodide engine. E2E is the only layer that catches "audio silently didn't init" and "WebGPU knob render broke" regressions — exactly the class of bug that unit tests miss. A flaky E2E matrix means every future feature PR ships blind. Green E2E is the precondition for the modular patch-bay and limiter work queued behind this.
+
+STRICT BOUNDARIES — you MAY touch:
+- tests/**              (all *.spec.ts, tests/helpers/**, tests/fixtures/**)
+- playwright.config.ts  (add a webServer block, tune per-project launchOptions, timeouts, retries)
+- src/components/StartOverlay.tsx  (ONLY if the fix requires a test-stable hook — e.g. a data-testid or an env/query-param auto-start path; do not restyle it)
+- package.json          (ONLY to add a `test:e2e` script if one is missing; do not touch deps without noting why in the state file)
+
+DO NOT TOUCH — ignore completely:
+- src/audio/graph/**    (reserved — a separate Copilot task is landing a master limiter/LUFS meter here; DO NOT edit to avoid a merge collision)
+- Any WASM/native source: assembly/**, rust-audio/**, emscripten/**, jc303_wasm/**, rubberband/**, tools/build_*.sh
+- Any *.wasm binaries or build outputs (public/rust-wasm/**, src/wasm/**)
+- vitest.setup.ts and unit tests under src/**/__tests__/** (unit gate is already green — leave it)
+
+FIRST ACTION (before any code change): delete the 5 committed merge artifacts and confirm nothing imports them:
+  git rm src/components/MainSequencer.tsx.orig src/hooks/useAudioEngine.ts.orig src/hooks/audioEngine/audioPlayback.ts.orig src/hooks/useAppState.tsx.orig src/engines/rubberband/PhonemeAligner.ts.orig
+Then grep the tree for any reference to a `.orig` path (there should be none) and commit that as an isolated first commit.
+
+ITERATION LOOP (repeat until the matrix is green three runs in a row):
+1. Install + build only what E2E needs: `pnpm install --frozen-lockfile`. If a full `pnpm run build` is too slow to iterate on, run the Vite dev server (`pnpm exec vite`) and point Playwright at it via the new webServer block (command + url + reuseExistingServer + a generous timeout for the WASM warm-up).
+2. Add a `webServer` block to playwright.config.ts so Playwright owns the dev server lifecycle instead of racing an external one.
+3. Run one project at a time to isolate flake: `pnpm exec playwright test --project=chromium`, then firefox, then webkit. WebKit is the usual offender — check that `--autoplay-policy=no-user-gesture-required` (already in launchOptions.args) actually applies under WebKit, and that StartOverlay's user-gesture requirement has a deterministic test path (auto-dismiss via a query param or data-testid the helpers click reliably).
+4. For each failing spec, read the actual error and the trace (`--trace on`). Fix the ROOT cause — a real selector/timing/gesture race — not by inflating timeouts. Only raise a timeout when the failure is a genuine WASM/WebGPU warm-up cost, and comment why.
+5. Before moving on from a spec: re-run it 3x (`--repeat-each=3`) to prove it's not still flaky.
+6. Verify you introduced no console errors: assert the page has no uncaught errors / no "AudioContext" or "WebGPU" init failures in the console during the smoke path.
+
+SELF-VERIFICATION GATE (must pass before you declare done):
+  pnpm exec tsc -b        # no type regressions from any test-helper edits
+  pnpm lint               # eslint . && scripts/check-root.mjs — the .orig purge should HELP this
+  pnpm exec playwright test --repeat-each=2   # full matrix, green
+
+SAVE-STATE (mandatory, every iteration boundary):
+Write/overwrite `.swarm-state.md` with: current status, which projects are green, which specs still flake and the exact error, what you changed since last checkpoint, and the exact resume command. Noah must be able to pause after any iteration and resume cleanly from that file alone. Keep the "Resume commands" block runnable verbatim.
+
+DELIVERABLE
+A green chromium+firefox+webkit Playwright run, a clean `git status` (no .orig files), and a final `.swarm-state.md` summarizing what was flaky and how each was fixed.
+```
+
+## B. GitHub issue — draft for Copilot (decoupled lane: master bus, NOT tests)
+
+> Deliberately scoped to `src/audio/graph/**` so Copilot never touches the `tests/` + `StartOverlay` files kimi-cli owns. Create it on GitHub, expand the "Proposed approach", then hand to Copilot via prompt D.
+
+```
+Title: feat(audio): master true-peak (ISP) limiter + LUFS/peak metering on graph output
+
+## Context / motivation
+web_sequencer's active focus includes audio-engine stability and the hybrid
+WebGPU→WASM→Pyodide→Native fallback chain. The master output currently has no
+brick-wall protection and no standards-compliant loudness metering, so exports and
+live play can inter-sample-peak clip, and there's no LUFS reference for mastering.
+This lands a true-peak limiter + a metering suite on the audio graph output. It is
+intentionally isolated to the master bus so it does not collide with in-flight E2E
+harness work (#1036) or the modular patch-bay epic (#1038).
+
+## Proposed approach (first pass — expand before handing to Copilot)
+- Add a master-bus limiter stage at the graph output in `src/audio/graph/` (see
+  `src/audio/graph/index.ts` and `src/hooks/audioEngine/engineLifecycle.ts` for where
+  the output node is assembled).
+- True-peak (ISP) detection via 4x oversampling on the metering path (not the audio
+  path) to estimate inter-sample peaks; brick-wall limiter with configurable ceiling
+  (default -1.0 dBTP), attack/release, and lookahead.
+- Metering: integrated + short-term (3s) + momentary (400ms) LUFS (BS.1770 K-weighting),
+  plus true-peak hold. Compute in an AudioWorklet or WASM to keep it off the main thread —
+  match whatever the existing analysis path already uses; do NOT add a new blocking node.
+- A small master-meter UI component (LUFS/dBTP readouts + gain-reduction indicator).
+
+## Acceptance criteria (rough — refine during expansion)
+- [ ] No inter-sample peak above the configured ceiling on a hot test signal (verify offline).
+- [ ] Integrated LUFS reading within tolerance of a known reference file.
+- [ ] Limiter adds no audible artifacts at nominal levels; real-time path stays glitch-free.
+- [ ] Metering runs off the main thread; no added main-thread contention (this repo has
+      an active hot-path-optimization theme — respect it).
+- [ ] Bypass toggle; state persists like other master settings.
+- [ ] Unit tests for LUFS math + true-peak detection against reference vectors.
+
+## Open questions for Noah
+- Worklet vs. WASM for the LUFS/true-peak math — reuse the FFT/analysis WASM (`assembly/fft.ts`) or a fresh worklet?
+- Should the limiter sit in the real-time graph, or only on the offline export/freeze path (where OpenMP oversampling already lives)?
+- Default ceiling: -1.0 dBTP (streaming-safe) or -0.3 (louder)?
+- Does the metering UI belong in the master strip, or a dedicated meter panel?
+```
+
+## C. Three chat-model expansion prompts (all target issue B)
+
+### C1 — Gemini Pro (implementation plan / dependency mapping)
+
+```
+You are reviewing a real codebase: web_sequencer (aka "Hyphon"), a browser-based
+pattern-oriented audio workstation. Stack: TypeScript, React 19, Vite, Tailwind;
+audio via Web Audio API + AudioWorklets, AssemblyScript WASM (FFT/oscillators/export),
+Rust/wasm-pack, Emscripten (jc303/Open303 TB-303 clones), WebGPU/WGSL, Pyodide.
+The master output node is assembled in src/audio/graph/index.ts and
+src/hooks/audioEngine/engineLifecycle.ts. Existing FFT/analysis WASM lives in
+assembly/fft.ts (built to src/wasm/fft.wasm).
+
+Here is a proposed GitHub issue:
+---
+[PASTE THE FULL TEXT OF ISSUE B HERE]
+---
+
+Do these, concretely, referencing likely file/function names in this stack:
+1. Enumerate every file and function that a master true-peak limiter + BS.1770
+   LUFS metering suite would touch or need to touch, and where the output node is
+   wired so the limiter inserts cleanly as the last stage.
+2. Identify missed dependencies: existing AudioWorklet registration/plumbing, how
+   the analysis path currently gets sample data, gain-reduction reporting back to
+   React state without main-thread contention, sample-rate assumptions.
+3. Produce a step-by-step implementation plan ordered to keep each commit green:
+   metering-only first (read-only, safe), then the limiter, then UI.
+4. Call out the highest-risk step and how to de-risk it.
+Be specific and skeptical; if the proposed approach conflicts with how Web Audio
+graph teardown/rebuild typically works, say so.
+```
+
+### C2 — Kimi.com (K2) (stress-test + alternatives)
+
+```
+Stress-test this engineering plan for a browser audio workstation (Web Audio API +
+AudioWorklets, WASM, WebGPU, React 19/TypeScript). The task: add a master true-peak
+(inter-sample-peak) limiter plus BS.1770 LUFS metering (integrated/short-term/momentary)
+to the master output node.
+
+Proposed approach:
+---
+[PASTE THE FULL TEXT OF ISSUE B HERE]
+---
+
+1. Attack the proposed approach: where will 4x-oversampled true-peak detection on the
+   metering path be wrong, expensive, or lie about peaks? Where does K-weighting /
+   gating go wrong in a real-time (not offline) context? What breaks on sample-rate
+   changes or graph rebuilds?
+2. Generate TWO genuinely different alternative architectures (e.g. all-WASM offline-only
+   metering vs. a real-time AudioWorklet meter vs. reusing the existing FFT WASM).
+3. Argue for the single best option for THIS stack, with the tradeoff that decided it
+   (latency, main-thread contention, export-vs-live parity, implementation cost).
+```
+
+### C3 — Grok.com (ecosystem currency check)
+
+```
+Current-ecosystem sanity check for an audio feature on a 2026 web stack: React 19,
+Vite, TypeScript, Web Audio API + AudioWorklet, AssemblyScript/Rust WASM, WebGPU/WGSL,
+Pyodide. Task: master true-peak (ISP) limiter + BS.1770 LUFS metering (integrated/
+short-term/momentary) on the master bus.
+
+---
+[PASTE THE FULL TEXT OF ISSUE B HERE]
+---
+
+Answer with what's current as of now:
+1. Is hand-rolling BS.1770 K-weighting + true-peak still the norm, or are there
+   maintained libraries / WASM crates / worklet packages worth adopting instead of
+   writing from scratch? Name them and their maintenance status.
+2. Any newer Web Audio / AudioWorklet capabilities (or gotchas — e.g. render-quantum,
+   AudioWorklet+WASM SIMD, WebGPU compute for metering) that change the best approach
+   vs. a few years ago?
+3. Browser-support caveats for the metering path across Chromium/Firefox/WebKit as of
+   now. Flag anything in the proposed approach that's already dated.
+```
+
+## D. Copilot Agent handoff
+
+```
+Implement the following fully-specified GitHub issue for the web_sequencer repo.
+
+Scope discipline: touch ONLY the master-bus audio path under src/audio/graph/ (and its
+worklet/WASM helpers + one master-meter UI component). Do NOT edit anything under tests/,
+playwright.config.ts, or src/components/StartOverlay.tsx — a separate change is in flight
+there and edits will collide. Keep every commit green (pnpm exec tsc -b && pnpm lint &&
+pnpm test). Add unit tests for the LUFS + true-peak math against reference vectors.
+Respect the repo's hot-path discipline: metering must run off the main thread. Open a PR;
+do not merge.
+
+{{EXPANDED_ISSUE}}
+```
+
+## E. Claude Code — whole-stack pipeline exercise (mid-day, independent of kimi-cli)
+
+```
+Exercise the web_sequencer build→deploy→verify pipeline end-to-end as a hygiene pass —
+this is pipeline health, NOT feature work, and must stay independent of any in-flight
+E2E or audio-graph changes.
+
+1. Full build from clean: `pnpm install --frozen-lockfile` then `pnpm run build`
+   (this runs build:wasm → build:emcc → optimize → tsc -b → vite build). Capture timings
+   and any WASM/emcc warnings. The pipeline chains AssemblyScript (asc), Rust wasm-pack,
+   and Emscripten (jc303/OpenMP) — report the first failing stage precisely if it breaks.
+2. Confirm the build lands under the `/hyphon/` base path correctly (Vite base config) so
+   assets resolve at the deploy subdirectory, and that WASM binaries are emitted and
+   referenced with correct paths.
+3. Dry-run the deploy: read deploy.py (`npm run deploy` calls it) and report exactly what
+   it does — target host, transport (SFTP/FTP), destination path — WITHOUT actually
+   pushing. Flag any hardcoded creds or unverified assumptions. Do NOT deploy.
+4. Smoke the output locally: `pnpm exec vite preview` and confirm the app boots, audio
+   engine initializes (no AudioContext errors in console), and a WebGPU knob renders (or
+   cleanly falls back). Save a screenshot.
+5. Report: build time per stage, bundle size, any dependency-audit red flags
+   (`pnpm audit`), and a go/no-go on whether the pipeline is deploy-ready. Change nothing
+   unless a one-line fix unblocks the build — if so, make it and note it.
+```
+
+## F. Jules wrap-up — integrate kimi-cli's output (end-of-day template)
+
+> Fill the three placeholders after kimi-cli finishes, then run.
+
+```
+You are wrapping up and integrating work another agent (kimi-cli) produced on the
+web_sequencer repo. Turn it into a clean, reviewable PR. Do NOT merge.
+
+WHAT KIMI-CLI DID
+Files changed: {{KIMI_CLI_FILES_CHANGED}}
+Summary: {{KIMI_CLI_SUMMARY}}
+Known issues Noah noticed on cursory review: {{KNOWN_ISSUES}}
+
+WRAP-UP CHECKLIST (do all, in order):
+1. Format:    pnpm exec prettier --write on the changed files (if prettier is configured;
+              otherwise skip and note it).
+2. Lint:      pnpm lint   (eslint . && node scripts/check-root.mjs) — fix all errors.
+3. Typecheck: pnpm exec tsc -b   — fix all type errors.
+4. Unit test: pnpm test   (vitest run) — fix any failures kimi-cli introduced.
+5. E2E:       pnpm exec playwright test   — since kimi-cli's task WAS the E2E fix, confirm
+              the full chromium/firefox/webkit matrix is green; re-run flaky specs with
+              --repeat-each=3.
+6. Finish stubs: complete any TODO/FIXME or stubbed code kimi-cli left behind.
+7. Coverage:  add unit tests for any new public function/helper that lacks them.
+8. Docs:      if any public API/config changed (e.g. playwright.config webServer, a new
+              test:e2e script), update README.md / relevant docs and CHANGELOG.md.
+9. Build:     pnpm run build   — must pass clean.
+10. Confirm `git status` is free of `.orig` or stray artifacts.
+
+ACCEPTANCE CRITERIA:
+- [ ] prettier clean  - [ ] lint 0 errors  - [ ] tsc clean  - [ ] vitest green
+- [ ] Playwright matrix green (3x on any previously-flaky spec)
+- [ ] no TODO/stub left from kimi-cli  - [ ] new public fns have tests
+- [ ] docs/CHANGELOG updated if public surface changed  - [ ] `pnpm run build` passes
+- [ ] clean working tree, no `.orig`
+
+Open a PR titled "chore(e2e): stabilize Playwright matrix + purge .orig artifacts"
+with a summary of what kimi-cli did and what you cleaned up. DO NOT MERGE — leave it
+for Noah to review.
+```
+
+## G. Review prompts (Gemini Pro)
+
+### G1 — review kimi-cli's raw diff (before Jules wraps it)
+
+```
+Review this diff from an AI agent (kimi-cli) that was tasked with restoring a green
+Playwright E2E matrix (chromium/firefox/webkit) for web_sequencer — a browser audio
+workstation (React 19/TS, Web Audio, WASM, WebGPU) — and removing committed .orig merge
+artifacts. Allowed scope was tests/**, playwright.config.ts, StartOverlay.tsx, package.json.
+
+[PASTE DIFF]
+
+Check for:
+1. Flakiness masked, not fixed — inflated timeouts, arbitrary waits, retries hiding a
+   real race instead of a deterministic gesture/selector fix.
+2. Scope drift — did it touch src/audio/graph/** or WASM/native it was told to avoid?
+3. Architectural drift in StartOverlay — did a test hook weaken the real user-gesture/
+   autoplay-unlock behavior in production?
+4. Performance: any new per-test full builds or heavy setup that will slow CI.
+5. Did the webServer block get configured correctly (lifecycle, reuseExistingServer, timeout)?
+Give a prioritized list of anything that should change before this is wrapped into a PR.
+```
+
+### G2 — review the Jules PR against objective + checklist
+
+```
+Review this PR (Jules' wrap-up of kimi-cli's E2E-stabilization work on web_sequencer)
+against two references.
+
+ORIGINAL OBJECTIVE: restore a deterministic green Playwright matrix (chromium/firefox/
+webkit), fix the missing webServer config and the StartOverlay gesture/autoplay flake,
+and remove the 5 committed .orig merge artifacts — without touching audio-graph/WASM code.
+
+WRAP-UP CHECKLIST THAT SHOULD BE SATISFIED: prettier clean, lint 0 errors, tsc clean,
+vitest green, Playwright matrix green (3x on flaky specs), no leftover TODO/stubs, new
+public fns tested, docs/CHANGELOG updated if public surface changed, `pnpm run build`
+passes, clean tree with no .orig.
+
+[PASTE PR DIFF + DESCRIPTION]
+
+For each checklist item: satisfied / not / can't-tell-from-diff. Then judge whether the PR
+actually achieves the objective (is the matrix genuinely deterministic, or just green once?),
+and list blocking issues vs. nits. End with a merge / request-changes recommendation.
+```
+
+---
+
+## Suggested timeline
+
+- **T+0 (kickoff, ~15 min):** Fire **A** (kimi-cli) — it runs long. Create issue **B** on GitHub.
+- **T+15m–T+1h (expansion, while kimi runs):** Run **C1/C2/C3** in parallel tabs; fold their answers into issue B's "Proposed approach". Hand the expanded issue to Copilot via **D**.
+- **Mid-day:** Run **E** (Claude Code pipeline hygiene) — independent, safe to run alongside everything.
+- **End-of-day (after kimi-cli finishes):** Fill placeholders, run **F** (Jules integrates → PR). 
+- **Review loop:** **G1** on kimi's raw diff before Jules touches it; **G2** on the Jules PR before you merge.
+
+## Open questions
+
+- **Is E2E actually red right now, or only flaky?** Couldn't reproduce a live run in this environment (no dev server / heavy WASM build). Confirmed the *structural* cause (no `webServer` block) but not the current pass/fail — kimi-cli's first run will tell you.
+- **pnpm vs npm:** lockfile + husky use `pnpm --frozen-lockfile`, so prompts use pnpm. PROJECT CONTEXT lists npm commands — confirm the canonical runner (they're interchangeable here but pick one for Jules/CI consistency).
+- **deploy.py target:** still unverified (host/transport/path). The Claude Code task (E) will surface it via dry-run read.
+- **Chat-history gap:** no `recent_chats`/`conversation_search` this run — if you flagged any web_sequencer bug in another project's session this week, it's not captured here. Drop it into the Ideas section for next run.

--- a/weekly_plan.md
+++ b/weekly_plan.md
@@ -1,0 +1,42 @@
+# web_sequencer — Weekly Plan
+
+## Today's focus
+**Fix First — stabilize the CI/test foundation before new feature work.**
+Restore green Playwright E2E on `main` (#1036: WebKit launch flags + flaky `StartOverlay` gesture/autoplay race + missing `webServer` block in `playwright.config.ts`) and purge the 5 committed `.orig` merge artifacts polluting `src/` (#1039). No new features land on a red E2E matrix or a repo carrying merge scars.
+
+Secondary (decoupled, for Copilot lane): master true-peak (ISP) limiter + LUFS/peak metering suite on the audio-graph output — touches `src/audio/graph/` + a new meter worklet, zero overlap with the test-fixture files kimi-cli will touch.
+
+## Ideas
+<!--
+User-written ideas go here during the week. Routine prioritizes these over generated ideas.
+Format: - [ ] Short description
+This section was EMPTY at first run (no prior weekly_plan.md existed). The two unpicked
+generated ideas below are seeded so future runs inherit them.
+-->
+- [ ] Master true-peak (ISP) limiter + LUFS/short-term/momentary metering suite on the master bus (`src/audio/graph/`) — generated 2026-08-03, decoupled Copilot lane today
+- [ ] `OscillatorBackend` interface + deterministic non-silent fallback so WebGPU→WASM→Pyodide→Native never yields silence on a failed tier (#1035) — generated 2026-08-03
+- [ ] AudioContext `latencyHint` + `sampleRate` negotiation policy (#1033) — generated 2026-08-03
+
+## Backlog
+<!-- Unfinished items, known bugs, deferred work. Reconciled from open GitHub issues + repo state. -->
+- [ ] #1036 ci(e2e): restore green Playwright on main (WebKit flags + flaky StartOverlay) — **PROMOTED TO TODAY'S FOCUS**
+- [ ] #1039 chore(repo): purge `.orig` merge artifacts + complete mega-module splits — **PARTIALLY IN TODAY'S FOCUS** (the `.orig` purge; mega-module splits deferred)
+- [ ] #1038 epic(graph): visual modular patch bay for sends, returns, and engine routing
+- [ ] #1037 feat(audio): master true-peak limiter + LUFS/peak metering suite (overlaps today's Copilot lane)
+- [ ] #1035 foundation(engine): OscillatorBackend interface + deterministic non-silent fallback
+- [ ] #1034 foundation(wasm): audit emcc INITIAL_MEMORY=512mb, pthread pool, AS wasm-gc flags
+- [ ] #1033 foundation(audio): AudioContext latencyHint + sampleRate negotiation policy
+- [ ] #1032 refactor: split `src/hooks/useAudioEngine.ts` into modules <700 lines
+- [ ] #1031 refactor: split `src/hooks/audioEngine/audioPlayback.ts` into modules <700 lines
+- [ ] #1030 refactor: split `src/components/__tests__/knobMaterial.contract.test.ts` into modules <700 lines
+- [ ] Follow-ups from Unreleased CHANGELOG: #632 (per-voice 303 engine selection UI), #633 (Prophecy controls discoverability), #634 (engine/help visibility)
+
+## Done
+<!-- Completed items, archived with date. -->
+- [x] CI unit gate restored green — 5/5 steps (install / build:wasm / tsc / lint / test = 1280 tests) — completed 2026-07-20 (per `.swarm-state.md`); pre-push husky guard added. NOTE: this covered the **unit/lint** gate, not the E2E/Playwright matrix, which remains red (see #1036).
+
+## Last run
+Date: 2026-08-03 (first run — no prior weekly_plan.md existed)
+Mode: Fix First
+Focus: Restore green Playwright E2E (#1036) + purge `.orig` merge artifacts (#1039)
+Outcome: Plan generated. Dispatch produced for kimi-cli (E2E fix), Copilot issue (master limiter/LUFS lane), 3 chat-model expansions, Claude Code whole-stack pipeline exercise, Jules wrap-up template, and 2 Gemini review prompts. weekly_plan.md created and committed.


### PR DESCRIPTION
## Summary

Adds `weekly_plan.md` — the first run of the weekly planner routine for web_sequencer. No prior plan file existed, so this seeds the full structure (Today's focus / Ideas / Backlog / Done / Last run) reconciled from repo state and open GitHub issues.

**Mode: Fix First.** The repo carries live foundation cracks that gate new feature work:
- **#1036** — Playwright E2E red/flaky on `main` (WebKit launch flags + flaky `StartOverlay` gesture/autoplay race). Confirmed `playwright.config.ts` has **no `webServer` block**, so E2E depends on a manually-started dev server — a real flakiness source.
- **#1039** — 5 committed `.orig` merge artifacts still polluting `src/` (verified present: `MainSequencer.tsx.orig`, `useAudioEngine.ts.orig`, `audioPlayback.ts.orig`, `useAppState.tsx.orig`, `PhonemeAligner.ts.orig`).

The `.swarm-state.md` from 2026-07-20 shows the **unit/lint** CI gate was restored green (1280 tests), but that never covered the E2E matrix — hence #1036 remains open.

## Changes
- New file: `weekly_plan.md`

## Notes
- Backlog reconciled from open issues #1030–#1039.
- Two generated ideas (deterministic oscillator fallback #1035, AudioContext negotiation #1033) seeded into Ideas for future runs.
- No code touched — planning artifact only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Trygp7VY8zkb7mwfJ9yz8F

---
_Generated by [Claude Code](https://claude.ai/code/session_01Trygp7VY8zkb7mwfJ9yz8F)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a weekly planning document outlining priorities for improving end-to-end test stability.
  - Documented plans for audio limiting and metering work, future ideas, issue-based backlog items, completed CI tasks, and results from the initial run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->