### PR TITLE
Refactor VoiceManager and SingingVoiceManager to use a generic VoicePool base class

### DIFF
--- a/src/engines/SingingVoiceManager.ts
+++ b/src/engines/SingingVoiceManager.ts
@@ -1,5 +1,6 @@
 import { SingingVoice, type SingingVoiceConfig } from './SingingVoice';
 import { playbackHealthMonitor } from '../audio/playback/PlaybackHealthMonitor';
+import { VoicePool } from './base/VoicePool';
 
 interface ActiveVoice {
     voice: SingingVoice;
@@ -8,17 +9,15 @@ interface ActiveVoice {
     source?: AudioBufferSourceNode; // For fallback mode
 }
 
-export class SingingVoiceManager {
+export class SingingVoiceManager extends VoicePool<SingingVoice> {
     private audioContext: AudioContext;
-    private voices: SingingVoice[] = [];
     private activeVoices: Map<number, ActiveVoice> = new Map();
     private loadedBanks: Map<number, string> = new Map();
     private config: SingingVoiceConfig;
-    private maxVoices: number;
 
     constructor(audioContext: AudioContext, maxVoices: number = 12, config: SingingVoiceConfig = {}) {
+        super(maxVoices);
         this.audioContext = audioContext;
-        this.maxVoices = maxVoices;
         this.config = {
             useHighQuality: false,
             preserveFormants: true,
@@ -55,50 +54,37 @@ export class SingingVoiceManager {
      * Prioritizes voices that already have the requested bank loaded to avoid redundant buffer transfers.
      * @returns The allocated SingingVoice, its index, and whether a new bank load is required.
      */
+    protected override getAffinityKey(index: number): string | undefined {
+        return this.loadedBanks.get(index);
+    }
+
+    protected override onStolen(voice: SingingVoice, index: number, time?: number): void {
+        super.onStolen(voice, index, time);
+        playbackHealthMonitor.recordVoiceSteal('singingVoice');
+        this.activeVoices.delete(index);
+    }
+
+    protected override stopVoice(voice: SingingVoice, time?: number): void {
+        voice.noteOff(time ?? this.audioContext.currentTime);
+    }
+
+    /**
+     * Acquire a free voice or steal the oldest one.
+     * Prioritizes voices that already have the requested bank loaded to avoid redundant buffer transfers.
+     * @returns The allocated SingingVoice, its index, and whether a new bank load is required.
+     */
     acquireVoiceForBank(bankId: string): { voice: SingingVoice; index: number; isNewBank: boolean } {
-        const activeIndices = new Set(this.activeVoices.keys());
+        const result = this.acquire({ affinityKey: bankId, steal: 'oldest' });
 
-        // 1. Find a free voice that already has this bank loaded
-        for (let i = 0; i < this.maxVoices; i++) {
-            if (!activeIndices.has(i) && this.loadedBanks.get(i) === bankId) {
-                return { voice: this.voices[i], index: i, isNewBank: false };
-            }
+        if (!result.affinityHit) {
+            this.loadedBanks.set(result.index, bankId);
         }
 
-        // 2. Find any free voice
-        for (let i = 0; i < this.maxVoices; i++) {
-            if (!activeIndices.has(i)) {
-                this.loadedBanks.set(i, bankId);
-                return { voice: this.voices[i], index: i, isNewBank: true };
-            }
-        }
-
-        // 3. Steal oldest voice
-        let oldestTime = Infinity;
-        let oldestIndex = -1;
-
-        // ⚡ Bolt Optimization: Replacing forEach with a block loop to prevent closure allocations
-        for (const [index, v] of this.activeVoices.entries()) {
-            if (v.startTime < oldestTime) {
-                oldestTime = v.startTime;
-                oldestIndex = index;
-            }
-        }
-
-        if (oldestIndex !== -1) {
-            const stolen = this.activeVoices.get(oldestIndex);
-            if (stolen) {
-                stolen.voice.noteOff(this.audioContext.currentTime);
-                this.activeVoices.delete(oldestIndex);
-                playbackHealthMonitor.recordVoiceSteal('singingVoice');
-            }
-            this.loadedBanks.set(oldestIndex, bankId);
-            return { voice: this.voices[oldestIndex], index: oldestIndex, isNewBank: true };
-        }
-
-        // Fallback
-        this.loadedBanks.set(0, bankId);
-        return { voice: this.voices[0], index: 0, isNewBank: true };
+        return {
+            voice: result.voice,
+            index: result.index,
+            isNewBank: !result.affinityHit
+        };
     }
 
     /**
@@ -112,6 +98,7 @@ export class SingingVoiceManager {
      * Register a voice as active.
      */
     registerActiveVoice(index: number, note: string, startTime: number) {
+        this.markActive(index, startTime);
         this.activeVoices.set(index, {
             voice: this.voices[index],
             note,
@@ -123,6 +110,7 @@ export class SingingVoiceManager {
      * Release a specific voice index.
      */
     releaseVoice(index: number) {
+        this.markInactive(index);
         this.activeVoices.delete(index);
     }
 
@@ -131,13 +119,6 @@ export class SingingVoiceManager {
      */
     getVoice(index: number): SingingVoice | undefined {
         return this.voices[index];
-    }
-
-    /**
-     * Get all voices (active or not)
-     */
-    getAllVoices(): SingingVoice[] {
-        return this.voices;
     }
 
     /**
@@ -155,11 +136,8 @@ export class SingingVoiceManager {
         return Array.from(this.activeVoices.values()).map(v => v.voice);
     }
 
-    stopAll() {
-        for (const activeVoice of this.activeVoices.values()) {
-            activeVoice.voice.noteOff(this.audioContext.currentTime);
-        }
+    override stopAll(time?: number) {
+        super.stopAll(time ?? this.audioContext.currentTime);
         this.activeVoices.clear();
-        // Reset params on all voices?
     }
 }

--- a/src/engines/VoiceManager.ts
+++ b/src/engines/VoiceManager.ts
@@ -11,6 +11,7 @@ import {
     generatePyodideLoopBuffer,
     type PyodideLike,
 } from '../utils/pyodideBuffers';
+import { VoicePool, type PoolableVoice } from './base/VoicePool';
 
 export interface VoiceEngineDeps {
     wasmEngine?: WasmOscillator | null;
@@ -20,7 +21,7 @@ export interface VoiceEngineDeps {
     pyodideBuffers?: Partial<Record<WaveShape, AudioBuffer | null>>;
 }
 
-export class Voice {
+export class Voice implements PoolableVoice {
     context: AudioContext;
     destination: AudioNode;
 
@@ -387,9 +388,7 @@ export class Voice {
     }
 }
 
-export class VoiceManager {
-    private voices: Voice[];
-    private currentIndex: number = 0;
+export class VoiceManager extends VoicePool<Voice> {
     private monophonic: boolean;
 
     constructor(
@@ -402,10 +401,20 @@ export class VoiceManager {
         globalDelayNode?: DelayNode,
         engineDeps?: VoiceEngineDeps,
     ) {
+        super(polyphony);
         this.monophonic = monophonic;
-        this.voices = Array.from({ length: Math.max(1, polyphony) }, () =>
+        this.voices = Array.from({ length: this.maxVoices }, () =>
             new Voice(context, destination, wavSaw, wavSqr, globalDelayNode, engineDeps)
         );
+    }
+
+    protected override onStolen(voice: Voice, index: number, time?: number): void {
+        super.onStolen(voice, index, time);
+        playbackHealthMonitor.recordVoiceSteal(this.monophonic ? 'voiceManager-monophonic' : 'voiceManager');
+    }
+
+    protected override stopVoice(voice: Voice, time?: number): void {
+        voice.stop(time ?? voice.context.currentTime);
     }
 
     playNote(
@@ -435,19 +444,18 @@ export class VoiceManager {
     }
 
     noteOff(note: string, time: number, params: SynthParams): void {
-        for (const voice of this.voices) {
+        for (let i = 0; i < this.voices.length; i++) {
+            const voice = this.voices[i]!;
             if (voice.isActive && voice.currentNote === note) {
                 voice.stopNote(time, params);
+                this.markInactive(i);
                 break;
             }
         }
     }
 
-    stopAll(time?: number): void {
-        // ⚡ Bolt Optimization: Replace forEach with for...of to prevent closure allocations
-        for (const v of this.voices) {
-            v.stop(time ?? v.context.currentTime);
-        }
+    override stopAll(time?: number): void {
+        super.stopAll(time ?? this.voices[0]?.context.currentTime ?? 0);
     }
 
     updateEngineDeps(deps: Partial<VoiceEngineDeps>): void {
@@ -458,30 +466,23 @@ export class VoiceManager {
 
     /** Prefer idle voices; stop and steal the round-robin victim when saturated. */
     private pickVoice(time: number): Voice {
-        if (this.monophonic) {
-            const voice = this.voices[0]!;
-            if (voice.isActive) {
-                voice.stop(time);
-                playbackHealthMonitor.recordVoiceSteal('voiceManager-monophonic');
-            }
-            return voice;
-        }
-
+        // We can optionally clean up `activeIndices` if `voice.isActive` went false externally.
+        // E.g., Voice has an internal timeout for release. Let's sync `activeIndices` with real `isActive`.
         for (let i = 0; i < this.voices.length; i++) {
-            const idx = (this.currentIndex + i) % this.voices.length;
-            const candidate = this.voices[idx]!;
-            if (!candidate.isActive) {
-                this.currentIndex = (idx + 1) % this.voices.length;
-                return candidate;
+            if (!this.voices[i]!.isActive && this.activeIndices.has(i)) {
+                this.markInactive(i);
             }
         }
 
-        const victim = this.voices[this.currentIndex]!;
-        this.currentIndex = (this.currentIndex + 1) % this.voices.length;
-        if (victim.isActive) {
-            victim.stop(time);
-            playbackHealthMonitor.recordVoiceSteal('voiceManager');
+        if (this.monophonic) {
+            const result = this.acquire({ steal: 'round-robin', time });
+            // Since it's monophonic, maxVoices is 1, so index is always 0.
+            this.markActive(result.index, time);
+            return result.voice;
         }
-        return victim;
+
+        const result = this.acquire({ steal: 'round-robin', time });
+        this.markActive(result.index, time);
+        return result.voice;
     }
 }

--- a/src/engines/base/VoicePool.ts
+++ b/src/engines/base/VoicePool.ts
@@ -1,0 +1,151 @@
+export type StealPolicy = 'round-robin' | 'oldest';
+
+export interface AcquireOptions {
+    affinityKey?: string;
+    steal?: StealPolicy;
+    time?: number;
+}
+
+export interface AcquireResult<T> {
+    voice: T;
+    index: number;
+    stole: boolean;
+    affinityHit: boolean;
+}
+
+export interface PoolableVoice {
+    isActive: boolean;
+}
+
+export abstract class VoicePool<TVoice extends PoolableVoice> {
+    protected voices: TVoice[] = [];
+    protected maxVoices: number;
+
+    protected activeIndices: Set<number> = new Set();
+    protected startTimes: Map<number, number> = new Map();
+    protected roundRobinIndex: number = 0;
+
+    constructor(maxVoices: number) {
+        this.maxVoices = Math.max(1, maxVoices);
+    }
+
+    /**
+     * Get all voices in the pool (active or inactive).
+     */
+    public getAllVoices(): TVoice[] {
+        return this.voices;
+    }
+
+    /**
+     * Core allocation logic. Finds an idle voice, optionally matching an affinity key,
+     * or steals one based on the specified policy.
+     */
+    protected acquire(options: AcquireOptions = {}): AcquireResult<TVoice> {
+        const { affinityKey, steal = 'round-robin', time } = options;
+
+        // 1. Find free voice with affinity match
+        if (affinityKey !== undefined) {
+            for (let i = 0; i < this.maxVoices; i++) {
+                if (!this.activeIndices.has(i)) {
+                    if (this.getAffinityKey(i) === affinityKey) {
+                        return { voice: this.voices[i]!, index: i, stole: false, affinityHit: true };
+                    }
+                }
+            }
+        }
+
+        // 2. Find any free voice
+        for (let i = 0; i < this.maxVoices; i++) {
+            // For round-robin, we check starting from the roundRobinIndex
+            const checkIndex = steal === 'round-robin'
+                ? (this.roundRobinIndex + i) % this.maxVoices
+                : i;
+
+            if (!this.activeIndices.has(checkIndex)) {
+                if (steal === 'round-robin') {
+                    this.roundRobinIndex = (checkIndex + 1) % this.maxVoices;
+                }
+                return { voice: this.voices[checkIndex]!, index: checkIndex, stole: false, affinityHit: false };
+            }
+        }
+
+        // 3. Steal
+        let victimIndex = 0;
+
+        if (steal === 'oldest') {
+            let oldestTime = Infinity;
+            victimIndex = -1;
+
+            for (const index of this.activeIndices) {
+                const startTime = this.startTimes.get(index) ?? Infinity;
+                if (startTime < oldestTime) {
+                    oldestTime = startTime;
+                    victimIndex = index;
+                }
+            }
+            if (victimIndex === -1) victimIndex = 0; // Fallback
+        } else {
+            // round-robin steal
+            victimIndex = this.roundRobinIndex;
+            this.roundRobinIndex = (this.roundRobinIndex + 1) % this.maxVoices;
+        }
+
+        const victimVoice = this.voices[victimIndex]!;
+
+        // Trigger steal hook
+        this.onStolen(victimVoice, victimIndex, time);
+
+        // Ensure it's removed from active set
+        this.markInactive(victimIndex);
+
+        return { voice: victimVoice, index: victimIndex, stole: true, affinityHit: false };
+    }
+
+    /**
+     * Mark a voice as active.
+     */
+    protected markActive(index: number, startTime: number = 0): void {
+        this.activeIndices.add(index);
+        this.startTimes.set(index, startTime);
+    }
+
+    /**
+     * Mark a voice as inactive.
+     */
+    protected markInactive(index: number): void {
+        this.activeIndices.delete(index);
+        this.startTimes.delete(index);
+    }
+
+    /**
+     * Stop all active voices immediately.
+     */
+    public stopAll(time?: number): void {
+        const indices = Array.from(this.activeIndices);
+        for (const index of indices) {
+            this.stopVoice(this.voices[index]!, time);
+            this.markInactive(index);
+        }
+    }
+
+    // --- Hooks ---
+
+    /**
+     * Optional: Return the current affinity key (e.g. loaded bank ID) for a slot.
+     */
+    protected getAffinityKey(index: number): string | undefined {
+        return undefined;
+    }
+
+    /**
+     * Hook called when a voice is stolen.
+     */
+    protected onStolen(voice: TVoice, index: number, time?: number): void {
+        this.stopVoice(voice, time);
+    }
+
+    /**
+     * Adapter to stop a voice.
+     */
+    protected abstract stopVoice(voice: TVoice, time?: number): void;
+}


### PR DESCRIPTION
- Created a generic VoicePool base class in src/engines/base/VoicePool.ts to handle voice tracking, idle scanning, and stealing policies.\n- Refactored VoiceManager to subclass VoicePool using a round-robin steal policy.\n- Refactored SingingVoiceManager to subclass VoicePool utilizing its loaded bank affinity mapping and oldest-steal policy.\n- Updated agent_plan.md to add new tasks to the Innovation Lab and check off completed refactoring items.\n- Fixed unit tests to ensure they pass with the new base class logic.

---
*PR created automatically by Jules for task [1897291123809398995](https://jules.google.com/task/1897291123809398995) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added shared voice-pool management for singing and regular voices.
  - Improved voice allocation with round-robin and oldest-voice selection options.
  - Added affinity-aware voice selection for better handling of related sounds.
  - Added tracking of active voices and voice start times.
  - Added support for stopping all active voices at a specified time.

- **Bug Fixes**
  - Improved handling of stolen and released voices to prevent stale active states.
  - Improved reuse of available voices in both monophonic and polyphonic playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->