### PR TITLE
Unify oscillator engines behind a shared OscillatorBackend contract

### DIFF
--- a/src/components/EngineHUD.tsx
+++ b/src/components/EngineHUD.tsx
@@ -1,6 +1,7 @@
 // Side-effecting HUD mount. Lightweight DOM overlay that polls engineTelemetry.
 import { engineTelemetry } from '../utils/engineTelemetry';
 import { LATENCY_MODES, getStoredLatencyMode, setStoredLatencyMode, type LatencyMode } from '../utils/audioLatencyMode';
+import { getOscillatorRegistry } from '../engines/backends/BackendRegistry';
 
 const CONTAINER_ID = 'engine-hud-root';
 if (typeof window !== 'undefined' && !document.getElementById(CONTAINER_ID)) {
@@ -29,6 +30,8 @@ if (typeof window !== 'undefined' && !document.getElementById(CONTAINER_ID)) {
   #${CONTAINER_ID} .backend-wasm { background:#0ea5e9; }
   #${CONTAINER_ID} .backend-js { background:#6b7280; }
   #${CONTAINER_ID} .backend-wav { background:#f59e0b; color:#000 }
+  #${CONTAINER_ID} .backend-wam { background:#0ea5e9; }
+  #${CONTAINER_ID} .backend-rust { background:#b45309; }
   #${CONTAINER_ID} .backend-open303 { background:#7c3aed }
   #${CONTAINER_ID} .cpu-ok { color:#86efac; }
   #${CONTAINER_ID} .cpu-warn { color:#fde047; }
@@ -119,6 +122,28 @@ if (typeof window !== 'undefined' && !document.getElementById(CONTAINER_ID)) {
       <div class="row"><div style="flex:1">GPU 303</div><div style="min-width:72px;text-align:right">${gpuBackend} ${gpuLat}</div></div>
       <div class="row" title="${runtime.gpuFallbackReason ?? ''}"><div style="flex:1">GPU fallback</div><div style="min-width:72px;text-align:right;font-size:10px">${gpuFb}</div></div>`;
 
+    // Oscillator backend chain (#1034): shows every backend in preference order,
+    // which one is active, and why the higher-preference ones were skipped.
+    const registry = getOscillatorRegistry();
+    const resolution = registry?.getLastResolution() ?? null;
+    const backendSection = (() => {
+      if (!resolution) return '';
+      const attemptRows = resolution.attempts.map((a) => {
+        const active = a.id === resolution.active;
+        const state = active ? 'ACTIVE' : a.reason ?? (a.ready ? 'ready' : 'not ready');
+        const color = active ? '#86efac' : a.reason ? '#f87171' : '#9ca3af';
+        return `<div class="row" title="${a.reason ?? ''}">
+          <div class="badge backend-${a.id}">${a.id}</div>
+          <div style="flex:1"></div>
+          <div style="color:${color};font-size:10px;text-align:right;max-width:190px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${state}</div>
+        </div>`;
+      }).join('');
+      const header = resolution.degraded
+        ? `<div style="font-size:11px;color:#fde047" title="${resolution.reason ?? ''}">fallback: ${resolution.requested} → ${resolution.active}</div>`
+        : `<div style="font-size:11px;opacity:0.7">preferred backend active (${resolution.active})</div>`;
+      return `<div class="subheader">Oscillator backends</div>${header}${attemptRows}`;
+    })();
+
     const workletNames = ['clock', 'open303', 'rubberband', 'vocoder'];
     const workletRows = workletNames.map((name) => {
       const w = runtime.worklets[name];
@@ -142,7 +167,7 @@ if (typeof window !== 'undefined' && !document.getElementById(CONTAINER_ID)) {
       ? `<div class="subheader">Degradations</div><div style="font-size:11px;opacity:0.85">${runtime.degradations.slice(-3).map(d => `${d.step}: ${d.active ? 'ON' : 'off'}`).join(' · ')}</div>`
       : '';
 
-    container.innerHTML = `<div class="header">Engine HUD</div>${summary}${latencySection}${offlineSection}<div class="subheader">Worklets</div>${workletRows}${degradeNote}<div class="subheader">Subsystems</div>${rows}<div class="hud-actions"><button type="button" id="hud-export-btn">Download Report</button><button type="button" id="hud-copy-btn">Copy JSON</button></div>`;
+    container.innerHTML = `<div class="header">Engine HUD</div>${summary}${latencySection}${offlineSection}${backendSection}<div class="subheader">Worklets</div>${workletRows}${degradeNote}<div class="subheader">Subsystems</div>${rows}<div class="hud-actions"><button type="button" id="hud-export-btn">Download Report</button><button type="button" id="hud-copy-btn">Copy JSON</button></div>`;
   }
 
   // Event delegation: render() replaces innerHTML every 500ms, so per-render

--- a/src/engines/VoiceManager.ts
+++ b/src/engines/VoiceManager.ts
@@ -4,7 +4,7 @@ import type { ScaleDefinition } from '../utils/musicTheory';
 import { parseWaveform, shapeToOscillatorType, type WaveShape } from '../utils/waveformParser';
 import type { WasmOscillator } from './WasmOscillator';
 import type { RustOscillator } from './RustOscillator';
-import { logEngineFallback } from '../utils/engineTelemetry';
+import { logEngineFallback, logWaveformSubstitution } from '../utils/engineTelemetry';
 import { playbackHealthMonitor } from '../audio/playback/PlaybackHealthMonitor';
 import {
     PYODIDE_REF_FREQ,
@@ -203,7 +203,20 @@ export class Voice implements PoolableVoice {
                 // Rust/WASM oscillator. Supports saw and sqr only; tri/sin are not
                 // defined as valid Rust waveforms in types.ts so this is a guard.
                 if (this.engineDeps?.rustEngine?.isReady) {
-                    const rustShape = (parsed.shape === 'tri' || parsed.shape === 'sin') ? 'saw' : parsed.shape as 'saw' | 'sqr';
+                    // The Rust kernel only implements saw/sqr. Mapping tri/sin onto
+                    // saw changes the wave family the user hears, so it is reported
+                    // (HUD + telemetry) instead of being applied silently.
+                    const needsSubstitution = parsed.shape === 'tri' || parsed.shape === 'sin';
+                    const rustShape = needsSubstitution ? 'saw' : (parsed.shape as 'saw' | 'sqr');
+                    if (needsSubstitution) {
+                        logWaveformSubstitution(
+                            'rust',
+                            'rust',
+                            parsed.shape,
+                            rustShape,
+                            'Rust oscillator implements saw/sqr only',
+                        );
+                    }
                     const float = this.engineDeps.rustEngine.generate(
                         REF_FREQ,
                         2.0,

--- a/src/engines/__tests__/Voice.test.ts
+++ b/src/engines/__tests__/Voice.test.ts
@@ -7,6 +7,7 @@ import { Voice, type VoiceEngineDeps } from '../VoiceManager';
 import type { WasmOscillator } from '../WasmOscillator';
 import type { RustOscillator } from '../RustOscillator';
 import type { SynthParams } from '../../types';
+import { engineDegradationStore } from '../../stores/engineDegradationStore';
 
 // ── Minimal SynthParams fixture ──────────────────────────────────────────────
 
@@ -266,6 +267,24 @@ describe('Voice.startNote — Rust engine', () => {
 
         expect(warn).toHaveBeenCalledWith(expect.stringContaining('rust-sqr'));
         expect(warn).toHaveBeenCalledWith(expect.stringContaining('returned empty'));
+        warn.mockRestore();
+    });
+
+    it('reports the tri → saw wave-family substitution instead of applying it silently', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const rustEngine = { isReady: true, generate: vi.fn(() => new Float32Array(512).fill(0.2)) };
+        const ctx = makeContext(makeOscillatorMock(), makeBufferSourceMock());
+        const voice = makeVoice({ rustEngine: rustEngine as unknown as RustOscillator }, undefined, undefined, ctx);
+
+        // 'rust-tri' is outside the Waveform union; the cast exercises the
+        // runtime guard that maps unsupported Rust shapes onto saw.
+        voice.startNote({ ...BASE_PARAMS, waveform: 'rust-tri' as SynthParams['waveform'] }, 'C4', 0);
+
+        expect(rustEngine.generate).toHaveBeenCalledWith(
+            261.63, 2.0, 44100, 'saw', expect.any(Number), expect.any(Number),
+        );
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('WaveformSubstitution'));
+        expect(engineDegradationStore.getIssue('waveform-substitution-rust-tri')?.status).toBe('active');
         warn.mockRestore();
     });
 });

--- a/src/engines/backends/BackendRegistry.ts
+++ b/src/engines/backends/BackendRegistry.ts
@@ -1,0 +1,300 @@
+/**
+ * Ordered oscillator backend selection (#1034).
+ *
+ * One place decides which backend is active, in one documented order:
+ *   WebGPU → AS WASM (wam) → Rust WASM → WAV PCM → pure JS
+ *
+ * Every step down that chain is recorded: telemetry resolution, the engine
+ * degradation store (drives the banner) and the EngineHUD all read from the
+ * same `BackendResolution`. There is no silent fallback path.
+ */
+
+import {
+    BACKEND_FALLBACK_ORDER,
+    BACKEND_LABELS,
+    type GenerateRequest,
+    type OscillatorBackend,
+    type OscillatorBackendId,
+} from './OscillatorBackend';
+import type { WaveShape } from '../../utils/waveformParser';
+import { engineTelemetry, logWaveformSubstitution } from '../../utils/engineTelemetry';
+import { engineDegradationStore } from '../../stores/engineDegradationStore';
+
+export const OSCILLATOR_SUBSYSTEM = 'oscillators';
+
+export interface BackendAttempt {
+    id: OscillatorBackendId;
+    supported: boolean;
+    ready: boolean;
+    /** Why this backend was skipped (undefined when it was selected). */
+    reason?: string;
+}
+
+export interface BackendResolution {
+    /** Backend actually selected. Never null — `js` is the terminal fallback. */
+    active: OscillatorBackendId;
+    /** Highest-preference backend in the registry, i.e. what we wanted. */
+    requested: OscillatorBackendId;
+    /** True when `active` is not `requested`. */
+    degraded: boolean;
+    /** Ordered record of what was tried and why it was skipped. */
+    attempts: BackendAttempt[];
+    /** Combined reason string for the HUD / banner (undefined when not degraded). */
+    reason?: string;
+    ts: number;
+}
+
+export class BackendRegistry {
+    private backends = new Map<OscillatorBackendId, OscillatorBackend>();
+    private lastResolution: BackendResolution | null = null;
+
+    register(backend: OscillatorBackend): void {
+        this.backends.set(backend.id, backend);
+    }
+
+    get(id: OscillatorBackendId): OscillatorBackend | undefined {
+        return this.backends.get(id);
+    }
+
+    /** Registered backends in fallback-preference order. */
+    ordered(): OscillatorBackend[] {
+        const out: OscillatorBackend[] = [];
+        for (const id of BACKEND_FALLBACK_ORDER) {
+            const b = this.backends.get(id);
+            if (b) out.push(b);
+        }
+        return out;
+    }
+
+    /** Initialize every registered backend, preference order, failures tolerated. */
+    async initAll(ctx: AudioContext): Promise<void> {
+        for (const backend of this.ordered()) {
+            try {
+                const result = await backend.init(ctx);
+                if (!result.ok) {
+                    console.warn(
+                        `[BackendRegistry] ${backend.id} unavailable: ${result.reason ?? 'unknown'}`,
+                    );
+                }
+            } catch (e) {
+                console.warn(`[BackendRegistry] ${backend.id} init threw`, e);
+                try {
+                    engineTelemetry.recordError(OSCILLATOR_SUBSYSTEM, e);
+                } catch {
+                    /* telemetry must never break audio init */
+                }
+            }
+        }
+    }
+
+    /**
+     * Walk the preference chain and pick the first supported+ready backend.
+     * When `shape` is given, backends that would have to change wave family to
+     * service it are skipped (and the skip is logged) rather than substituting.
+     */
+    resolve(shape?: WaveShape): BackendResolution {
+        const ordered = this.ordered();
+        const attempts: BackendAttempt[] = [];
+        const requested = ordered[0]?.id ?? 'js';
+
+        let active: OscillatorBackendId | null = null;
+
+        for (const backend of ordered) {
+            const supported = backend.isSupported;
+            const ready = backend.isReady;
+
+            if (!supported || !ready) {
+                attempts.push({
+                    id: backend.id,
+                    supported,
+                    ready,
+                    reason: !supported ? 'unsupported in this environment' : 'not initialized',
+                });
+                continue;
+            }
+            if (shape && !backend.supportsShape(shape)) {
+                attempts.push({
+                    id: backend.id,
+                    supported,
+                    ready,
+                    reason: `does not render "${shape}" natively`,
+                });
+                continue;
+            }
+            attempts.push({ id: backend.id, supported, ready });
+            active = backend.id;
+            break;
+        }
+
+        // `js` is always registered in practice; guard so resolve() is total.
+        const resolvedActive = active ?? 'js';
+        const degraded = resolvedActive !== requested;
+        const reason = degraded
+            ? attempts
+                  .filter((a) => a.reason)
+                  .map((a) => `${a.id}: ${a.reason}`)
+                  .join('; ')
+            : undefined;
+
+        const resolution: BackendResolution = {
+            active: resolvedActive,
+            requested,
+            degraded,
+            attempts,
+            reason,
+            ts: Date.now(),
+        };
+        this.lastResolution = resolution;
+        return resolution;
+    }
+
+    getLastResolution(): BackendResolution | null {
+        return this.lastResolution;
+    }
+
+    /**
+     * Resolve, then publish the outcome to telemetry + the degradation store.
+     * Call this once per selection so a fallback is always user-visible.
+     */
+    resolveAndPublish(shape?: WaveShape): BackendResolution {
+        const resolution = this.resolve(shape);
+        publishResolution(resolution);
+        return resolution;
+    }
+
+    /**
+     * Render through the chain: try each usable backend in order, dropping to
+     * the next on null/throw. Every drop is logged. Returns the buffer plus the
+     * backend that produced it.
+     */
+    async generate(
+        req: GenerateRequest,
+    ): Promise<{ samples: Float32Array; backendId: OscillatorBackendId } | null> {
+        const ordered = this.ordered();
+        const requested = ordered[0]?.id ?? 'js';
+        const skipped: string[] = [];
+
+        for (const backend of ordered) {
+            if (!backend.isSupported || !backend.isReady) {
+                skipped.push(`${backend.id}: ${backend.isSupported ? 'not initialized' : 'unsupported'}`);
+                continue;
+            }
+            if (!backend.supportsShape(req.shape)) {
+                skipped.push(`${backend.id}: cannot render "${req.shape}"`);
+                continue;
+            }
+            try {
+                const samples = await backend.generate(req);
+                if (samples && samples.length > 0) {
+                    if (backend.id !== requested) {
+                        publishResolution({
+                            active: backend.id,
+                            requested,
+                            degraded: true,
+                            attempts: [],
+                            reason: skipped.join('; ') || 'higher-preference backend returned no samples',
+                            ts: Date.now(),
+                        });
+                    }
+                    return { samples, backendId: backend.id };
+                }
+                skipped.push(`${backend.id}: returned no samples`);
+            } catch (e) {
+                skipped.push(`${backend.id}: threw (${e instanceof Error ? e.message : String(e)})`);
+                try {
+                    engineTelemetry.recordError(OSCILLATOR_SUBSYSTEM, e);
+                } catch {
+                    /* best-effort */
+                }
+            }
+        }
+
+        console.error(
+            `[BackendRegistry] no oscillator backend could render "${req.shape}": ${skipped.join('; ')}`,
+        );
+        return null;
+    }
+
+    disposeAll(): void {
+        for (const backend of this.backends.values()) {
+            try {
+                backend.dispose();
+            } catch {
+                /* disposal must not throw during teardown */
+            }
+        }
+        this.backends.clear();
+        this.lastResolution = null;
+    }
+}
+
+/**
+ * Process-wide handle on the registry the audio engine built, so diagnostic
+ * surfaces (EngineHUD, degradation banner) can read the live chain without
+ * threading a ref through the React tree.
+ */
+let activeRegistry: BackendRegistry | null = null;
+
+export function setOscillatorRegistry(registry: BackendRegistry | null): void {
+    activeRegistry = registry;
+}
+
+export function getOscillatorRegistry(): BackendRegistry | null {
+    return activeRegistry;
+}
+
+/**
+ * Publish a resolution to telemetry + degradation store. Split out so tests can
+ * exercise it directly, and so `generate()` and `resolve()` report identically.
+ */
+export function publishResolution(resolution: BackendResolution): void {
+    try {
+        engineTelemetry.registerResolution(
+            OSCILLATOR_SUBSYSTEM,
+            resolution.active,
+            resolution.reason ?? 'init-decision',
+        );
+
+        if (resolution.degraded) {
+            engineTelemetry.recordDegradation(
+                OSCILLATOR_SUBSYSTEM,
+                true,
+                resolution.reason ?? 'backend fallback',
+            );
+            console.warn(
+                `[BackendRegistry] oscillator backend fell back ` +
+                    `${BACKEND_LABELS[resolution.requested]} → ${BACKEND_LABELS[resolution.active]} ` +
+                    `(${resolution.reason ?? 'unknown'})`,
+            );
+            engineDegradationStore.report({
+                id: 'oscillator-backend',
+                subsystem: OSCILLATOR_SUBSYSTEM,
+                category: resolution.requested === 'webgpu' ? 'gpu' : 'wasm',
+                message: `Oscillators running on ${BACKEND_LABELS[resolution.active]} instead of ${BACKEND_LABELS[resolution.requested]}`,
+                reason: resolution.reason ?? 'backend unavailable',
+                status: 'active',
+                activeBackend: resolution.active,
+                requestedBackend: resolution.requested,
+                retryable: false,
+            });
+        } else {
+            engineDegradationStore.resolve('oscillator-backend');
+        }
+    } catch (e) {
+        console.warn('[BackendRegistry] failed to publish backend resolution', e);
+    }
+}
+
+/**
+ * Report a wave-family substitution made outside the registry (a caller that
+ * already holds a concrete engine). Kept here so every substitution in the
+ * codebase routes through the same telemetry + HUD path.
+ */
+export function reportShapeSubstitution(
+    backendId: OscillatorBackendId,
+    requestedShape: WaveShape,
+    substitutedShape: WaveShape,
+    reason: string,
+): void {
+    logWaveformSubstitution(OSCILLATOR_SUBSYSTEM, backendId, requestedShape, substitutedShape, reason);
+}

--- a/src/engines/backends/OscillatorBackend.ts
+++ b/src/engines/backends/OscillatorBackend.ts
@@ -1,0 +1,115 @@
+/**
+ * Shared oscillator backend contract (#1034).
+ *
+ * Every oscillator implementation (WebGPU, AssemblyScript WASM, Rust WASM,
+ * WAV/PCM, plain JS) is wrapped in an adapter implementing this interface so
+ * that lifecycle code can select, probe and fall back across backends without
+ * knowing anything about the concrete engine — and without `as any` readiness
+ * checks.
+ *
+ * Two rules the contract exists to enforce:
+ *   1. Readiness is typed. `isSupported` (this machine *can* run it) and
+ *      `isReady` (it *is* initialized) are separate, non-optional booleans.
+ *   2. A backend never silently substitutes a different waveform family.
+ *      `supportsShape()` is authoritative; substitution goes through
+ *      `logWaveformSubstitution` so it lands in the HUD and telemetry.
+ */
+
+import type { WaveShape } from '../../utils/waveformParser';
+
+export type OscillatorBackendId = 'webgpu' | 'wam' | 'rust' | 'wav' | 'js';
+
+/**
+ * Ordered preference chain — best first. Selection walks this list and takes
+ * the first backend that is both supported and ready. `js` is terminal: it has
+ * no dependencies and is always ready, so resolution can never come up empty.
+ */
+export const BACKEND_FALLBACK_ORDER: readonly OscillatorBackendId[] = [
+    'webgpu',
+    'wam',
+    'rust',
+    'wav',
+    'js',
+] as const;
+
+/** Human-facing labels for the HUD / degradation banner. */
+export const BACKEND_LABELS: Record<OscillatorBackendId, string> = {
+    webgpu: 'WebGPU',
+    wam: 'AS WASM',
+    rust: 'Rust WASM',
+    wav: 'WAV PCM',
+    js: 'JS oscillator',
+};
+
+export interface BackendCapabilities {
+    /** WASM SIMD is used by the backend's DSP kernel. */
+    simd: boolean;
+    /** Backend can use worker/atomics threading. */
+    threads: boolean;
+    /** Backend can render faster-than-realtime for freeze/export. */
+    offline: boolean;
+    /** Simultaneous voices the backend can sustain; Infinity for graph-native. */
+    polyphony: number;
+    /** Waveform families the backend renders natively. */
+    shapes: readonly WaveShape[];
+}
+
+export interface InitResult {
+    /** Backend finished init and is usable. */
+    ok: boolean;
+    backendId: OscillatorBackendId;
+    /** Why init failed (or a short note on success). Always set on failure. */
+    reason?: string;
+}
+
+export interface GenerateRequest {
+    /** Frequency in Hz of the rendered cycle/table. */
+    frequency: number;
+    /** Duration in seconds. */
+    duration: number;
+    sampleRate: number;
+    shape: WaveShape;
+    /** Lowpass cutoff in Hz. Backends without a filter ignore it. */
+    cutoff: number;
+    /** Filter resonance / Q. Backends without a filter ignore it. */
+    resonance: number;
+}
+
+/**
+ * Normalized surface shared by every oscillator backend.
+ *
+ * `generate` is the required rendering primitive — all current backends are
+ * buffer producers. `noteOn`/`noteOff` are optional and implemented only by
+ * backends that own realtime voices themselves (none today; the hook exists so
+ * a future worklet-resident engine plugs in here rather than adding a parallel
+ * entry point).
+ */
+export interface OscillatorBackend {
+    readonly id: OscillatorBackendId;
+    /** Stable display label. */
+    readonly label: string;
+    /** This environment can run the backend at all (feature detection). */
+    readonly isSupported: boolean;
+    /** Backend has completed init and `generate()` will be attempted. */
+    readonly isReady: boolean;
+    readonly capabilities: BackendCapabilities;
+
+    init(ctx: AudioContext): Promise<InitResult>;
+    /**
+     * Render `duration` seconds. Returns null when the backend cannot service
+     * the request — callers must then fall back (and log it).
+     */
+    generate(req: GenerateRequest): Promise<Float32Array | null>;
+    /** True when the backend renders `shape` without changing wave family. */
+    supportsShape(shape: WaveShape): boolean;
+    dispose(): void;
+
+    /** Optional realtime surface for backends that own their own voices. */
+    noteOn?(note: number, velocity: number, when: number): void;
+    noteOff?(note: number, when: number): void;
+}
+
+/** Convenience guard used by selection code — keeps the checks in one place. */
+export function isBackendUsable(backend: OscillatorBackend | null | undefined): backend is OscillatorBackend {
+    return !!backend && backend.isSupported && backend.isReady;
+}

--- a/src/engines/backends/__tests__/BackendRegistry.test.ts
+++ b/src/engines/backends/__tests__/BackendRegistry.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { BackendRegistry, OSCILLATOR_SUBSYSTEM } from '../BackendRegistry';
+import {
+    BACKEND_FALLBACK_ORDER,
+    type BackendCapabilities,
+    type GenerateRequest,
+    type InitResult,
+    type OscillatorBackend,
+    type OscillatorBackendId,
+} from '../OscillatorBackend';
+import { JsOscillatorBackend } from '../adapters';
+import { engineTelemetry } from '../../../utils/engineTelemetry';
+import { engineDegradationStore } from '../../../stores/engineDegradationStore';
+import type { WaveShape } from '../../../utils/waveformParser';
+
+/** Configurable stub honouring the shared contract — no `as any` anywhere. */
+class StubBackend implements OscillatorBackend {
+    readonly label: string;
+    isSupported: boolean;
+    isReady: boolean;
+    generateResult: Float32Array | null;
+    throwOnGenerate = false;
+    generateCalls = 0;
+
+    readonly id: OscillatorBackendId;
+
+    constructor(
+        id: OscillatorBackendId,
+        opts: {
+            supported?: boolean;
+            ready?: boolean;
+            shapes?: readonly WaveShape[];
+            result?: Float32Array | null;
+        } = {},
+    ) {
+        this.id = id;
+        this.label = id;
+        this.isSupported = opts.supported ?? true;
+        this.isReady = opts.ready ?? true;
+        this.capabilities = {
+            simd: false,
+            threads: false,
+            offline: true,
+            polyphony: 8,
+            shapes: opts.shapes ?? ['saw', 'sqr', 'tri', 'sin'],
+        };
+        this.generateResult = opts.result !== undefined ? opts.result : new Float32Array([1, -1, 1, -1]);
+    }
+
+    capabilities: BackendCapabilities;
+
+    async init(): Promise<InitResult> {
+        return { ok: this.isReady, backendId: this.id };
+    }
+
+    supportsShape(shape: WaveShape): boolean {
+        return this.capabilities.shapes.includes(shape);
+    }
+
+    async generate(_req: GenerateRequest): Promise<Float32Array | null> {
+        this.generateCalls++;
+        if (this.throwOnGenerate) throw new Error('boom');
+        return this.generateResult;
+    }
+
+    dispose(): void {
+        this.isReady = false;
+    }
+}
+
+const REQ: GenerateRequest = {
+    frequency: 261.63,
+    duration: 0.05,
+    sampleRate: 44100,
+    shape: 'saw',
+    cutoff: 8000,
+    resonance: 1,
+};
+
+describe('BackendRegistry ordering', () => {
+    beforeEach(() => {
+        engineDegradationStore.clear('oscillator-backend');
+        vi.restoreAllMocks();
+    });
+
+    it('exposes the documented WebGPU → wam → rust → wav → js chain', () => {
+        expect(BACKEND_FALLBACK_ORDER).toEqual(['webgpu', 'wam', 'rust', 'wav', 'js']);
+    });
+
+    it('orders registered backends by preference, not registration order', () => {
+        const registry = new BackendRegistry();
+        registry.register(new StubBackend('js'));
+        registry.register(new StubBackend('webgpu'));
+        registry.register(new StubBackend('rust'));
+        expect(registry.ordered().map((b) => b.id)).toEqual(['webgpu', 'rust', 'js']);
+    });
+
+    it('selects the highest-preference backend that is supported and ready', () => {
+        const registry = new BackendRegistry();
+        registry.register(new StubBackend('webgpu', { supported: false }));
+        registry.register(new StubBackend('wam', { ready: false }));
+        registry.register(new StubBackend('rust'));
+        registry.register(new JsOscillatorBackend());
+
+        const resolution = registry.resolve();
+        expect(resolution.active).toBe('rust');
+        expect(resolution.requested).toBe('webgpu');
+        expect(resolution.degraded).toBe(true);
+        expect(resolution.reason).toContain('webgpu: unsupported in this environment');
+        expect(resolution.reason).toContain('wam: not initialized');
+    });
+
+    it('is not degraded when the preferred backend is usable', () => {
+        const registry = new BackendRegistry();
+        registry.register(new StubBackend('webgpu'));
+        registry.register(new JsOscillatorBackend());
+        const resolution = registry.resolve();
+        expect(resolution.active).toBe('webgpu');
+        expect(resolution.degraded).toBe(false);
+        expect(resolution.reason).toBeUndefined();
+    });
+
+    it('skips backends that cannot render the requested shape natively', () => {
+        const registry = new BackendRegistry();
+        registry.register(new StubBackend('rust', { shapes: ['saw', 'sqr'] }));
+        registry.register(new JsOscillatorBackend());
+
+        expect(registry.resolve('saw').active).toBe('rust');
+
+        const tri = registry.resolve('tri');
+        expect(tri.active).toBe('js');
+        expect(tri.reason).toContain('does not render "tri" natively');
+    });
+
+    it('always resolves to js rather than returning nothing', () => {
+        const registry = new BackendRegistry();
+        registry.register(new StubBackend('webgpu', { supported: false }));
+        registry.register(new JsOscillatorBackend());
+        expect(registry.resolve().active).toBe('js');
+    });
+});
+
+describe('BackendRegistry fallback is always logged and surfaced', () => {
+    beforeEach(() => {
+        engineDegradationStore.clear('oscillator-backend');
+    });
+
+    it('records a telemetry resolution and a degradation store issue on fallback', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const registry = new BackendRegistry();
+        registry.register(new StubBackend('webgpu', { supported: false }));
+        registry.register(new JsOscillatorBackend());
+
+        const resolution = registry.resolveAndPublish();
+        expect(resolution.active).toBe('js');
+
+        const snapshot = engineTelemetry.snapshot();
+        expect(snapshot[OSCILLATOR_SUBSYSTEM]?.resolution?.backend).toBe('js');
+        expect(snapshot[OSCILLATOR_SUBSYSTEM]?.resolution?.reason).toContain('webgpu');
+
+        const issue = engineDegradationStore.getIssue('oscillator-backend');
+        expect(issue).toBeDefined();
+        expect(issue?.activeBackend).toBe('js');
+        expect(issue?.requestedBackend).toBe('webgpu');
+        expect(issue?.status).toBe('active');
+
+        expect(warn).toHaveBeenCalled();
+        expect(warn.mock.calls.some(([msg]) => String(msg).includes('fell back'))).toBe(true);
+        warn.mockRestore();
+    });
+
+    it('clears the degradation issue when the preferred backend is active', () => {
+        const registry = new BackendRegistry();
+        registry.register(new StubBackend('webgpu'));
+        registry.register(new JsOscillatorBackend());
+        registry.resolveAndPublish();
+        expect(engineDegradationStore.getIssue('oscillator-backend')?.status).not.toBe('active');
+    });
+});
+
+describe('BackendRegistry.generate', () => {
+    beforeEach(() => {
+        engineDegradationStore.clear('oscillator-backend');
+    });
+
+    it('falls through to the next backend when one returns no samples', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const gpu = new StubBackend('webgpu', { result: new Float32Array(0) });
+        const rust = new StubBackend('rust');
+        const registry = new BackendRegistry();
+        registry.register(gpu);
+        registry.register(rust);
+
+        const out = await registry.generate(REQ);
+        expect(out?.backendId).toBe('rust');
+        expect(gpu.generateCalls).toBe(1);
+        expect(rust.generateCalls).toBe(1);
+        expect(engineDegradationStore.getIssue('oscillator-backend')?.activeBackend).toBe('rust');
+        warn.mockRestore();
+    });
+
+    it('falls through when a backend throws, and records the error', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const gpu = new StubBackend('webgpu');
+        gpu.throwOnGenerate = true;
+        const registry = new BackendRegistry();
+        registry.register(gpu);
+        registry.register(new StubBackend('js'));
+
+        const out = await registry.generate(REQ);
+        expect(out?.backendId).toBe('js');
+        expect(engineTelemetry.snapshot()[OSCILLATOR_SUBSYSTEM]?.errors.count).toBeGreaterThan(0);
+        warn.mockRestore();
+    });
+
+    it('reports null (loudly) when nothing can render the request', async () => {
+        const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const registry = new BackendRegistry();
+        registry.register(new StubBackend('rust', { shapes: ['saw'] }));
+        const out = await registry.generate({ ...REQ, shape: 'tri' });
+        expect(out).toBeNull();
+        expect(err).toHaveBeenCalled();
+        err.mockRestore();
+    });
+});

--- a/src/engines/backends/__tests__/backendComparison.test.ts
+++ b/src/engines/backends/__tests__/backendComparison.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import {
+    COMPARISON_BANDS,
+    compareBackends,
+    compareRenders,
+    measureRender,
+} from '../backendComparison';
+import { JsOscillatorBackend, RustWasmBackend, WavPcmBackend } from '../adapters';
+import type { RustOscillator } from '../../RustOscillator';
+import type { GenerateRequest } from '../OscillatorBackend';
+
+const SR = 44100;
+const REQ: GenerateRequest = {
+    frequency: 220,
+    duration: 0.2,
+    sampleRate: SR,
+    shape: 'saw',
+    cutoff: 20000,
+    resonance: 1,
+};
+
+function render(shape: 'saw' | 'sqr' | 'tri' | 'sin', gain = 1, n = 8192): Float32Array {
+    const out = new Float32Array(n);
+    const inc = REQ.frequency / SR;
+    let phase = 0;
+    for (let i = 0; i < n; i++) {
+        const p = phase;
+        out[i] =
+            gain *
+            (shape === 'saw'
+                ? 2 * p - 1
+                : shape === 'sqr'
+                  ? p < 0.5
+                      ? 1
+                      : -1
+                  : shape === 'tri'
+                    ? 2 * Math.abs(2 * p - 1) - 1
+                    : Math.sin(2 * Math.PI * p));
+        phase += inc;
+        if (phase >= 1) phase -= 1;
+    }
+    return out;
+}
+
+/** A Rust engine stub that returns a real saw, so the harness has two backends. */
+function stubRustEngine(shape: 'saw' | 'sqr'): RustOscillator {
+    const engine = {
+        isReady: true,
+        init: async () => {},
+        generate: () => render(shape),
+    };
+    return engine as unknown as RustOscillator;
+}
+
+describe('measureRender', () => {
+    it('reports level and per-band energy', () => {
+        const metrics = measureRender('js', render('saw'), SR);
+        expect(metrics.backendId).toBe('js');
+        expect(metrics.rms).toBeGreaterThan(0);
+        expect(metrics.peak).toBeGreaterThan(0.9);
+        for (const band of COMPARISON_BANDS) {
+            expect(Number.isFinite(metrics.bands[band.name])).toBe(true);
+        }
+    });
+});
+
+describe('compareRenders', () => {
+    it('passes for identical renders', () => {
+        const a = render('saw');
+        const cmp = compareRenders({ backendId: 'js', samples: a }, { backendId: 'rust', samples: a.slice() }, SR);
+        expect(cmp.rmsErrorDb).toBeLessThan(0.01);
+        expect(cmp.worstBandErrorDb).toBeLessThan(0.01);
+        expect(cmp.withinTolerance).toBe(true);
+    });
+
+    it('level-matches, so a merely quieter backend is not flagged', () => {
+        const cmp = compareRenders(
+            { backendId: 'js', samples: render('saw', 1) },
+            { backendId: 'rust', samples: render('saw', 0.25) },
+            SR,
+        );
+        expect(cmp.withinTolerance).toBe(true);
+    });
+
+    it('flags a backend that silently changed wave family', () => {
+        const cmp = compareRenders(
+            { backendId: 'js', samples: render('sin') },
+            { backendId: 'rust', samples: render('saw') },
+            SR,
+        );
+        expect(cmp.worstBandErrorDb).toBeGreaterThan(6);
+        expect(cmp.withinTolerance).toBe(false);
+    });
+
+    it('flags silence from a backend that claimed to be ready', () => {
+        const cmp = compareRenders(
+            { backendId: 'js', samples: render('saw') },
+            { backendId: 'rust', samples: new Float32Array(8192) },
+            SR,
+        );
+        expect(cmp.withinTolerance).toBe(false);
+    });
+});
+
+describe('compareBackends', () => {
+    it('renders through each backend and compares against the first', async () => {
+        const js = new JsOscillatorBackend();
+        const rust = new RustWasmBackend(stubRustEngine('saw'));
+        await js.init();
+        await rust.init();
+
+        const report = await compareBackends([js, rust], REQ);
+        expect(report.metrics.map((m) => m.backendId).sort()).toEqual(['js', 'rust']);
+        expect(report.comparisons).toHaveLength(1);
+        expect(report.comparisons[0].withinTolerance).toBe(true);
+        expect(report.unavailable).toHaveLength(0);
+    });
+
+    it('lists backends that cannot service the request instead of dropping them', async () => {
+        const js = new JsOscillatorBackend();
+        const rust = new RustWasmBackend(stubRustEngine('saw'));
+        const wav = new WavPcmBackend();
+        await js.init();
+        await rust.init();
+        await wav.init();
+
+        const report = await compareBackends([js, rust, wav], { ...REQ, shape: 'tri' });
+        expect(report.unavailable.map((u) => u.backendId).sort()).toEqual(['rust', 'wav']);
+        expect(report.unavailable.find((u) => u.backendId === 'rust')?.reason).toContain('tri');
+        expect(report.metrics.map((m) => m.backendId)).toEqual(['js']);
+    });
+
+    it('detects a backend that drifted to the wrong wave family', async () => {
+        const js = new JsOscillatorBackend();
+        // Rust engine wired to a square while the request asks for a saw.
+        const rust = new RustWasmBackend(stubRustEngine('sqr'));
+        await js.init();
+        await rust.init();
+
+        const report = await compareBackends([js, rust], REQ);
+        expect(report.comparisons[0].withinTolerance).toBe(false);
+    });
+});

--- a/src/engines/backends/__tests__/oscillatorFallback.integration.test.ts
+++ b/src/engines/backends/__tests__/oscillatorFallback.integration.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Integration coverage for the oscillator fallback path (#1034).
+ *
+ * Uses the real adapters and the real registry — only the concrete engines are
+ * stubbed, because WebGPU/WASM cannot run under jsdom. It proves the whole
+ * chain end to end: engines fail to init → registry drops down the preference
+ * order → the fallback is logged, recorded in telemetry, and raised in the
+ * degradation store that feeds the HUD and banner.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { BackendRegistry, OSCILLATOR_SUBSYSTEM } from '../BackendRegistry';
+import {
+    JsOscillatorBackend,
+    RustWasmBackend,
+    WamWasmBackend,
+    WavPcmBackend,
+    WebGpuBackend,
+} from '../adapters';
+import type { WebGpuOscillator } from '../../WebGpuOscillator';
+import type { WasmOscillator } from '../../WasmOscillator';
+import type { RustOscillator } from '../../RustOscillator';
+import { engineTelemetry } from '../../../utils/engineTelemetry';
+import { engineDegradationStore } from '../../../stores/engineDegradationStore';
+import type { GenerateRequest } from '../OscillatorBackend';
+
+function stubGpu(supported: boolean): WebGpuOscillator {
+    const engine = {
+        isSupported: false,
+        init: vi.fn(async () => {
+            engine.isSupported = supported;
+        }),
+        generate: vi.fn(async () => new Float32Array([0.5, -0.5, 0.5, -0.5])),
+        destroy: vi.fn(),
+    };
+    return engine as unknown as WebGpuOscillator;
+}
+
+function stubWasm(ready: boolean): WasmOscillator {
+    const engine = {
+        isReady: false,
+        init: vi.fn(async () => {
+            engine.isReady = ready;
+        }),
+        generate: vi.fn(() => new Float32Array([0.25, -0.25, 0.25, -0.25])),
+    };
+    return engine as unknown as WasmOscillator;
+}
+
+function stubRust(ready: boolean): RustOscillator {
+    const engine = {
+        isReady: false,
+        init: vi.fn(async () => {
+            engine.isReady = ready;
+        }),
+        generate: vi.fn(() => new Float32Array([0.1, -0.1, 0.1, -0.1])),
+    };
+    return engine as unknown as RustOscillator;
+}
+
+/** Mirrors how engineLifecycle assembles the chain. */
+async function buildChain(opts: {
+    gpu: boolean;
+    wam: boolean;
+    rust: boolean;
+    wavBuffer?: AudioBuffer | null;
+}) {
+    const registry = new BackendRegistry();
+    const gpuBackend = new WebGpuBackend(stubGpu(opts.gpu));
+    const wamBackend = new WamWasmBackend(stubWasm(opts.wam));
+    const rustBackend = new RustWasmBackend(stubRust(opts.rust));
+    const wavBackend = new WavPcmBackend({ saw: opts.wavBuffer ?? null });
+
+    registry.register(gpuBackend);
+    registry.register(wamBackend);
+    registry.register(rustBackend);
+    registry.register(wavBackend);
+    registry.register(new JsOscillatorBackend());
+
+    for (const backend of registry.ordered()) {
+        await backend.init(undefined as unknown as AudioContext);
+    }
+    return { registry, gpuBackend, wamBackend, rustBackend, wavBackend };
+}
+
+const REQ: GenerateRequest = {
+    frequency: 220,
+    duration: 0.02,
+    sampleRate: 44100,
+    shape: 'saw',
+    cutoff: 6000,
+    resonance: 1.2,
+};
+
+describe('oscillator backend fallback (integration)', () => {
+    let warn: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        engineDegradationStore.clear('oscillator-backend');
+        warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    it('selects WebGPU when the GPU device initializes', async () => {
+        const { registry } = await buildChain({ gpu: true, wam: true, rust: true });
+        const resolution = registry.resolveAndPublish();
+
+        expect(resolution.active).toBe('webgpu');
+        expect(resolution.degraded).toBe(false);
+        expect(engineDegradationStore.getIssue('oscillator-backend')?.status).not.toBe('active');
+    });
+
+    it('falls back GPU → AS WASM when only the GPU is unavailable, and says so', async () => {
+        const { registry } = await buildChain({ gpu: false, wam: true, rust: true });
+        const resolution = registry.resolveAndPublish();
+
+        expect(resolution.active).toBe('wam');
+        expect(resolution.degraded).toBe(true);
+        expect(resolution.reason).toContain('webgpu');
+
+        const issue = engineDegradationStore.getIssue('oscillator-backend');
+        expect(issue?.status).toBe('active');
+        expect(issue?.activeBackend).toBe('wam');
+        expect(issue?.message).toContain('AS WASM');
+    });
+
+    it('walks the full chain to the JS oscillator when every engine fails', async () => {
+        const { registry } = await buildChain({ gpu: false, wam: false, rust: false });
+        const resolution = registry.resolveAndPublish();
+
+        expect(resolution.active).toBe('js');
+        expect(resolution.attempts.map((a) => a.id)).toEqual(['webgpu', 'wam', 'rust', 'wav', 'js']);
+        for (const id of ['webgpu', 'wam', 'rust', 'wav']) {
+            expect(resolution.attempts.find((a) => a.id === id)?.reason).toBeTruthy();
+        }
+
+        // Logged …
+        expect(warn.mock.calls.some(([m]) => String(m).includes('fell back'))).toBe(true);
+        // … recorded in telemetry …
+        const snapshot = engineTelemetry.snapshot();
+        expect(snapshot[OSCILLATOR_SUBSYSTEM]?.resolution?.backend).toBe('js');
+        // … and shown to the user via the degradation store (HUD + banner source).
+        expect(engineDegradationStore.getIssue('oscillator-backend')?.activeBackend).toBe('js');
+    });
+
+    it('still produces audible samples of the right wave family on the fallback path', async () => {
+        const { registry } = await buildChain({ gpu: false, wam: false, rust: false });
+        const out = await registry.generate(REQ);
+
+        expect(out).not.toBeNull();
+        expect(out!.backendId).toBe('js');
+        expect(out!.samples.length).toBe(Math.ceil(REQ.sampleRate * REQ.duration));
+        // A saw ramps monotonically inside a cycle and spans roughly [-1, 1].
+        expect(Math.max(...out!.samples)).toBeGreaterThan(0.9);
+        expect(Math.min(...out!.samples)).toBeLessThan(-0.9);
+    });
+
+    it('skips Rust for tri/sin rather than substituting a saw', async () => {
+        const { registry, rustBackend } = await buildChain({ gpu: false, wam: false, rust: true });
+
+        expect(registry.resolve('saw').active).toBe('rust');
+
+        const tri = registry.resolve('tri');
+        expect(tri.active).toBe('js');
+        expect(tri.reason).toContain('rust: does not render "tri" natively');
+        expect(await rustBackend.generate({ ...REQ, shape: 'tri' })).toBeNull();
+    });
+});

--- a/src/engines/backends/adapters.ts
+++ b/src/engines/backends/adapters.ts
@@ -1,0 +1,358 @@
+/**
+ * Adapters wrapping each concrete oscillator engine in the shared
+ * `OscillatorBackend` contract (#1034).
+ *
+ * The adapters own no DSP — they normalize readiness, capabilities and the
+ * generate signature so lifecycle/selection code has exactly one shape to
+ * talk to. Engines keep their existing public API for direct callers
+ * (VoiceManager still calls `wasmEngine.generate(...)` on the hot path).
+ */
+
+import type { WebGpuOscillator } from '../WebGpuOscillator';
+import type { WasmOscillator } from '../WasmOscillator';
+import type { RustOscillator } from '../RustOscillator';
+import { shapeToOscillatorType, type WaveShape } from '../../utils/waveformParser';
+import { engineTelemetry } from '../../utils/engineTelemetry';
+import type {
+    BackendCapabilities,
+    GenerateRequest,
+    InitResult,
+    OscillatorBackend,
+    OscillatorBackendId,
+} from './OscillatorBackend';
+import { BACKEND_LABELS } from './OscillatorBackend';
+
+const ALL_SHAPES: readonly WaveShape[] = ['saw', 'sqr', 'tri', 'sin'];
+
+/** Shared plumbing: id/label, init bookkeeping, telemetry-safe helpers. */
+abstract class BaseBackend implements OscillatorBackend {
+    abstract readonly id: OscillatorBackendId;
+    abstract readonly capabilities: BackendCapabilities;
+
+    protected initialized = false;
+    protected failureReason: string | null = null;
+
+    get label(): string {
+        return BACKEND_LABELS[this.id];
+    }
+
+    abstract get isSupported(): boolean;
+
+    get isReady(): boolean {
+        return this.initialized && this.isSupported;
+    }
+
+    supportsShape(shape: WaveShape): boolean {
+        return this.capabilities.shapes.includes(shape);
+    }
+
+    abstract init(ctx: AudioContext): Promise<InitResult>;
+    abstract generate(req: GenerateRequest): Promise<Float32Array | null>;
+
+    dispose(): void {
+        this.initialized = false;
+    }
+
+    protected ok(reason?: string): InitResult {
+        this.initialized = true;
+        this.failureReason = null;
+        return { ok: true, backendId: this.id, reason };
+    }
+
+    protected fail(reason: string): InitResult {
+        this.initialized = false;
+        this.failureReason = reason;
+        return { ok: false, backendId: this.id, reason };
+    }
+
+    /** Latency recording must never break audio init. */
+    protected timed<T>(fn: () => T): T {
+        const t0 = typeof performance !== 'undefined' ? performance.now() : 0;
+        const out = fn();
+        try {
+            if (typeof performance !== 'undefined') {
+                engineTelemetry.recordLatency(`oscillator-${this.id}`, performance.now() - t0);
+            }
+        } catch {
+            /* telemetry is best-effort */
+        }
+        return out;
+    }
+}
+
+export class WebGpuBackend extends BaseBackend {
+    readonly id = 'webgpu' as const;
+    readonly capabilities: BackendCapabilities = {
+        simd: false,
+        threads: true,
+        offline: true,
+        polyphony: 64,
+        shapes: ALL_SHAPES,
+    };
+
+    private readonly engine: WebGpuOscillator;
+
+    constructor(engine: WebGpuOscillator) {
+        super();
+        this.engine = engine;
+    }
+
+    /** Exposed so lifecycle code can keep handing the raw engine to consumers. */
+    get raw(): WebGpuOscillator {
+        return this.engine;
+    }
+
+    get isSupported(): boolean {
+        return this.engine.isSupported;
+    }
+
+    async init(_ctx?: AudioContext): Promise<InitResult> {
+        try {
+            await this.engine.init();
+        } catch (e) {
+            return this.fail(`WebGpuOscillator.init() threw: ${e instanceof Error ? e.message : String(e)}`);
+        }
+        return this.engine.isSupported
+            ? this.ok('device-ready')
+            : this.fail('WebGPU unavailable (no adapter/device)');
+    }
+
+    async generate(req: GenerateRequest): Promise<Float32Array | null> {
+        if (!this.isReady) return null;
+        const t0 = typeof performance !== 'undefined' ? performance.now() : 0;
+        const out = await this.engine.generate(req.frequency, req.duration, req.sampleRate, req.shape);
+        try {
+            if (typeof performance !== 'undefined') {
+                engineTelemetry.recordLatency('oscillator-webgpu', performance.now() - t0);
+            }
+        } catch {
+            /* best-effort */
+        }
+        return out;
+    }
+
+    dispose(): void {
+        super.dispose();
+        this.engine.destroy();
+    }
+}
+
+export class WamWasmBackend extends BaseBackend {
+    readonly id = 'wam' as const;
+    readonly capabilities: BackendCapabilities = {
+        simd: true,
+        threads: false,
+        offline: true,
+        polyphony: 16,
+        shapes: ALL_SHAPES,
+    };
+
+    private readonly engine: WasmOscillator;
+
+    constructor(engine: WasmOscillator) {
+        super();
+        this.engine = engine;
+    }
+
+    get raw(): WasmOscillator {
+        return this.engine;
+    }
+
+    get isSupported(): boolean {
+        return typeof WebAssembly !== 'undefined';
+    }
+
+    async init(_ctx?: AudioContext): Promise<InitResult> {
+        if (!this.isSupported) return this.fail('WebAssembly unavailable');
+        try {
+            await this.engine.init();
+        } catch (e) {
+            return this.fail(`WasmOscillator.init() threw: ${e instanceof Error ? e.message : String(e)}`);
+        }
+        return this.engine.isReady
+            ? this.ok('loaded')
+            : this.fail('oscillators.wasm instantiation failed');
+    }
+
+    get isReady(): boolean {
+        return this.initialized && this.engine.isReady;
+    }
+
+    async generate(req: GenerateRequest): Promise<Float32Array | null> {
+        if (!this.isReady) return null;
+        return this.timed(() =>
+            this.engine.generate(
+                req.frequency,
+                req.duration,
+                req.sampleRate,
+                req.shape,
+                req.cutoff,
+                req.resonance,
+            ),
+        );
+    }
+}
+
+export class RustWasmBackend extends BaseBackend {
+    readonly id = 'rust' as const;
+    /** The Rust kernel only implements saw/sqr — tri/sin are NOT substituted here. */
+    readonly capabilities: BackendCapabilities = {
+        simd: true,
+        threads: false,
+        offline: true,
+        polyphony: 16,
+        shapes: ['saw', 'sqr'],
+    };
+
+    private readonly engine: RustOscillator;
+
+    constructor(engine: RustOscillator) {
+        super();
+        this.engine = engine;
+    }
+
+    get raw(): RustOscillator {
+        return this.engine;
+    }
+
+    get isSupported(): boolean {
+        return typeof WebAssembly !== 'undefined';
+    }
+
+    async init(_ctx?: AudioContext): Promise<InitResult> {
+        if (!this.isSupported) return this.fail('WebAssembly unavailable');
+        try {
+            await this.engine.init();
+        } catch (e) {
+            return this.fail(`RustOscillator.init() threw: ${e instanceof Error ? e.message : String(e)}`);
+        }
+        return this.engine.isReady ? this.ok('loaded') : this.fail('rust-wasm module import failed');
+    }
+
+    get isReady(): boolean {
+        return this.initialized && this.engine.isReady;
+    }
+
+    async generate(req: GenerateRequest): Promise<Float32Array | null> {
+        // A tri/sin request would come out as a saw — refuse rather than
+        // silently change wave family. Callers fall back and log.
+        if (!this.isReady || !this.supportsShape(req.shape)) return null;
+        return this.timed(() =>
+            this.engine.generate(
+                req.frequency,
+                req.duration,
+                req.sampleRate,
+                req.shape as 'saw' | 'sqr',
+                req.cutoff,
+                req.resonance,
+            ),
+        );
+    }
+}
+
+/**
+ * Pre-decoded WAV/PCM single-cycle tables. Only saw and square exist as assets,
+ * matching the buffers loaded in engineLifecycle.
+ */
+export class WavPcmBackend extends BaseBackend {
+    readonly id = 'wav' as const;
+    readonly capabilities: BackendCapabilities = {
+        simd: false,
+        threads: false,
+        offline: true,
+        polyphony: Number.POSITIVE_INFINITY,
+        shapes: ['saw', 'sqr'],
+    };
+
+    private buffers: Partial<Record<WaveShape, AudioBuffer | null>> = {};
+
+    constructor(buffers: Partial<Record<WaveShape, AudioBuffer | null>> = {}) {
+        super();
+        this.buffers = buffers;
+    }
+
+    setBuffers(buffers: Partial<Record<WaveShape, AudioBuffer | null>>): void {
+        this.buffers = { ...this.buffers, ...buffers };
+    }
+
+    get isSupported(): boolean {
+        return this.capabilities.shapes.some((s) => !!this.buffers[s]);
+    }
+
+    async init(_ctx?: AudioContext): Promise<InitResult> {
+        return this.isSupported ? this.ok('pcm-tables-loaded') : this.fail('no WAV tables decoded');
+    }
+
+    supportsShape(shape: WaveShape): boolean {
+        return this.capabilities.shapes.includes(shape) && !!this.buffers[shape];
+    }
+
+    async generate(req: GenerateRequest): Promise<Float32Array | null> {
+        if (!this.isReady || !this.supportsShape(req.shape)) return null;
+        const buf = this.buffers[req.shape];
+        if (!buf) return null;
+        // PCM tables are fixed-rate assets; hand back the raw channel data and
+        // let the caller resample via playbackRate (as Voice already does).
+        return buf.getChannelData(0).slice();
+    }
+}
+
+/**
+ * Terminal backend. Always supported, always ready — renders the correct wave
+ * family analytically so the fallback path is never silence and never the
+ * wrong harmonic character.
+ */
+export class JsOscillatorBackend extends BaseBackend {
+    readonly id = 'js' as const;
+    readonly capabilities: BackendCapabilities = {
+        simd: false,
+        threads: false,
+        offline: true,
+        polyphony: Number.POSITIVE_INFINITY,
+        shapes: ALL_SHAPES,
+    };
+
+    get isSupported(): boolean {
+        return true;
+    }
+
+    get isReady(): boolean {
+        return true;
+    }
+
+    async init(_ctx?: AudioContext): Promise<InitResult> {
+        return this.ok('always-available');
+    }
+
+    /** Native Web Audio type for the shape — used when driving an OscillatorNode. */
+    oscillatorTypeFor(shape: WaveShape): OscillatorType {
+        return shapeToOscillatorType(shape);
+    }
+
+    async generate(req: GenerateRequest): Promise<Float32Array | null> {
+        const n = Math.max(1, Math.ceil(req.sampleRate * req.duration));
+        const out = new Float32Array(n);
+        const inc = req.frequency / req.sampleRate;
+        let phase = 0;
+        for (let i = 0; i < n; i++) {
+            out[i] = sampleShape(req.shape, phase);
+            phase += inc;
+            if (phase >= 1) phase -= 1;
+        }
+        return out;
+    }
+}
+
+/** Naive (non-bandlimited) shape evaluation — matches the JS oscillator family. */
+function sampleShape(shape: WaveShape, phase: number): number {
+    switch (shape) {
+        case 'saw':
+            return 2 * phase - 1;
+        case 'sqr':
+            return phase < 0.5 ? 1 : -1;
+        case 'tri':
+            return 2 * Math.abs(2 * phase - 1) - 1;
+        case 'sin':
+            return Math.sin(2 * Math.PI * phase);
+    }
+}

--- a/src/engines/backends/backendComparison.ts
+++ b/src/engines/backends/backendComparison.ts
@@ -1,0 +1,242 @@
+/**
+ * Offline backend comparison harness (#1034).
+ *
+ * Renders the same `GenerateRequest` through several `OscillatorBackend`s and
+ * compares level + spectral band energy, reusing the 303 authenticity metric
+ * primitives so the two harnesses stay consistent.
+ *
+ * Purpose is regression detection, not perceptual grading: a backend that
+ * quietly starts producing a different wave family, half the level, or silence
+ * shows up as a band/RMS delta far outside the tolerance.
+ */
+
+import { bandRmsDb, levelMatch, metricsFor } from '../../utils/tb303AuthenticityMetrics';
+import type { GenerateRequest, OscillatorBackend, OscillatorBackendId } from './OscillatorBackend';
+
+/** Bands compared across backends (Hz). Chosen to separate wave families. */
+export const COMPARISON_BANDS: ReadonlyArray<{ name: string; lo: number; hi: number }> = [
+    { name: 'fundamental', lo: 100, hi: 400 },
+    { name: 'low-harmonics', lo: 400, hi: 2000 },
+    { name: 'high-harmonics', lo: 2000, hi: 8000 },
+];
+
+/** Default tolerances — generous enough for legitimate implementation spread. */
+export const COMPARISON_TOLERANCES = {
+    /** Level-matched broadband RMS delta (dB). */
+    rmsDb: 3,
+    /** Per-band energy delta after level matching (dB). */
+    bandDb: 6,
+    /** Even-vs-odd harmonic balance delta (dB). See `evenOddRatioDb`. */
+    evenOddDb: 6,
+};
+
+/** Harmonics inspected by the even/odd balance metric. */
+const EVEN_HARMONICS = [2, 4, 6, 8];
+const ODD_HARMONICS = [3, 5, 7, 9];
+
+/**
+ * Even-vs-odd harmonic balance in dB.
+ *
+ * Broad-band energy alone cannot separate a saw from a square — both roll off
+ * at ~1/n — but a square has essentially no even harmonics while a saw has
+ * them at full strength. This ratio is therefore the metric that catches a
+ * backend quietly switching wave family, which is the failure this harness
+ * exists to detect. Needs the fundamental, so it is only computed when the
+ * caller knows it (as `compareBackends` does, from the request).
+ */
+export function evenOddRatioDb(samples: Float32Array, sampleRate: number, f0: number): number {
+    if (f0 <= 0) return 0;
+    const win = analysisWindow(samples);
+    const halfWidth = f0 * 0.25;
+
+    const energy = (harmonics: number[]): number => {
+        let sum = 0;
+        for (const h of harmonics) {
+            const centre = f0 * h;
+            if (centre + halfWidth >= sampleRate / 2) continue;
+            const db = bandRmsDb(win, sampleRate, centre - halfWidth, centre + halfWidth);
+            if (Number.isFinite(db)) sum += Math.pow(10, db / 10);
+        }
+        return sum;
+    };
+
+    const even = energy(EVEN_HARMONICS);
+    const odd = energy(ODD_HARMONICS);
+    // Floor both sides so an absent family yields a large but finite ratio.
+    const floor = 1e-12;
+    return 10 * Math.log10((even + floor) / (odd + floor));
+}
+
+export interface BackendRenderMetrics {
+    backendId: OscillatorBackendId;
+    sampleCount: number;
+    rms: number;
+    rmsDbfs: number;
+    peak: number;
+    bands: Record<string, number>;
+}
+
+export interface BackendComparison {
+    reference: OscillatorBackendId;
+    candidate: OscillatorBackendId;
+    rmsErrorDb: number;
+    bandErrorDb: Record<string, number>;
+    /** Even/odd harmonic balance delta (dB); null when no fundamental was given. */
+    evenOddErrorDb: number | null;
+    /** Largest band error — the single number to gate on. */
+    worstBandErrorDb: number;
+    withinTolerance: boolean;
+}
+
+export interface BackendComparisonReport {
+    request: GenerateRequest;
+    metrics: BackendRenderMetrics[];
+    comparisons: BackendComparison[];
+    /** Backends that could not render the request at all. */
+    unavailable: Array<{ backendId: OscillatorBackendId; reason: string }>;
+}
+
+function peakOf(samples: Float32Array): number {
+    let p = 0;
+    for (let i = 0; i < samples.length; i++) {
+        const v = Math.abs(samples[i]);
+        if (v > p) p = v;
+    }
+    return p;
+}
+
+/**
+ * The shared rFFT is radix-2, so spectral analysis runs on the largest
+ * power-of-two prefix of the render. Level metrics use the full buffer.
+ */
+export function analysisWindow(samples: Float32Array): Float32Array {
+    if (samples.length < 2) return samples;
+    const pow2 = 1 << Math.floor(Math.log2(samples.length));
+    return pow2 === samples.length ? samples : samples.subarray(0, pow2);
+}
+
+export function measureRender(
+    backendId: OscillatorBackendId,
+    samples: Float32Array,
+    sampleRate: number,
+): BackendRenderMetrics {
+    const win = analysisWindow(samples);
+    const level = metricsFor(win, sampleRate);
+    const bands: Record<string, number> = {};
+    for (const band of COMPARISON_BANDS) {
+        bands[band.name] = bandRmsDb(win, sampleRate, band.lo, band.hi);
+    }
+    return {
+        backendId,
+        sampleCount: samples.length,
+        rms: level.rms,
+        rmsDbfs: level.rmsDbfs,
+        peak: peakOf(samples),
+        bands,
+    };
+}
+
+/**
+ * Compare two renders after level matching, so a backend that is merely
+ * quieter is not reported as spectrally wrong.
+ */
+export function compareRenders(
+    reference: { backendId: OscillatorBackendId; samples: Float32Array },
+    candidate: { backendId: OscillatorBackendId; samples: Float32Array },
+    sampleRate: number,
+    tolerances = COMPARISON_TOLERANCES,
+    /** Rendered fundamental in Hz; enables the even/odd harmonic check. */
+    fundamental?: number,
+): BackendComparison {
+    const n = Math.min(reference.samples.length, candidate.samples.length);
+    const ref = reference.samples.slice(0, n);
+    const cand = levelMatch(candidate.samples.slice(0, n), ref);
+
+    const refMetrics = measureRender(reference.backendId, ref, sampleRate);
+    const candMetrics = measureRender(candidate.backendId, cand, sampleRate);
+
+    const bandErrorDb: Record<string, number> = {};
+    let worstBandErrorDb = 0;
+    for (const band of COMPARISON_BANDS) {
+        const err = Math.abs(candMetrics.bands[band.name] - refMetrics.bands[band.name]);
+        bandErrorDb[band.name] = err;
+        if (Number.isFinite(err) && err > worstBandErrorDb) worstBandErrorDb = err;
+    }
+
+    const rmsErrorDb = Math.abs(candMetrics.rmsDbfs - refMetrics.rmsDbfs);
+
+    const evenOddErrorDb =
+        fundamental && fundamental > 0
+            ? Math.abs(
+                  evenOddRatioDb(cand, sampleRate, fundamental) -
+                      evenOddRatioDb(ref, sampleRate, fundamental),
+              )
+            : null;
+
+    return {
+        reference: reference.backendId,
+        candidate: candidate.backendId,
+        rmsErrorDb,
+        bandErrorDb,
+        evenOddErrorDb,
+        worstBandErrorDb,
+        withinTolerance:
+            rmsErrorDb <= tolerances.rmsDb &&
+            worstBandErrorDb <= tolerances.bandDb &&
+            (evenOddErrorDb === null || evenOddErrorDb <= tolerances.evenOddDb),
+    };
+}
+
+/**
+ * Render `req` through every backend and compare each against the first one
+ * that produced samples. Backends that cannot service the request are listed
+ * in `unavailable` rather than silently omitted.
+ */
+export async function compareBackends(
+    backends: OscillatorBackend[],
+    req: GenerateRequest,
+    tolerances = COMPARISON_TOLERANCES,
+): Promise<BackendComparisonReport> {
+    const rendered: Array<{ backendId: OscillatorBackendId; samples: Float32Array }> = [];
+    const unavailable: Array<{ backendId: OscillatorBackendId; reason: string }> = [];
+
+    for (const backend of backends) {
+        if (!backend.isSupported || !backend.isReady) {
+            unavailable.push({
+                backendId: backend.id,
+                reason: backend.isSupported ? 'not initialized' : 'unsupported',
+            });
+            continue;
+        }
+        if (!backend.supportsShape(req.shape)) {
+            unavailable.push({ backendId: backend.id, reason: `cannot render "${req.shape}"` });
+            continue;
+        }
+        try {
+            const samples = await backend.generate(req);
+            if (samples && samples.length > 0) {
+                rendered.push({ backendId: backend.id, samples });
+            } else {
+                unavailable.push({ backendId: backend.id, reason: 'returned no samples' });
+            }
+        } catch (e) {
+            unavailable.push({
+                backendId: backend.id,
+                reason: `threw (${e instanceof Error ? e.message : String(e)})`,
+            });
+        }
+    }
+
+    const metrics = rendered.map((r) => measureRender(r.backendId, r.samples, req.sampleRate));
+    const comparisons: BackendComparison[] = [];
+    if (rendered.length > 1) {
+        const ref = rendered[0];
+        for (let i = 1; i < rendered.length; i++) {
+            comparisons.push(
+                compareRenders(ref, rendered[i], req.sampleRate, tolerances, req.frequency),
+            );
+        }
+    }
+
+    return { request: req, metrics, comparisons, unavailable };
+}

--- a/src/hooks/audioEngine/engineLifecycle.ts
+++ b/src/hooks/audioEngine/engineLifecycle.ts
@@ -1,6 +1,15 @@
 import type { MutableRefObject } from 'react';
 import { WebGpuOscillator } from '../../engines/WebGpuOscillator';
 import { WasmOscillator } from '../../engines/WasmOscillator';
+import { RustOscillator } from '../../engines/RustOscillator';
+import { BackendRegistry, setOscillatorRegistry } from '../../engines/backends/BackendRegistry';
+import {
+    JsOscillatorBackend,
+    RustWasmBackend,
+    WamWasmBackend,
+    WavPcmBackend,
+    WebGpuBackend,
+} from '../../engines/backends/adapters';
 import { Open303Manager } from '../../engines/Open303Manager';
 import { SingingVoiceManager } from '../../engines/SingingVoiceManager';
 import { VoiceManager } from '../../engines/VoiceManager';
@@ -90,14 +99,29 @@ export async function initializeAudioContextAndEngines(
 
     const { masterBusInput } = buildClassicElectribeGraph(context, refs);
 
-    // Initialize Engines
-    const gpuEngine = new WebGpuOscillator();
-    await gpuEngine.init().catch(e => console.warn("GPU Engine init failed", e));
-    refs.gpuEngineRef.current = gpuEngine;
+    // Initialize oscillator backends through the shared registry. Every engine
+    // is wrapped in an OscillatorBackend adapter so readiness is typed and the
+    // fallback chain (WebGPU → AS WASM → Rust → WAV PCM → JS) lives in one place.
+    const registry = new BackendRegistry();
+    const webGpuBackend = new WebGpuBackend(new WebGpuOscillator());
+    const wamBackend = new WamWasmBackend(new WasmOscillator());
+    const rustBackend = new RustWasmBackend(new RustOscillator());
+    const wavBackend = new WavPcmBackend();
+    registry.register(webGpuBackend);
+    registry.register(wamBackend);
+    registry.register(rustBackend);
+    registry.register(wavBackend);
+    registry.register(new JsOscillatorBackend());
+    setOscillatorRegistry(registry);
 
-    const wasmEngine = new WasmOscillator();
-    await wasmEngine.init().catch(e => console.warn("WASM Engine init failed", e));
-    refs.wasmEngineRef.current = wasmEngine;
+    // The WAV backend only becomes supported once its tables are decoded, so it
+    // is initialized further down; the GPU/WASM/Rust backends init here.
+    await webGpuBackend.init(context);
+    await wamBackend.init(context);
+    await rustBackend.init(context);
+
+    refs.gpuEngineRef.current = webGpuBackend.raw;
+    refs.wasmEngineRef.current = wamBackend.raw;
 
     // Initialize Open303 Manager
     const open303Manager = new Open303Manager();
@@ -135,22 +159,27 @@ export async function initializeAudioContextAndEngines(
     refs.wavSawBufferRef.current = sawBuf;
     refs.wavSqrBufferRef.current = sqrBuf;
 
-    // Register oscillator backend decision (webgpu -> wasm -> wav -> js)
-    try {
-        let oscillatorBackend = 'js';
-        if (gpuEngine && (gpuEngine as any).isSupported) oscillatorBackend = 'webgpu';
-        else if (wasmEngine && (wasmEngine as any).isReady) oscillatorBackend = 'wasm';
-        else if (sawBuf || sqrBuf) oscillatorBackend = 'wav';
-        engineTelemetry.registerResolution('oscillators', oscillatorBackend, 'init-decision');
-    } catch (e) {
-        console.warn('Engine telemetry registration failed for oscillators', e);
-    }
+    // Resolve the active oscillator backend from the ordered chain. The result
+    // is published to telemetry + the degradation store, so any fallback is
+    // logged and shows up in EngineHUD rather than degrading silently.
+    wavBackend.setBuffers({ saw: sawBuf, sqr: sqrBuf });
+    await wavBackend.init(context);
+    registry.resolveAndPublish();
 
     // Initialize Voice Managers (routed through per-track monitor buses for expression LEDs)
     const synthADest = refs.synthABusRef.current ?? refs.masterSaturationRef.current!;
     const synthBDest = refs.synthBBusRef.current ?? refs.masterSaturationRef.current!;
     refs.voiceManagerARef.current = new VoiceManager(context, synthADest, 8, false, sawBuf || undefined, sqrBuf || undefined, refs.delayNodeRef.current || undefined);
     refs.voiceManagerBRef.current = new VoiceManager(context, synthBDest, 1, true, sawBuf || undefined, sqrBuf || undefined, refs.delayNodeRef.current || undefined);
+
+    // Hand the initialized backends to the voices so rust-*/wam-* waveforms
+    // reach a real engine instead of dropping straight to the JS oscillator.
+    const voiceEngineDeps = {
+        wasmEngine: wamBackend.raw,
+        rustEngine: rustBackend.raw,
+    };
+    refs.voiceManagerARef.current.updateEngineDeps(voiceEngineDeps);
+    refs.voiceManagerBRef.current.updateEngineDeps(voiceEngineDeps);
 
     await initializeSustainProcessor(context, urls.sustainProcessorUrl, refs.sustainNodeRef, refs.masterGainRef);
 

--- a/src/utils/engineTelemetry.ts
+++ b/src/utils/engineTelemetry.ts
@@ -686,6 +686,42 @@ export function emitUserEngineFallbackWarning(
   }
 }
 
+/**
+ * Report that a backend rendered a *different waveform family* than the one
+ * requested (e.g. a triangle request serviced as a saw).
+ *
+ * This is the one degradation a user hears but cannot see, so it is never
+ * allowed to be silent: console, telemetry resolution history and the
+ * degradation store (which drives the banner and EngineHUD) all get it.
+ */
+export function logWaveformSubstitution(
+  subsystem: string,
+  backendId: string,
+  requestedShape: string,
+  substitutedShape: string,
+  reason: string,
+): void {
+  const detail = `${backendId} cannot render "${requestedShape}", using "${substitutedShape}" (${reason})`;
+  console.warn(`[WaveformSubstitution] ${subsystem}: ${detail}`);
+  try {
+    engineTelemetry.registerResolution(subsystem, `${backendId}:${substitutedShape}`, detail);
+    engineTelemetry.recordDegradation(subsystem, true, detail);
+    engineDegradationStore.report({
+      id: `waveform-substitution-${subsystem}-${requestedShape}`,
+      subsystem,
+      category: 'audio',
+      message: `"${requestedShape}" waveform is being played as "${substitutedShape}"`,
+      reason: detail,
+      status: 'active',
+      activeBackend: `${backendId}:${substitutedShape}`,
+      requestedBackend: `${backendId}:${requestedShape}`,
+      retryable: false,
+    });
+  } catch {
+    /* telemetry must never break audio */
+  }
+}
+
 export function logEngineFallback(
   subsystem: string,
   requestedBackend: string,


### PR DESCRIPTION
## Why

Multiple oscillator backends existed with parallel APIs and ad-hoc readiness checks, so `engineLifecycle` selected a backend via `(engine as any).isSupported` casts and a waveform could silently change family (Rust renders `tri`/`sin` as a saw). New voices kept adding parallel entry points with no shared contract.

## What changed

**Shared contract** — `src/engines/backends/OscillatorBackend.ts`

Typed `isSupported` / `isReady` (separate, non-optional), `init(ctx)`, `generate`, `supportsShape`, `dispose`, and a capabilities block (`simd` / `threads` / `offline` / `polyphony` / `shapes`). Optional `noteOn` / `noteOff` exist so a future worklet-resident engine plugs in here rather than adding another parallel entry point — no current backend implements them, since all of them are buffer producers.

**Adapters** — `src/engines/backends/adapters.ts`

`WebGpuBackend`, `WamWasmBackend`, `RustWasmBackend`, `WavPcmBackend`, `JsOscillatorBackend`. They own no DSP; engines keep their existing public API for direct callers (VoiceManager's hot path is untouched). Engines are injected and imported type-only, so backend selection is testable without built WASM artifacts.

**Ordered fallback** — `src/engines/backends/BackendRegistry.ts`

WebGPU → AS WASM → Rust → WAV PCM → pure JS, in one place. Every step down publishes a telemetry resolution, an `engineDegradationStore` issue (drives the banner + HUD) and a console warning. `resolve()` is total — JS is terminal, so selection can never come up empty. `generate()` walks the same chain, dropping through on null/throw and logging each drop.

**No silent waveform substitution**

`RustWasmBackend` declares `shapes: ['saw', 'sqr']` and returns null for `tri`/`sin` rather than handing back a saw. The pre-existing VoiceManager guard that maps `tri`/`sin` → `saw` now routes through a new `logWaveformSubstitution` (console + telemetry + degradation store), so the one degradation a user can hear but not see is always reported.

**Offline comparison harness** — `src/engines/backends/backendComparison.ts`

Renders the same request through several backends and compares level-matched RMS and band energy, reusing the 303 authenticity metric primitives. Broad-band energy alone cannot separate a saw from a square (both roll off at ~1/n — measured delta was ~3.4 dB), so the harness also computes an even/odd harmonic-balance ratio, which is what actually catches a wave-family drift.

**EngineHUD** gains an "Oscillator backends" section: the full chain, the active backend, and why each higher-preference one was skipped.

**engineLifecycle** builds the chain through the registry — both `as any` readiness checks are gone — and wires the initialized WASM/Rust engines into both VoiceManagers, so `rust-*` / `wam-*` waveforms now reach a real engine instead of dropping to the JS oscillator (nothing was supplying `rustEngine` before).

## Acceptance

- [x] No `as any` readiness checks in engine lifecycle
- [x] Fallback always logged + shown in EngineHUD (telemetry + degradation store + console, asserted in tests)
- [x] One integration test proves the fallback path (`oscillatorFallback.integration.test.ts` walks the full chain to JS with the real adapters)
- [x] Types cover `isReady` / `isSupported` without casts

## Testing

- `npx vitest run` — 3 new suites, 24 new tests, all green; Voice suite still 19/19.
- The 9 failing suites are pre-existing and unrelated: they fail identically on a clean tree because `src/wasm/*.wasm` build artifacts aren't present in this environment.
- `tsc -b` clean, `npm run lint` clean.

## Notes / follow-ups

- `RustOscillator` now initializes at boot so the Rust link in the chain is real. If `public/rust-wasm/` isn't deployed, its existing `logEngineFallback` fires once at startup — loud by design, and now visible in the HUD.
- The chain covers the oscillator path. Open303/JC303, Prophecy and the high-fid offline engines still have their own selection logic; migrating them onto `OscillatorBackend` is the natural next step.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLkjJN649Rc6TqfEQqqFY5)_