### PR TITLE
Fix knob canvas swallowing clicks on module controls; E2E drives real clicks

### DIFF
--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -48,3 +48,15 @@ jobs:
         run: pnpm run preview --port 5173 & sleep 5
       - name: Run Playwright tests
         run: pnpm exec playwright test --reporter=github
+
+      # Traces are captured on first retry (playwright.config.ts). Without this,
+      # a red run leaves only the truncated GitHub-reporter log to debug from.
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -433,9 +433,37 @@ Global ignores include: `dist/`, `emsdk/`, `assembly/`, `emscripten/`, `jc303_wa
 5. **Accessibility Tests**: `AppAccessibility.test.tsx`, `AutomationStepA11y.test.tsx`, `LiveKeyboardA11y.test.tsx`, `SongModeA11y.test.tsx`, `VoiceEditorA11y.test.tsx`
 
 ### E2E Tests (Playwright)
-- **Location**: `tests/*.spec.ts` (~2 spec files)
-- **Config**: `playwright.config.ts`
-- **Base URL**: `http://localhost:5173`
+- **Location**: `tests/*.spec.ts`
+- **Config**: `playwright.config.ts` (owns the dev/preview server via `webServer`)
+- **Base URL**: `http://127.0.0.1:5173`
+- **Shared helpers**: `tests/helpers/boot.ts` — use these instead of hand-rolling
+  a boot sequence per spec.
+
+#### E2E smoke path (how to drive the UI)
+
+1. **Boot** — `initializeHyphonAudio(page)`. Navigates with `?e2e=1`, waits for
+   `INITIALIZE SYSTEM` to be *enabled* (it stays disabled until the Pyodide
+   bootstrap reports ready), clicks it with a real gesture (required to unlock
+   the AudioContext, especially on WebKit), then waits out the LoadingOverlay
+   and dismisses HelpTip pins / toasts that would steal clicks.
+2. **The rack mounts ONE module at a time** — `Rack` renders
+   `modules[selectedTrack]`, so `SYNTH B` / `BASS 2` do not exist in the DOM
+   until their track is selected. Use `openRackModule(page, 'BASS 2')`, which
+   clicks the sequencer row header and returns the mounted module.
+3. **Waveform selection is two-level** — oscillator family
+   (`selectOscillatorFamily(module, 'open303')`, addressed by badge text) and
+   then the shape (`Select Rust SAW waveform`).
+4. **Clicking module controls** — use `clickControl(locator)`. The knob REC
+   overlay can cover the *centre* of a compact selector button; `clickControl`
+   probes for a point the control actually owns instead of force-clicking
+   through to the REC button. Prefer it over `domClick`, which dispatches an
+   event no real user can produce.
+5. **Status pills** — the header holds several `role="status"` nodes; use
+   `engineStatusIndicators(page)`, not a bare `getByRole('status')`.
+
+**Browser launch flags are per-project.** `--autoplay-policy` is Chromium-only;
+putting it in the shared `use` block aborts WebKit at launch ("Cannot parse
+arguments"). Firefox takes `firefoxUserPrefs` instead.
 
 ### Mocking
 - `AudioContext` fully mocked in `vitest.setup.ts`

--- a/src/components/HardwareModule.tsx
+++ b/src/components/HardwareModule.tsx
@@ -544,6 +544,22 @@ export const HardwareModule = memo(
 
             const handlePointerDown = (e: PointerEvent) => {
                 if (e.button !== 0) return;
+                // The oscillator/voice selectors, REC buttons and HelpTip pins are DOM
+                // overlays stacked above the knob canvas, and their hit areas can sit on
+                // top of a knob's canvas region. Capturing the pointer here would
+                // preventDefault() the click before it reached them, so those controls
+                // looked live but did nothing for a real user (E2E had to fall back to
+                // synthetic DOM clicks to drive them). Only the canvas itself may start
+                // a knob drag. The a11y slider overlay is pointer-events:none, so knob
+                // dragging is unaffected.
+                const target = e.target as Element | null;
+                if (
+                    target &&
+                    target !== container &&
+                    target.closest('button, input, select, textarea, a, [role="button"]')
+                ) {
+                    return;
+                }
                 const hitIndex = findHitKnob(e.clientX, e.clientY);
                 if (hitIndex !== -1) {
                     container.setPointerCapture(e.pointerId);

--- a/tests/engine303-switch.spec.ts
+++ b/tests/engine303-switch.spec.ts
@@ -5,13 +5,13 @@ import {
   selectOscillatorFamily,
   select303Voice,
   engineStatusIndicators,
-  domClick,
+  clickControl,
 } from './helpers/boot';
 
 /**
  * E2E: 303 voice selection ("303 Voices" architecture).
- * Oscillator family + voice clicks use force:true — knob REC hitboxes overlap
- * the compact selectors inside HardwareModule.
+ * Oscillator family + voice clicks are real user clicks; the knob canvas used to
+ * capture the pointer and cancel them (fixed in #1035).
  */
 
 test('303 voice switch: SYNTH B toggles between stock and JC303 voices', async ({ page }) => {
@@ -29,7 +29,7 @@ test('303 voice switch: SYNTH B toggles between stock and JC303 voices', async (
     await expect(voiceGroup.getByLabel('JC303 engine family active')).toBeVisible();
     await expect(engineStatusIndicators(page)).toContainText('JC303');
 
-    await domClick(stockBtn);
+    await clickControl(stockBtn);
     await expect(stockBtn).toHaveAttribute('aria-pressed', 'true');
     await expect(jc303Btn).toHaveAttribute('aria-pressed', 'false');
     await expect(voiceGroup.getByLabel('Open303 engine family active')).toBeVisible();

--- a/tests/helpers/boot.ts
+++ b/tests/helpers/boot.ts
@@ -103,7 +103,14 @@ export async function dismissHelpTips(page: Page): Promise<void> {
   }
 }
 
-/** Native DOM click — bypasses Playwright hit-testing and overlay interception. */
+/**
+ * Native DOM click — bypasses Playwright hit-testing entirely.
+ *
+ * Kept for the rare control that is genuinely occluded, but prefer a real
+ * `click()`: HardwareModule no longer swallows pointerdowns aimed at its DOM
+ * overlays (#1035), so module controls respond to real user input and the specs
+ * should exercise that path rather than a synthetic event a user cannot produce.
+ */
 export async function domClick(locator: Locator): Promise<void> {
   await locator.evaluate((el) => {
     if (el instanceof HTMLElement) el.click();
@@ -166,11 +173,49 @@ export async function openRackModule(page: Page, track: RackTrackKey) {
 }
 
 /**
+ * Click a point on `target` that the element actually owns.
+ *
+ * HardwareModule stacks the knob REC ("R") buttons in an absolute overlay that
+ * can land on the *centre* of a compact selector button — so a plain click is
+ * (correctly) refused as intercepted, while `force: true` would silently
+ * deliver the click to the REC button instead. A real user can still hit the
+ * uncovered part of the control, so we probe across the target and click there.
+ *
+ * Throws if the target is covered edge to edge — that is a UI hit-target bug
+ * worth failing on, not something to paper over.
+ */
+export async function clickControl(target: Locator): Promise<void> {
+  await target.waitFor({ state: 'visible', timeout: 15_000 });
+  await target.scrollIntoViewIfNeeded();
+  const box = await target.boundingBox();
+  if (!box) throw new Error('clickControl: target has no bounding box');
+
+  const clearFraction = await target.evaluate(
+    (el, { b, fracs }) => {
+      for (const f of fracs) {
+        const hit = document.elementFromPoint(b.x + b.width * f, b.y + b.height / 2);
+        if (hit && (hit === el || el.contains(hit))) return f;
+      }
+      return null;
+    },
+    { b: box, fracs: [0.5, 0.2, 0.8, 0.1, 0.9] },
+  );
+
+  if (clearFraction === null) {
+    throw new Error(
+      'clickControl: no unobstructed point on target — an overlay covers it entirely',
+    );
+  }
+  await target.click({ position: { x: box.width * clearFraction, y: box.height / 2 } });
+}
+
+/**
  * Select an oscillator family via OscillatorTypeSelector (replaces legacy
  * `Select 303-saw waveform` buttons).
  *
- * Uses a native DOM click because HardwareModule's absolute knob overlay
- * (REC "R" hitboxes) and HelpTip pins intercept Playwright pointer hits.
+ * Uses a real click: the knob canvas used to capture the pointer and cancel
+ * these clicks, which is fixed in HardwareModule (#1035). HelpTip pins are
+ * dismissed first, and `clickControl` steers around the REC overlay.
  */
 export async function selectOscillatorFamily(
   module: Locator,
@@ -182,11 +227,11 @@ export async function selectOscillatorFamily(
   await expect(group).toBeVisible({ timeout: 15_000 });
   const badge = OSC_FAMILY_BADGE[family];
   const btn = group.getByRole('button', { name: badge, exact: true });
-  await domClick(btn);
+  await clickControl(btn);
   await expect(btn).toHaveAttribute('aria-pressed', 'true', { timeout: 10_000 });
 }
 
-/** Click a Voice303Selector option via native DOM click. */
+/** Click a Voice303Selector option with a real user click. */
 export async function select303Voice(module: Locator, voiceName: RegExp): Promise<void> {
   const page = module.page();
   await dismissHelpTips(page);
@@ -195,7 +240,7 @@ export async function select303Voice(module: Locator, voiceName: RegExp): Promis
   // First-use HelpTip pins when the selector mounts — dismiss again.
   await dismissHelpTips(page);
   const btn = voiceGroup.getByRole('button', { name: voiceName });
-  await domClick(btn);
+  await clickControl(btn);
   await expect(btn).toHaveAttribute('aria-pressed', 'true', { timeout: 10_000 });
 }
 

--- a/tests/rust_oscillator.spec.ts
+++ b/tests/rust_oscillator.spec.ts
@@ -1,9 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { initializeHyphonAudio, openRackModule, selectOscillatorFamily, domClick } from './helpers/boot';
+import { initializeHyphonAudio, openRackModule, selectOscillatorFamily, clickControl } from './helpers/boot';
 
 /**
  * Rust oscillator waveform selector smoke.
- * Family + variant clicks use native DOM click (knob REC overlay intercepts otherwise).
+ * Family + variant clicks are real user clicks — HardwareModule no longer
+ * cancels pointerdowns aimed at its DOM overlays (#1035).
  */
 test('Verify Rust Oscillator loads and Waveform Selector updates', async ({ page }) => {
   await initializeHyphonAudio(page);
@@ -13,11 +14,11 @@ test('Verify Rust Oscillator loads and Waveform Selector updates', async ({ page
 
   const rustSawBtn = leadModule.getByLabel('Select Rust SAW waveform');
   await expect(rustSawBtn).toBeVisible({ timeout: 10_000 });
-  await domClick(rustSawBtn);
+  await clickControl(rustSawBtn);
   await expect(rustSawBtn).toHaveAttribute('aria-pressed', 'true');
 
   const rustSqrBtn = leadModule.getByLabel('Select Rust SQR waveform');
-  await domClick(rustSqrBtn);
+  await clickControl(rustSqrBtn);
   await expect(rustSqrBtn).toHaveAttribute('aria-pressed', 'true');
   await expect(rustSawBtn).toHaveAttribute('aria-pressed', 'false');
 });


### PR DESCRIPTION
## Context

#1046 landed while this was in progress and already fixed most of the E2E gate: per-project launch flags, the shared boot helper, rack row selection, the two-level waveform UI, and the two unskips. I verified the current `main` suite locally — **Chromium is green (14 passed, 3 pre-existing `test.fixme`)**.

This PR covers the part that remained, plus two smaller CI/doc gaps.

## The bug #1046 worked around

`tests/helpers/boot.ts` drove HardwareModule's controls with `domClick` (a synthetic `el.click()`), noting that "knob REC hitboxes overlap the compact selectors". That hid a real user-facing bug: **with a real mouse, selecting a 303 voice or oscillator family on SYNTH A / SYNTH B did nothing at all.** I confirmed it in the browser — `aria-pressed` stayed `false`, no console error, no state change.

Root cause: HardwareModule's canvas `pointerdown` handler hit-tests knob regions by coordinate. The oscillator/voice selectors and REC buttons are DOM overlays stacked above that canvas, so a pointerdown aimed at a *button* still matched a knob, called `setPointerCapture` and `preventDefault()` — cancelling the click before it reached the button. The handler now bails out when the event originates on an interactive overlay.

The a11y slider overlay is `pointer-events: none`, so knob drags still land on the container and are unaffected — both `knob-drag-modifiers` specs still pass.

With the fix in, `selectOscillatorFamily` and `select303Voice` use real clicks, so the specs exercise the path a user actually takes. `domClick` stays exported but is documented as a last resort.

## One overlap is genuinely geometric

The REC "R" button physically sits on top of the **centre** of a compact family button. Playwright correctly refuses a plain click there, and `force: true` would silently deliver the click to the REC button instead — a green test asserting the wrong thing.

New `clickControl` helper probes across the target for a point the element actually owns (a point a real user can hit too) and clicks there, throwing if the control is covered edge to edge. That last case would be a hit-target bug worth failing on rather than papering over.

**Follow-up worth filing:** the REC overlay covering the centre of a selector button is still a layout defect — the control is only clickable at its edges. I left the layout alone since fixing it properly is a UI change beyond this issue's scope.

## Also

- The E2E workflow uploads the Playwright report + traces on failure. Traces are already captured on first retry, but a red run currently leaves only the truncated GitHub-reporter log — which is exactly what made the original failures hard to read.
- `AGENTS.md` documents the E2E smoke path: boot semantics (the INITIALIZE SYSTEM button is *disabled* until the Pyodide bootstrap reports ready), the rack mounting one module at a time, two-level waveform selection, `clickControl`, the several `role="status"` pills in the header, and the per-project launch-flag rule.

## Acceptance

- [x] `npx playwright test` green on Chromium — verified locally, now with real clicks rather than synthetic ones
- [ ] Firefox + WebKit — **unverified here**: only Chromium is installed in this environment and the sandbox forbids `playwright install`. Their launch-flag fix landed in #1046; this PR changes no browser-specific behavior, so CI on this PR is the check.
- [x] No Chromium-only CLI flags applied to WebKit (already true after #1046; unchanged)
- [x] Shared StartOverlay helper used by the flaky specs (already true after #1046; extended with `clickControl`)

## Testing

- Full Chromium E2E: 14 passed, 3 skipped (pre-existing `test.fixme` in `knob-canvas-smoke` / `knob-drag-modifiers`).
- Unit suite: 158 files / 3 skipped, all green.
- `tsc -b` and `npm run lint` clean.

## Separate blocker, not fixed here

The E2E workflow on `main` is still red, but **it no longer gets as far as Playwright** — `pnpm run build` now fails in the Emscripten step:

```
Wrote 0 export mappings to public/hyphon_wasm_export_map.json
[export-map] FAILED
- Missing required exports (36): malloc, free, open303_create, …
```

`tools/extract_wasm_export_map.mjs` matches only double-quoted glue forms (`Module["_x"]=wasmExports["y"]`), and the glue emitted after #1050's build-flag changes evidently no longer matches. I did not fix this: emcc is not available in this environment, so any regex change would be an untested guess about glue I cannot see. Worth its own issue — the E2E gate cannot go green until it is resolved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLkjJN649Rc6TqfEQqqFY5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved knob interaction so dragging works reliably without accidental interference from buttons and other controls.
  * Fixed pointer interaction behavior, enabling natural clicks for waveform and voice selection.

* **Tests**
  * Strengthened browser-based testing to better reflect real user interactions across oscillator and voice controls.
  * Failed test runs now include diagnostic reports and results for easier troubleshooting.

* **Documentation**
  * Expanded end-to-end testing guidance, including setup, controls, indicators, and browser requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->