### PR TITLE
Master true-peak limiter + BS.1770 metering, and the user-editable patch bay

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -57,6 +57,7 @@ Only these markdown files may live at the repository root. `pnpm run check:root`
 | [303-baseline/](docs/audio-engine/303-baseline/) | Canonical-pattern engine baseline WAVs + hardware capture protocol |
 | [303-baseline-spectra/](docs/audio-engine/303-baseline-spectra/) | Spectrogram PNGs and RMS/band metrics for Phase-0 baselines |
 | [jc303-prophecy.md](docs/audio-engine/jc303-prophecy.md) | Open303/JC303 switching and Prophecy routing |
+| [master-loudness.md](docs/audio-engine/master-loudness.md) | Master true-peak limiter + BS.1770 LUFS metering (graph placement, accuracy, export) |
 | [jc303-fix-plan.md](docs/audio-engine/jc303-fix-plan.md) | JC-303 WASM fix plan |
 | [jc303-technical-analysis.md](docs/audio-engine/jc303-technical-analysis.md) | JC-303 build/stack technical analysis |
 | [PLAYBACK_STABILITY.md](docs/audio-engine/PLAYBACK_STABILITY.md) | Song-mode playback jitter thresholds and stress tests |

--- a/docs/PERFORMANCE_BUDGET.md
+++ b/docs/PERFORMANCE_BUDGET.md
@@ -13,6 +13,7 @@ fixed order until headroom recovers below **60%** (hysteresis).
 | TB-303       | `open303-processor`    | `open303`     |
 | Rubber Band  | `RubberBandProcessor`  | `rubberband`  |
 | Vocoder STFT | `vocoder-processor`    | `vocoder`     |
+| Master loudness | `master-loudness-processor` | `masterLoudness` |
 
 Metrics are throttled to the main thread at ~10 Hz via `MessagePort` (`worklet-perf`
 messages). Underruns are counted when `process()` wall time exceeds the quantum
@@ -26,6 +27,28 @@ masterBudgetPercent = min(100, Σ workletCpuPercent)
 
 All worklets share the same audio rendering thread; their CPU costs add within each
 quantum.
+
+## Master loudness / true-peak limiter
+
+`master-loudness-processor` runs the BS.1770-5 meters and the true-peak limiter for
+the single stereo master pair (post-panner, pre-destination). Measured cost of one
+128-frame quantum — limiter plus meter, the same code path the worklet runs — is
+**~0.35 ms**, i.e. **~13 % of the 2.67 ms budget** at 48 kHz. The figure comes from
+the `audio-thread budget` case in
+`src/audio/loudness/__tests__/exportLoudness.test.ts`, which fails above 0.5 ms.
+
+Where the cost goes: the limiter detects inter-sample peaks at 8× and the meter at
+4× (ITU minimum), so each frame costs ~384 FIR taps per channel. Two knobs exist if
+this budget ever needs reclaiming, in order of preference:
+
+1. drop the limiter's detection to 4× (costs ~0.2 dB of ceiling accuracy on
+   near-Nyquist transients, which the internal headroom already absorbs);
+2. move the DSP to a SharedArrayBuffer-backed worker — deliberately **deferred**,
+   since a single stereo pair does not justify the lock-free ring buffers and the
+   COOP/COEP-safe, zero-network posture is easier to keep inside one worklet.
+
+Bypassing the limiter (`enabled: false`) makes the stage a near-free pass-through,
+but the meters stop as well.
 
 ## Glitch detection
 

--- a/docs/audio-engine/master-loudness.md
+++ b/docs/audio-engine/master-loudness.md
@@ -1,0 +1,91 @@
+# Master True-Peak Limiter & BS.1770 Loudness Metering
+
+Broadcast-style loudness for the master bus: momentary / short-term / gated
+integrated LUFS, true-peak (dBTP) metering, and a real-time true-peak brick-wall
+limiter. Everything is first-party — no runtime DSP dependency, no network use.
+
+## Where it sits
+
+```
+… → masterCompressor → masterGain → masterPanner → masterLimiter → destination
+```
+
+`masterLimiter` is the last insert before `destination` (`defaultElectribeGraph.ts`),
+so it protects and measures *everything* — including the choir buses that bypass the
+master FX chain by entering at `masterGain`.
+
+The node is an AudioWorklet, so it is created **before** the graph is compiled
+(`createMasterLoudnessStage` → `buildClassicElectribeGraph({ masterLimiterNode })`).
+If the worklet cannot be registered, `compileAudioGraph` bridges
+`masterPanner → destination` and playback continues without metering.
+
+## Modules
+
+| File | Role |
+|------|------|
+| `src/audio/loudness/kWeighting.ts` | BS.1770-5 K-weighting biquads, derived per sample rate |
+| `src/audio/loudness/truePeak.ts` | Polyphase FIR oversampler + true-peak detection |
+| `src/audio/loudness/loudnessMeter.ts` | Momentary / short-term / gated integrated LUFS |
+| `src/audio/loudness/limiter.ts` | Lookahead true-peak brick-wall limiter |
+| `src/audio/loudness/offline.ts` | Export-side analysis and normalisation |
+| `src/audio/loudness/masterLoudnessStage.ts` | Main-thread node handle, stats stream, debounced params |
+| `src/audio-worklets/master-loudness-processor.ts` | The worklet: limiter → meter, scalar stats out |
+| `src/components/MasterLoudnessMeter.tsx` | Master strip UI |
+
+## Accuracy and how it is validated
+
+- **K-weighting** is computed from the analog prototypes at the live sample rate. The
+  tests assert the 48 kHz result equals the coefficient table printed in BS.1770-5,
+  which is the only rate the recommendation tabulates — so nothing is vendored and
+  44.1 / 48 / 96 kHz are all correct.
+- **Gating** follows BS.1770-4/5: 400 ms blocks at 100 ms hop, absolute gate at
+  −70 LUFS, relative gate 10 LU below the ungated mean. Blocks are accumulated into a
+  fixed-size histogram (0.1 LU bins), so a long session cannot grow worklet memory.
+- **True peak** uses a 128-tap windowed-sinc polyphase interpolator, 4× at ≤ 48 kHz
+  and 2× at 96 kHz (≥ 192 kHz effective, per ITU). Tests assert the canonical case:
+  a 0 dBFS fs/4 sine at 45° reads +3.01 dBTP where a sample-peak meter reads 0 dBFS.
+- Tolerances held in tests: **±0.1 LU** and **±0.1 dBTP**.
+
+Test signals need faded edges when a measurement must be accurate to 0.1 dB: a buffer
+that starts or ends mid-cycle is a step, and the band-limited reconstruction of a step
+genuinely overshoots by ~1 dB. That is a property of the signal, not a meter bug.
+
+## Limiter
+
+- Default ceiling **−1.0 dBTP**, lookahead 1.5 ms, attack 1 ms, release 60 ms.
+- Detection runs at **8×** (twice the metering factor): 4× estimation underestimates
+  near-Nyquist transients enough to break the brick wall.
+- The gain target sits `0.4 dB` under the requested ceiling. This absorbs the residual
+  ISP estimation error *and* the inter-sample energy that applying a time-varying gain
+  creates, so an 8× measurement of the output stays at or below the ceiling. Under
+  heavy limiting the output therefore measures a few tenths below the number on the
+  knob — deliberately, and in the safe direction.
+- **Bypass** (`enabled: false`) is a bit-exact pass-through with zero latency; the
+  meters stop too.
+- **Monitor-only** is a zero-latency sample-domain hard clip for live performance.
+- Latency (`lookahead + detector group delay`) is reported to the main thread for
+  monitor-latency accounting and shown in the UI.
+
+## Export
+
+`exportStemsToZip` measures the master stem with the same DSP (8× true peak offline)
+and writes the report into `metadata.json`. Passing `options.loudness.normalizeTo`
+(a number or `'streaming' | 'club' | 'broadcast'`) additionally gain-matches the stem
+and re-limits it; the result reports what was *actually* achieved, which can fall
+short of an aggressive target once the ceiling binds.
+
+## UI and persistence
+
+The worklet posts scalar stats only (never audio buffers) at ≤ 30 Hz. State flows one
+way: UI → `MasterLoudnessStage.update()` → debounced `postMessage` → worklet. Settings
+persist to `localStorage` as primitives and are re-validated on load, so a corrupted
+entry falls back to defaults rather than feeding NaN to the audio thread.
+
+Integrated loudness survives transport start/stop and resets only on the explicit
+**Reset** button.
+
+## Performance
+
+~0.35 ms per 128-frame stereo quantum (~13 % of the 2.67 ms budget at 48 kHz). See
+[PERFORMANCE_BUDGET.md](../PERFORMANCE_BUDGET.md) for the measurement and for the two
+options if that budget is ever needed elsewhere.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { LoadingOverlay } from './components/LoadingOverlay'
 import { SEQUENCER_STYLES } from './components/sequencer/constants'
 import { SongMode } from './components/SongMode'
 import { MobileTransportDock } from './components/MobileTransportDock'
+import { MasterLoudnessMeter } from './components/MasterLoudnessMeter'
 import { EngineDegradationBanner } from './components/EngineDegradationBanner'
 import { A11yAnnouncer } from './components/A11yAnnouncer'
 import { useCompactLayoutContext } from './contexts/CompactLayoutContext'
@@ -241,6 +242,12 @@ export const App: React.FC = () => {
                     <div className={`hyphon-rack-shell overflow-hidden ${isCompact ? 'h-[min(40vh,340px)] min-h-[260px]' : 'h-[380px]'}`}>
                         <RackNode />
                     </div>
+                </div>
+
+                {/* Master true-peak limiter + BS.1770 loudness meters, sitting
+                    with the rack because it measures the master bus output. */}
+                <div className="w-full max-w-[1000px] mx-auto shrink-0 mt-2 px-2 sm:px-4">
+                    <MasterLoudnessMeter />
                 </div>
 
                 <div className="shrink-0 py-3 sm:py-4 mt-2 max-w-[1000px] mx-auto w-full px-2 sm:px-4">

--- a/src/audio-worklets/master-loudness-processor.ts
+++ b/src/audio-worklets/master-loudness-processor.ts
@@ -1,0 +1,163 @@
+// src/audio-worklets/master-loudness-processor.ts
+// Master-bus true-peak limiter + BS.1770-5 loudness meter.
+//
+// Sits post-compressor / pre-destination. The limiter runs first, the meter
+// measures the limiter's *output*, so the numbers on screen are the numbers
+// that leave the master bus (and, via the shared DSP, the numbers in the file).
+//
+// Only scalar stats cross the MessagePort, at most `reportHz` times per second.
+// No audio buffers are ever posted to the main thread.
+
+import { WorkletPerfReporter } from './workletPerfReporter';
+import { LoudnessMeter } from '../audio/loudness/loudnessMeter';
+import { TruePeakLimiter } from '../audio/loudness/limiter';
+import { MASTER_LOUDNESS_PROCESSOR_NAME } from '../audio/loudness/types';
+import type {
+    LimiterSettings,
+    LoudnessStats,
+    MasterLoudnessCommand,
+} from '../audio/loudness/types';
+
+declare class AudioWorkletProcessor {
+    readonly port: MessagePort;
+    constructor(options?: unknown);
+    process(
+        inputs: Float32Array[][],
+        outputs: Float32Array[][],
+        parameters: Record<string, Float32Array>,
+    ): boolean;
+}
+
+declare function registerProcessor(
+    name: string,
+    processorCtor: new (options?: unknown) => AudioWorkletProcessor,
+): void;
+declare const sampleRate: number;
+
+const DEFAULT_REPORT_HZ = 24;
+const MAX_REPORT_HZ = 30;
+const CHANNEL_COUNT = 2;
+
+interface MasterLoudnessOptions {
+    processorOptions?: {
+        limiter?: Partial<LimiterSettings>;
+        reportHz?: number;
+    };
+}
+
+class MasterLoudnessProcessor extends AudioWorkletProcessor {
+    private readonly meter: LoudnessMeter;
+    private readonly limiter: TruePeakLimiter;
+    /** Reusable views handed to the DSP — never reallocated in process(). */
+    private readonly inputViews: Float32Array[] = [];
+    private readonly outputViews: Float32Array[] = [];
+    /** Zero-filled stand-in for a missing input channel; sized to the quantum once. */
+    private silence: Float32Array;
+
+    /** Audio-thread CPU telemetry, same channel as the other worklets. */
+    private readonly perf: WorkletPerfReporter;
+
+    private framesSinceReport = 0;
+    private reportInterval: number;
+    private alive = true;
+
+    constructor(options?: unknown) {
+        super();
+        const processorOptions = (options as MasterLoudnessOptions | undefined)?.processorOptions ?? {};
+        this.meter = new LoudnessMeter({ sampleRate, channelCount: CHANNEL_COUNT });
+        this.limiter = new TruePeakLimiter(sampleRate, CHANNEL_COUNT, processorOptions.limiter);
+        this.silence = new Float32Array(128);
+        this.perf = new WorkletPerfReporter(this.port, 'masterLoudness');
+        this.reportInterval = this.framesPerReport(processorOptions.reportHz ?? DEFAULT_REPORT_HZ);
+
+        this.port.onmessage = (event: MessageEvent<MasterLoudnessCommand>) => {
+            this.handleCommand(event.data);
+        };
+    }
+
+    private framesPerReport(hz: number): number {
+        const clamped = Math.min(Math.max(hz, 1), MAX_REPORT_HZ);
+        return Math.max(1, Math.round(sampleRate / clamped));
+    }
+
+    private handleCommand(command: MasterLoudnessCommand | undefined): void {
+        if (!command) return;
+        switch (command.type) {
+            case 'set-limiter':
+                this.limiter.setSettings(command.data);
+                break;
+            case 'reset-loudness':
+                // Momentary/short-term keep running; only the integrated
+                // measurement and held peaks are user-resettable.
+                this.meter.resetIntegrated();
+                this.meter.resetPeaks();
+                break;
+            case 'set-report-hz':
+                this.reportInterval = this.framesPerReport(command.data);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private buildStats(): LoudnessStats {
+        const { gainReductionDb, clipped } = this.limiter.takeStats();
+        return {
+            momentary: this.meter.momentary,
+            shortTerm: this.meter.shortTerm,
+            integrated: this.meter.integrated,
+            truePeak: this.meter.truePeakDb,
+            samplePeak: this.meter.samplePeakDb,
+            gainReduction: gainReductionDb,
+            clipped,
+        };
+    }
+
+    process(inputs: Float32Array[][], outputs: Float32Array[][]): boolean {
+        const output = outputs[0];
+        if (!output || output.length === 0) return this.alive;
+
+        const frames = output[0].length;
+        const endProcess = this.perf.beginProcess(frames);
+        try {
+            this.render(inputs, output, frames);
+        } finally {
+            endProcess();
+        }
+        return this.alive;
+    }
+
+    private render(inputs: Float32Array[][], output: Float32Array[], frames: number): void {
+        const input = inputs[0];
+        if (this.silence.length !== frames) {
+            // The render quantum is fixed at 128 in practice; this runs once.
+            this.silence = new Float32Array(frames);
+        }
+        for (let ch = 0; ch < CHANNEL_COUNT; ch += 1) {
+            const source = input?.[ch] ?? input?.[0];
+            this.inputViews[ch] = source && source.length >= frames ? source : this.silence;
+            this.outputViews[ch] = output[ch] ?? output[0];
+        }
+
+        this.limiter.process(this.inputViews, this.outputViews, frames);
+        this.meter.process(this.outputViews, frames);
+
+        // Mono destinations get the limited left channel rather than silence.
+        for (let ch = CHANNEL_COUNT; ch < output.length; ch += 1) {
+            const extra = output[ch];
+            for (let i = 0; i < frames; i += 1) extra[i] = this.outputViews[0][i];
+        }
+
+        this.framesSinceReport += frames;
+        if (this.framesSinceReport >= this.reportInterval) {
+            this.framesSinceReport = 0;
+            this.port.postMessage({
+                type: 'loudness-stats',
+                data: this.buildStats(),
+                latencySeconds: this.limiter.latencySeconds,
+            });
+        }
+    }
+}
+
+registerProcessor(MASTER_LOUDNESS_PROCESSOR_NAME, MasterLoudnessProcessor);

--- a/src/audio/graph/__tests__/compileGraph.test.ts
+++ b/src/audio/graph/__tests__/compileGraph.test.ts
@@ -3,6 +3,7 @@ import {
     CLASSIC_ELECTRIBE_GRAPH,
     MASTER_CHAIN_CONNECTIONS,
     MASTER_CHAIN_ORDER,
+    MASTER_CHAIN_ORDER_WITH_LIMITER,
     compileAudioGraph,
     extractMasterChainConnections,
 } from '../index';
@@ -140,9 +141,13 @@ describe('compileAudioGraph', () => {
                 nodes: CLASSIC_ELECTRIBE_GRAPH.nodes.filter((n) =>
                     MASTER_CHAIN_ORDER.includes(n.id) || n.id === 'masterAnalyser',
                 ),
+                // The master limiter node is only compiled when the host
+                // supplies a worklet; its edges stay in so the compiler has to
+                // bridge masterPanner straight to the destination.
                 edges: CLASSIC_ELECTRIBE_GRAPH.edges.filter(
                     (e) =>
                         MASTER_CHAIN_ORDER.includes(e.from) ||
+                        e.from === 'masterLimiter' ||
                         e.from === 'masterGain' && e.to === 'masterAnalyser',
                 ),
             },
@@ -196,7 +201,88 @@ describe('compileAudioGraph', () => {
         });
         const masterPairs = extractMasterChainConnections(graph.connectionLog);
         expect(masterPairs).toHaveLength(MASTER_CHAIN_CONNECTIONS.length);
+        // Without a master limiter node its two edges collapse into one.
+        expect(graph.connectionLog.length).toBe(CLASSIC_ELECTRIBE_GRAPH.edges.length - 1);
+    });
+});
+
+describe('master limiter stage', () => {
+    it('declares the limiter as the last insert before the destination', () => {
+        const toDestination = CLASSIC_ELECTRIBE_GRAPH.edges.filter((e) => e.to === 'destination');
+        expect(toDestination).toEqual([{ from: 'masterLimiter', to: 'destination' }]);
+        expect(MASTER_CHAIN_ORDER_WITH_LIMITER).toContain('masterLimiter');
+        // Post-compressor: nothing in the master chain sits after the limiter.
+        const fromLimiter = CLASSIC_ELECTRIBE_GRAPH.edges.filter((e) => e.from === 'masterLimiter');
+        expect(fromLimiter).toEqual([{ from: 'masterLimiter', to: 'destination' }]);
+    });
+
+    it('wires masterPanner → masterLimiter → destination when a node is supplied', () => {
+        const { context } = createTrackingContext();
+        const impulse = context.createBuffer(2, 100, 48000);
+        const limiterNode = { id: 'masterLimiter', connect: () => {} } as unknown as AudioNode;
+
+        const graph = compileAudioGraph(context, CLASSIC_ELECTRIBE_GRAPH, {
+            createReverbImpulse: () => impulse,
+            createMasterLimiterNode: () => limiterNode,
+        });
+
+        expect(graph.getNode('masterLimiter')).toBe(limiterNode);
+        expect(graph.getRoleNode('masterLimiter')).toBe(limiterNode);
+        const pairs = extractMasterChainConnections(graph.connectionLog).map((c) => [c.from, c.to]);
+        expect(pairs).toEqual([
+            ['masterSaturation', 'bassSidechainEQ'],
+            ['bassSidechainEQ', 'sidechainGain'],
+            ['sidechainGain', 'masterCompressor'],
+            ['masterCompressor', 'masterGain'],
+            ['masterGain', 'masterPanner'],
+            ['masterPanner', 'masterLimiter'],
+            ['masterLimiter', 'destination'],
+        ]);
         expect(graph.connectionLog.length).toBe(CLASSIC_ELECTRIBE_GRAPH.edges.length);
+    });
+
+    it('bridges masterPanner → destination when the worklet is unavailable', () => {
+        const { context } = createTrackingContext();
+        const impulse = context.createBuffer(2, 100, 48000);
+        const graph = compileAudioGraph(context, CLASSIC_ELECTRIBE_GRAPH, {
+            createReverbImpulse: () => impulse,
+            createMasterLimiterNode: () => null,
+        });
+
+        expect(graph.nodes.has('masterLimiter')).toBe(false);
+        const pairs = extractMasterChainConnections(graph.connectionLog).map((c) => [c.from, c.to]);
+        expect(pairs).toEqual(MASTER_CHAIN_CONNECTIONS.map(([from, to]) => [from, to]));
+    });
+
+    it('routes masterGain to the limiter when the stereo panner is skipped', () => {
+        const { context } = createTrackingContext();
+        const limiterNode = { id: 'masterLimiter', connect: () => {} } as unknown as AudioNode;
+        // Minimal master-only config: the choir panners are unrelated to this
+        // fallback and the compiler has no bridge for them.
+        const graph = compileAudioGraph(
+            context,
+            {
+                id: 'no-panner',
+                name: 'No Panner',
+                nodes: CLASSIC_ELECTRIBE_GRAPH.nodes.filter((n) =>
+                    MASTER_CHAIN_ORDER_WITH_LIMITER.includes(n.id),
+                ),
+                edges: CLASSIC_ELECTRIBE_GRAPH.edges.filter(
+                    (e) =>
+                        MASTER_CHAIN_ORDER_WITH_LIMITER.includes(e.from) &&
+                        MASTER_CHAIN_ORDER_WITH_LIMITER.includes(e.to),
+                ),
+            },
+            {
+                createMasterLimiterNode: () => limiterNode,
+                useStereoPanner: false,
+            },
+        );
+
+        const pairs = graph.connectionLog.map((c) => [c.from, c.to]);
+        expect(pairs).toContainEqual(['masterGain', 'masterLimiter']);
+        expect(pairs).toContainEqual(['masterLimiter', 'destination']);
+        expect(pairs.some(([from]) => from === 'masterPanner')).toBe(false);
     });
 });
 

--- a/src/audio/graph/compileGraph.ts
+++ b/src/audio/graph/compileGraph.ts
@@ -10,6 +10,7 @@ import type {
     DynamicsCompressorConfig,
     GainConfig,
     GraphConnectionRecord,
+    GraphEdgeSpec,
     GraphNodeFactory,
     GraphNodeId,
     GraphNodeRole,
@@ -23,10 +24,20 @@ export interface CompileGraphOptions {
     /** When false, skip masterPanner and connect masterGain → destination directly. */
     useStereoPanner?: boolean;
     createReverbImpulse?: (context: AudioContext, preset: 'room' | 'plate' | 'hall') => AudioBuffer;
+    /**
+     * Supplies the master true-peak limiter / loudness-meter node.
+     *
+     * The stage is an AudioWorklet, so its module has to be loaded before the
+     * graph is compiled — see `createMasterLoudnessStage`. Returning `null`
+     * (the default) omits the node and bridges the chain straight to the
+     * destination, so a browser that cannot register the worklet still plays.
+     */
+    createMasterLimiterNode?: (context: AudioContext) => AudioNode | null;
 }
 
 const DEFAULT_OPTIONS: Required<CompileGraphOptions> = {
     useStereoPanner: true,
+    createMasterLimiterNode: () => null,
     createReverbImpulse: (context, preset) => {
         switch (preset) {
             case 'room':
@@ -135,11 +146,41 @@ function createNode(
             analysers.set(id, analyser);
             return bus;
         }
+        case 'masterLimiter':
+            return options.createMasterLimiterNode(context);
         case 'destination':
             return context.destination;
         default:
             throw new Error(`Unknown graph node factory: ${factory}`);
     }
+}
+
+/**
+ * Remove edges through nodes that were not compiled, splicing predecessor to
+ * successor so the chain stays connected (used for the optional master limiter).
+ * Edge order is preserved: the bridged edge takes the slot of the incoming one.
+ */
+function bridgeAbsentNodes(
+    edges: readonly GraphEdgeSpec[],
+    present: ReadonlySet<GraphNodeId>,
+    optionalIds: readonly GraphNodeId[],
+): GraphEdgeSpec[] {
+    let result = [...edges];
+    for (const id of optionalIds) {
+        if (present.has(id)) continue;
+        const successors = result.filter((edge) => edge.from === id).map((edge) => edge.to);
+        const bridged: GraphEdgeSpec[] = [];
+        for (const edge of result) {
+            if (edge.from === id) continue;
+            if (edge.to === id) {
+                for (const to of successors) bridged.push({ from: edge.from, to });
+                continue;
+            }
+            bridged.push(edge);
+        }
+        result = bridged;
+    }
+    return result;
 }
 
 function registerRole(
@@ -186,7 +227,9 @@ export function compileAudioGraph(
 
     // When stereo panner node was not created, reroute masterGain → destination
     const hasStereoPanner = nodes.has('masterPanner');
-    const edges = config.edges.filter((edge) => {
+    const optionalEdges = bridgeAbsentNodes(config.edges, new Set(nodes.keys()), ['masterLimiter']);
+
+    const edges = optionalEdges.filter((edge) => {
         if (hasStereoPanner) return true;
         if (edge.from === 'masterGain' && edge.to === 'masterPanner') return false;
         if (edge.from === 'masterPanner') return false;
@@ -195,11 +238,12 @@ export function compileAudioGraph(
 
     if (!hasStereoPanner) {
         const masterGain = nodes.get('masterGain');
+        const limiter = nodes.get('masterLimiter');
         if (masterGain) {
-            masterGain.connect(context.destination);
+            masterGain.connect(limiter ?? context.destination);
             connectionLog.push({
                 from: 'masterGain',
-                to: 'destination',
+                to: limiter ? 'masterLimiter' : 'destination',
                 order: connectionLog.length,
             });
         }
@@ -258,6 +302,7 @@ export function extractMasterChainConnections(
     log: readonly GraphConnectionRecord[],
 ): Array<{ from: string; to: string }> {
     const masterIds = new Set([
+        'masterLimiter',
         'masterSaturation',
         'bassSidechainEQ',
         'sidechainGain',

--- a/src/audio/graph/defaultElectribeGraph.ts
+++ b/src/audio/graph/defaultElectribeGraph.ts
@@ -45,6 +45,16 @@ export const CLASSIC_ELECTRIBE_GRAPH: AudioGraphConfig = {
             role: 'masterOutput',
             config: { pan: 0 },
         },
+        {
+            // True-peak limiter + BS.1770 meter. Last insert before the
+            // destination so it protects (and measures) everything upstream,
+            // including the choir buses that bypass the master FX chain.
+            // Compiled only when the host supplies a worklet node — otherwise
+            // the chain bridges straight to `destination`.
+            id: 'masterLimiter',
+            factory: 'masterLimiter',
+            role: 'masterLimiter',
+        },
         { id: 'destination', factory: 'destination' },
         {
             id: 'masterAnalyser',
@@ -129,7 +139,8 @@ export const CLASSIC_ELECTRIBE_GRAPH: AudioGraphConfig = {
         { from: 'sidechainGain', to: 'masterCompressor' },
         { from: 'masterCompressor', to: 'masterGain' },
         { from: 'masterGain', to: 'masterPanner' },
-        { from: 'masterPanner', to: 'destination' },
+        { from: 'masterPanner', to: 'masterLimiter' },
+        { from: 'masterLimiter', to: 'destination' },
 
         // Passive master analyser tap (read-only)
         { from: 'masterGain', to: 'masterAnalyser' },
@@ -156,6 +167,18 @@ export const CLASSIC_ELECTRIBE_GRAPH: AudioGraphConfig = {
         { from: 'choirRightPanner', to: 'masterGain' },
     ],
 };
+
+/** Ordered master-chain node ids when the limiter stage is compiled in. */
+export const MASTER_CHAIN_ORDER_WITH_LIMITER: readonly string[] = [
+    'masterSaturation',
+    'bassSidechainEQ',
+    'sidechainGain',
+    'masterCompressor',
+    'masterGain',
+    'masterPanner',
+    'masterLimiter',
+    'destination',
+];
 
 /** Ordered master-chain node ids for test assertions. */
 export const MASTER_CHAIN_ORDER: readonly string[] = [

--- a/src/audio/graph/index.ts
+++ b/src/audio/graph/index.ts
@@ -86,14 +86,27 @@ export interface BuildElectribeGraphResult {
     masterBusInput: WaveShaperNode;
 }
 
+export interface BuildElectribeGraphOptions {
+    /**
+     * Master true-peak limiter / loudness-meter node, already constructed via
+     * `createMasterLoudnessStage`. Omit it and the chain runs panner →
+     * destination exactly as before.
+     */
+    masterLimiterNode?: AudioNode | null;
+}
+
 /**
  * Build the default Classic Electribe routing graph and populate engine refs.
  */
 export function buildClassicElectribeGraph(
     context: AudioContext,
     refs: ElectribeGraphRefs,
+    options: BuildElectribeGraphOptions = {},
 ): BuildElectribeGraphResult {
-    const graph = compileAudioGraph(context, CLASSIC_ELECTRIBE_GRAPH);
+    const limiterNode = options.masterLimiterNode ?? null;
+    const graph = compileAudioGraph(context, CLASSIC_ELECTRIBE_GRAPH, {
+        createMasterLimiterNode: () => limiterNode,
+    });
     const masterBusInput = assignMasterChainRefs(graph, refs);
     assignTrackBusRefs(graph, refs);
     assignAuxSendRefs(graph, refs);
@@ -101,8 +114,14 @@ export function buildClassicElectribeGraph(
     return { graph, masterBusInput };
 }
 
-export { CLASSIC_ELECTRIBE_GRAPH, MASTER_CHAIN_ORDER, MASTER_CHAIN_CONNECTIONS } from './defaultElectribeGraph';
+export {
+    CLASSIC_ELECTRIBE_GRAPH,
+    MASTER_CHAIN_ORDER,
+    MASTER_CHAIN_ORDER_WITH_LIMITER,
+    MASTER_CHAIN_CONNECTIONS,
+} from './defaultElectribeGraph';
 export { compileAudioGraph, extractMasterChainConnections } from './compileGraph';
+export type { CompileGraphOptions } from './compileGraph';
 export type {
     AudioGraphConfig,
     CompiledAudioGraph,

--- a/src/audio/graph/types.ts
+++ b/src/audio/graph/types.ts
@@ -10,6 +10,7 @@ export type GraphNodeRole =
     | 'masterFxInput'
     | 'masterDryInput'
     | 'masterOutput'
+    | 'masterLimiter'
     | 'trackBus'
     | 'trackAnalyser'
     | 'auxReturn'
@@ -26,6 +27,7 @@ export type GraphNodeFactory =
     | 'convolver'
     | 'delay'
     | 'trackMonitor'
+    | 'masterLimiter'
     | 'destination';
 
 export interface BiquadFilterConfig {

--- a/src/audio/loudness/__tests__/exportLoudness.test.ts
+++ b/src/audio/loudness/__tests__/exportLoudness.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Offline export path: loudness reporting, normalisation, live-vs-file parity
+ * and the audio-thread performance budget for the master worklet.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { analyzeLoudness, normalizeToTarget, formatLufs } from '../offline';
+import { LoudnessMeter } from '../loudnessMeter';
+import { TruePeakLimiter } from '../limiter';
+import { measureTruePeakDbtp } from '../truePeak';
+import { LOUDNESS_TARGETS, SILENCE_LUFS } from '../types';
+import {
+    loadLimiterSettings,
+    saveLimiterSettings,
+    sanitizeLimiterSettings,
+    LIMITER_STORAGE_KEY,
+} from '../settings';
+import { DEFAULT_LIMITER_SETTINGS } from '../types';
+
+const SAMPLE_RATE = 48000;
+
+/** Pseudo-music: a few partials plus transients, deterministic across runs. */
+function mixdown(seconds: number, sampleRate = SAMPLE_RATE, amplitude = 0.5): Float32Array[] {
+    const frames = Math.round(seconds * sampleRate);
+    const left = new Float32Array(frames);
+    const right = new Float32Array(frames);
+    let seed = 12345;
+    for (let i = 0; i < frames; i += 1) {
+        seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+        const noise = (seed / 0x7fffffff) * 2 - 1;
+        const fade = Math.min(1, i / 2000, (frames - i) / 2000);
+        const tone =
+            0.6 * Math.sin((2 * Math.PI * 110 * i) / sampleRate) +
+            0.3 * Math.sin((2 * Math.PI * 440 * i) / sampleRate) +
+            0.1 * Math.sin((2 * Math.PI * 3000 * i) / sampleRate);
+        const transient = i % 12000 < 32 ? 0.8 * noise : 0.02 * noise;
+        left[i] = fade * amplitude * (tone + transient);
+        right[i] = fade * amplitude * (tone - transient);
+    }
+    return [left, right];
+}
+
+describe('offline loudness report', () => {
+    it('reports integrated loudness, true peak and sample peak', () => {
+        const report = analyzeLoudness(mixdown(6), SAMPLE_RATE);
+        expect(Number.isFinite(report.integrated)).toBe(true);
+        expect(report.truePeak).toBeGreaterThanOrEqual(report.samplePeak - 0.01);
+        expect(report.maxShortTerm).toBeGreaterThanOrEqual(report.integrated - 5);
+        expect(report.maxMomentary).toBeGreaterThanOrEqual(report.maxShortTerm - 5);
+    });
+
+    it('formats silence readably', () => {
+        expect(formatLufs(SILENCE_LUFS)).toBe('-inf');
+        expect(formatLufs(-13.94)).toBe('-13.9');
+    });
+});
+
+describe('live vs offline parity', () => {
+    // The worklet and the export path run the same DSP, so a mix limited in
+    // 128-frame quanta must measure the same as the offline analysis of the
+    // rendered result.
+    it('matches within 0.1 LU and 0.1 dBTP', () => {
+        const source = mixdown(8);
+
+        // "Live": limit in render quanta, metering the limiter output.
+        const limiter = new TruePeakLimiter(SAMPLE_RATE, 2, { ceilingDbtp: -1 });
+        const meter = new LoudnessMeter({ sampleRate: SAMPLE_RATE, channelCount: 2 });
+        const rendered = source.map((channel) => new Float32Array(channel.length));
+        const inViews: Float32Array[] = [];
+        const outViews: Float32Array[] = [];
+        for (let offset = 0; offset < source[0].length; offset += 128) {
+            const size = Math.min(128, source[0].length - offset);
+            for (let ch = 0; ch < 2; ch += 1) {
+                inViews[ch] = source[ch].subarray(offset, offset + size);
+                outViews[ch] = rendered[ch].subarray(offset, offset + size);
+            }
+            limiter.process(inViews, outViews, size);
+            meter.process(outViews, size);
+        }
+
+        // "File": analyse the rendered buffer in one pass.
+        const offline = analyzeLoudness(rendered, SAMPLE_RATE);
+        expect(Math.abs(offline.integrated - meter.integrated)).toBeLessThanOrEqual(0.1);
+        expect(Math.abs(offline.truePeak - meter.truePeakDb)).toBeLessThanOrEqual(0.1);
+    });
+});
+
+describe('normalizeToTarget', () => {
+    it('brings a quiet mix up to the streaming target', () => {
+        const channels = mixdown(8, SAMPLE_RATE, 0.05);
+        const result = normalizeToTarget(channels, SAMPLE_RATE, 'streaming');
+        expect(result.targetLufs).toBe(LOUDNESS_TARGETS.streaming);
+        expect(result.appliedGain).toBeGreaterThan(1);
+        expect(Math.abs(result.resultingIntegrated - LOUDNESS_TARGETS.streaming)).toBeLessThan(1);
+    });
+
+    it('brings a hot mix down and keeps the ceiling', () => {
+        const channels = mixdown(8, SAMPLE_RATE, 0.9);
+        const result = normalizeToTarget(channels, SAMPLE_RATE, -23, { ceilingDbtp: -1 });
+        expect(result.appliedGain).toBeLessThan(1);
+        expect(Math.abs(result.resultingIntegrated + 23)).toBeLessThan(1);
+        expect(measureTruePeakDbtp(channels, SAMPLE_RATE, 8)).toBeLessThanOrEqual(-1);
+    });
+
+    it('accepts a numeric target and reports what was actually achieved', () => {
+        const channels = mixdown(6, SAMPLE_RATE, 0.4);
+        const result = normalizeToTarget(channels, SAMPLE_RATE, LOUDNESS_TARGETS.club, {
+            ceilingDbtp: -1,
+        });
+        expect(result.targetLufs).toBe(-9);
+        // A -9 LUFS target under a -1 dBTP ceiling may fall short; the caller is
+        // told the truth rather than being left to assume the target was met.
+        expect(result.resultingIntegrated).toBeLessThanOrEqual(-9 + 0.5);
+        expect(measureTruePeakDbtp(channels, SAMPLE_RATE, 8)).toBeLessThanOrEqual(-1);
+    });
+
+    it('leaves silence alone instead of applying infinite gain', () => {
+        const channels = [new Float32Array(48000), new Float32Array(48000)];
+        const result = normalizeToTarget(channels, SAMPLE_RATE, 'streaming');
+        expect(result.appliedGain).toBe(1);
+        expect(channels[0].every((value) => value === 0)).toBe(true);
+    });
+});
+
+describe('audio-thread budget', () => {
+    // Documented in docs/PERFORMANCE_BUDGET.md — this is the number that
+    // justifies keeping the DSP in one worklet instead of a SAB worker.
+    it('processes a stereo quantum well inside the 2.67 ms budget', () => {
+        const limiter = new TruePeakLimiter(SAMPLE_RATE, 2);
+        const meter = new LoudnessMeter({ sampleRate: SAMPLE_RATE, channelCount: 2 });
+        const input = [new Float32Array(128), new Float32Array(128)];
+        const output = [new Float32Array(128), new Float32Array(128)];
+        for (let i = 0; i < 128; i += 1) {
+            input[0][i] = 0.7 * Math.sin(i / 3);
+            input[1][i] = 0.7 * Math.sin(i / 3.1);
+        }
+
+        const iterations = 2000;
+        for (let i = 0; i < 200; i += 1) {
+            limiter.process(input, output, 128);
+            meter.process(output, 128);
+        }
+        const start = performance.now();
+        for (let i = 0; i < iterations; i += 1) {
+            limiter.process(input, output, 128);
+            meter.process(output, 128);
+        }
+        const perQuantumMs = (performance.now() - start) / iterations;
+
+        // 128 frames at 48 kHz is a 2.67 ms budget. Assert a wide margin so the
+        // test is not flaky on loaded CI machines but still catches a regression
+        // that would make the master stage unusable.
+        expect(perQuantumMs).toBeLessThan(0.5);
+    });
+});
+
+describe('limiter settings persistence', () => {
+    it('round-trips through storage as primitives only', () => {
+        const store = new Map<string, string>();
+        const storage = {
+            getItem: (key: string) => store.get(key) ?? null,
+            setItem: (key: string, value: string) => store.set(key, value),
+        } as unknown as Storage;
+
+        saveLimiterSettings({ ...DEFAULT_LIMITER_SETTINGS, ceilingDbtp: -2.5 }, storage);
+        const raw = store.get(LIMITER_STORAGE_KEY)!;
+        const parsed = JSON.parse(raw);
+        for (const value of Object.values(parsed)) {
+            expect(['number', 'boolean']).toContain(typeof value);
+        }
+        expect(loadLimiterSettings(storage).ceilingDbtp).toBe(-2.5);
+    });
+
+    it('falls back to defaults on corrupted or hostile values', () => {
+        expect(sanitizeLimiterSettings(null)).toEqual(DEFAULT_LIMITER_SETTINGS);
+        expect(sanitizeLimiterSettings({ ceilingDbtp: NaN }).ceilingDbtp).toBe(
+            DEFAULT_LIMITER_SETTINGS.ceilingDbtp,
+        );
+        expect(sanitizeLimiterSettings({ ceilingDbtp: 40 }).ceilingDbtp).toBe(
+            DEFAULT_LIMITER_SETTINGS.ceilingDbtp,
+        );
+        expect(sanitizeLimiterSettings({ lookaheadMs: -5 }).lookaheadMs).toBe(
+            DEFAULT_LIMITER_SETTINGS.lookaheadMs,
+        );
+        expect(sanitizeLimiterSettings({ enabled: 'yes' }).enabled).toBe(
+            DEFAULT_LIMITER_SETTINGS.enabled,
+        );
+    });
+
+    it('survives a storage backend that throws', () => {
+        const hostile = {
+            getItem: () => {
+                throw new Error('denied');
+            },
+            setItem: () => {
+                throw new Error('quota');
+            },
+        } as unknown as Storage;
+        expect(loadLimiterSettings(hostile)).toEqual(DEFAULT_LIMITER_SETTINGS);
+        expect(() => saveLimiterSettings(DEFAULT_LIMITER_SETTINGS, hostile)).not.toThrow();
+    });
+});

--- a/src/audio/loudness/__tests__/loudnessMeter.test.ts
+++ b/src/audio/loudness/__tests__/loudnessMeter.test.ts
@@ -1,0 +1,241 @@
+/**
+ * BS.1770-5 / EBU TECH 3341 conformance for the first-party loudness meter.
+ *
+ * The reference values are the ones published in the recommendations
+ * themselves (tone tests, gating cases and the 48 kHz coefficient table), so
+ * the DSP is validated against known-good numbers rather than against itself.
+ * Tolerances follow TECH 3341: ±0.1 LU.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { LoudnessMeter, meanSquareToLufs } from '../loudnessMeter';
+import { shelfCoefficients, highPassCoefficients } from '../kWeighting';
+import { analyzeLoudness } from '../offline';
+import { SILENCE_LUFS } from '../types';
+
+const TOLERANCE_LU = 0.1;
+
+/** Stereo sine at `db` dBFS, identical in both channels. */
+function stereoSine(
+    seconds: number,
+    sampleRate: number,
+    frequency = 1000,
+    db = -20,
+): Float32Array[] {
+    const frames = Math.round(seconds * sampleRate);
+    const amplitude = Math.pow(10, db / 20) * Math.SQRT2; // db is RMS, not peak
+    const left = new Float32Array(frames);
+    for (let i = 0; i < frames; i += 1) {
+        left[i] = amplitude * Math.sin((2 * Math.PI * frequency * i) / sampleRate);
+    }
+    return [left, Float32Array.from(left)];
+}
+
+function silence(seconds: number, sampleRate: number): Float32Array[] {
+    const frames = Math.round(seconds * sampleRate);
+    return [new Float32Array(frames), new Float32Array(frames)];
+}
+
+function concat(...segments: Float32Array[][]): Float32Array[] {
+    const channels = segments[0].length;
+    const out: Float32Array[] = [];
+    for (let ch = 0; ch < channels; ch += 1) {
+        const total = segments.reduce((sum, segment) => sum + segment[ch].length, 0);
+        const buffer = new Float32Array(total);
+        let offset = 0;
+        for (const segment of segments) {
+            buffer.set(segment[ch], offset);
+            offset += segment[ch].length;
+        }
+        out.push(buffer);
+    }
+    return out;
+}
+
+describe('K-weighting coefficients', () => {
+    // ITU-R BS.1770-5 Tables 1 and 2 — the only rate the recommendation tabulates.
+    it('matches the tabulated 48 kHz stage 1 (shelving) coefficients', () => {
+        const c = shelfCoefficients(48000);
+        expect(c.b0).toBeCloseTo(1.53512485958697, 6);
+        expect(c.b1).toBeCloseTo(-2.69169618940638, 6);
+        expect(c.b2).toBeCloseTo(1.19839281085285, 6);
+        expect(c.a1).toBeCloseTo(-1.69065929318241, 6);
+        expect(c.a2).toBeCloseTo(0.73248077421585, 6);
+    });
+
+    it('matches the tabulated 48 kHz stage 2 (RLB high-pass) coefficients', () => {
+        const c = highPassCoefficients(48000);
+        expect(c.b0).toBeCloseTo(1.0, 6);
+        expect(c.b1).toBeCloseTo(-2.0, 6);
+        expect(c.b2).toBeCloseTo(1.0, 6);
+        expect(c.a1).toBeCloseTo(-1.99004745483398, 6);
+        expect(c.a2).toBeCloseTo(0.99007225036621, 6);
+    });
+
+    it('produces different coefficients per sample rate (no hard-coded table)', () => {
+        expect(shelfCoefficients(44100).b0).not.toBeCloseTo(shelfCoefficients(48000).b0, 5);
+        expect(highPassCoefficients(96000).a1).not.toBeCloseTo(highPassCoefficients(48000).a1, 5);
+    });
+});
+
+describe('LoudnessMeter — TECH 3341 tone cases', () => {
+    // EBU TECH 3341 case 1: -23 LUFS 1 kHz stereo tone reads -23.0 ±0.1.
+    it('reads -23 LUFS for a -23 dBFS 1 kHz stereo tone', () => {
+        const report = analyzeLoudness(stereoSine(20, 48000, 1000, -26), 48000);
+        // -26 dBFS per channel, summed over two channels → -23 LUFS.
+        expect(report.integrated).toBeCloseTo(-23.0, 1);
+        expect(Math.abs(report.integrated + 23.0)).toBeLessThanOrEqual(TOLERANCE_LU);
+    });
+
+    it('reads -33 LUFS for the same tone 10 dB quieter', () => {
+        const report = analyzeLoudness(stereoSine(20, 48000, 1000, -36), 48000);
+        expect(Math.abs(report.integrated + 33.0)).toBeLessThanOrEqual(TOLERANCE_LU);
+    });
+
+    it('agrees between momentary, short-term and integrated on steady tone', () => {
+        const meter = new LoudnessMeter({ sampleRate: 48000, channelCount: 2 });
+        const [left, right] = stereoSine(10, 48000, 1000, -26);
+        meter.process([left, right], left.length);
+        expect(Math.abs(meter.momentary + 23)).toBeLessThanOrEqual(TOLERANCE_LU);
+        expect(Math.abs(meter.shortTerm + 23)).toBeLessThanOrEqual(TOLERANCE_LU);
+        expect(Math.abs(meter.integrated + 23)).toBeLessThanOrEqual(TOLERANCE_LU);
+    });
+
+    it('reports silence rather than NaN or -0 for a zero signal', () => {
+        const report = analyzeLoudness(silence(5, 48000), 48000);
+        expect(report.integrated).toBe(SILENCE_LUFS);
+        expect(report.maxMomentary).toBe(SILENCE_LUFS);
+        expect(report.truePeak).toBe(SILENCE_LUFS);
+    });
+});
+
+describe('LoudnessMeter — gating', () => {
+    // TECH 3341 case 3: 20 s of -23 LUFS tone padded with -70 LUFS material
+    // still reads -23.0 ±0.1 — the pad is below the absolute gate. The 20 s
+    // length matters: the six blocks straddling each edge are legitimately part
+    // of the measurement, so a shorter tone reads slightly low on any
+    // compliant meter.
+    it('ignores silence below the absolute gate', () => {
+        const loud = stereoSine(20, 48000, 1000, -26);
+        const signal = concat(silence(10, 48000), loud, silence(10, 48000));
+        const report = analyzeLoudness(signal, 48000);
+        expect(Math.abs(report.integrated + 23)).toBeLessThanOrEqual(TOLERANCE_LU);
+    });
+
+    // ... and a passage more than 10 LU below the ungated mean must be dropped
+    // by the relative gate.
+    it('drops blocks below the relative gate', () => {
+        const loud = stereoSine(10, 48000, 1000, -26); // -23 LUFS
+        const quiet = stereoSine(10, 48000, 1000, -56); // -53 LUFS, > 10 LU down
+        const gated = analyzeLoudness(concat(loud, quiet), 48000).integrated;
+        const loudOnly = analyzeLoudness(loud, 48000).integrated;
+        expect(Math.abs(gated - loudOnly)).toBeLessThanOrEqual(TOLERANCE_LU);
+    });
+
+    it('keeps blocks within 10 LU of the mean', () => {
+        // -23 and -28 LUFS: both survive gating, so the result sits between them.
+        const a = stereoSine(10, 48000, 1000, -26);
+        const b = stereoSine(10, 48000, 1000, -31);
+        const integrated = analyzeLoudness(concat(a, b), 48000).integrated;
+        expect(integrated).toBeLessThan(-23);
+        expect(integrated).toBeGreaterThan(-28);
+    });
+
+    it('resets the integrated measurement on request without disturbing momentary', () => {
+        const meter = new LoudnessMeter({ sampleRate: 48000, channelCount: 2 });
+        const quiet = stereoSine(20, 48000, 1000, -46);
+        meter.process(quiet, quiet[0].length);
+        expect(Math.abs(meter.integrated + 43)).toBeLessThanOrEqual(TOLERANCE_LU);
+
+        meter.resetIntegrated();
+        expect(meter.integrated).toBe(SILENCE_LUFS);
+        // Momentary keeps running across the reset — the UI must not blink.
+        expect(Math.abs(meter.momentary + 43)).toBeLessThanOrEqual(TOLERANCE_LU);
+
+        const loud = stereoSine(20, 48000, 1000, -26);
+        meter.process(loud, loud[0].length);
+        expect(Math.abs(meter.integrated + 23)).toBeLessThanOrEqual(TOLERANCE_LU);
+    });
+});
+
+describe('LoudnessMeter — sample rate independence', () => {
+    for (const sampleRate of [44100, 48000, 96000]) {
+        it(`reads -23 LUFS at ${sampleRate} Hz`, () => {
+            const report = analyzeLoudness(stereoSine(12, sampleRate, 1000, -26), sampleRate);
+            expect(Math.abs(report.integrated + 23)).toBeLessThanOrEqual(TOLERANCE_LU);
+        });
+    }
+
+    it('gives the same reading for the same signal at different rates', () => {
+        const at44 = analyzeLoudness(stereoSine(12, 44100, 997, -26), 44100).integrated;
+        const at96 = analyzeLoudness(stereoSine(12, 96000, 997, -26), 96000).integrated;
+        expect(Math.abs(at44 - at96)).toBeLessThanOrEqual(TOLERANCE_LU);
+    });
+});
+
+describe('LoudnessMeter — robustness', () => {
+    it('treats NaN and Infinity as silence instead of poisoning the meter', () => {
+        const frames = 48000;
+        const left = new Float32Array(frames);
+        const right = new Float32Array(frames);
+        for (let i = 0; i < frames; i += 1) {
+            const value = 0.1 * Math.sin((2 * Math.PI * 1000 * i) / 48000);
+            left[i] = i === 12345 ? NaN : value;
+            right[i] = i === 20000 ? Infinity : value;
+        }
+        const report = analyzeLoudness([left, right], 48000);
+        expect(Number.isFinite(report.integrated)).toBe(true);
+        expect(Number.isFinite(report.truePeak)).toBe(true);
+        expect(report.truePeak).toBeLessThan(6);
+    });
+
+    it('maps a zero mean square to -Infinity, not NaN', () => {
+        expect(meanSquareToLufs(0)).toBe(SILENCE_LUFS);
+        expect(meanSquareToLufs(NaN)).toBe(SILENCE_LUFS);
+        expect(meanSquareToLufs(-1)).toBe(SILENCE_LUFS);
+    });
+
+    it('allocates nothing per render quantum', () => {
+        const meter = new LoudnessMeter({ sampleRate: 48000, channelCount: 2 });
+        const block = [new Float32Array(128), new Float32Array(128)];
+        for (let i = 0; i < 128; i += 1) {
+            block[0][i] = 0.25;
+            block[1][i] = 0.25;
+        }
+        const before = countAllocations(() => meter.process(block, 128));
+        expect(before).toBe(0);
+    });
+});
+
+/**
+ * Count typed-array constructions performed by `fn`.
+ * A real-time DSP path must not allocate on the audio thread.
+ */
+function countAllocations(fn: () => void): number {
+    const constructors: Array<keyof typeof globalThis> = [
+        'Float32Array',
+        'Float64Array',
+        'Int32Array',
+        'Array',
+    ];
+    const originals = constructors.map((name) => [name, globalThis[name]] as const);
+    let count = 0;
+    for (const [name, original] of originals) {
+        const proxy = new Proxy(original as unknown as object, {
+            construct(target, args, newTarget) {
+                count += 1;
+                return Reflect.construct(target as never, args, newTarget);
+            },
+        });
+        (globalThis as Record<string, unknown>)[name as string] = proxy;
+    }
+    try {
+        fn();
+    } finally {
+        for (const [name, original] of originals) {
+            (globalThis as Record<string, unknown>)[name as string] = original;
+        }
+    }
+    return count;
+}

--- a/src/audio/loudness/__tests__/truePeakLimiter.test.ts
+++ b/src/audio/loudness/__tests__/truePeakLimiter.test.ts
@@ -1,0 +1,298 @@
+/**
+ * True-peak detection (BS.1770-5 Annex 2 / BS.2217) and brick-wall limiting.
+ *
+ * The headline case is the fs/4 sine with a 45° phase offset: its samples sit
+ * at ±0.7071 while the underlying waveform reaches 1.0, so a compliant meter
+ * must report +3.01 dBTP where a sample-peak meter reads 0 dBFS.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    TruePeakDetector,
+    buildPolyphaseCoefficients,
+    dbToLinear,
+    linearToDb,
+    measureTruePeakDbtp,
+    oversamplingFactorFor,
+} from '../truePeak';
+import { TruePeakLimiter, MAX_LOOKAHEAD_MS } from '../limiter';
+import { DEFAULT_LIMITER_SETTINGS } from '../types';
+
+const TOLERANCE_DB = 0.1;
+
+/**
+ * Test tone, optionally with faded edges.
+ *
+ * The fade matters when a measurement has to be accurate to ±0.1 dB: a buffer
+ * that starts or ends mid-cycle is a step discontinuity, and the band-limited
+ * reconstruction of a step genuinely overshoots by ~1 dB. The limiter cases
+ * below therefore use edges the way real program material has them; the
+ * detector cases use raw tones whose exact true peak is known analytically.
+ */
+function sine(
+    frames: number,
+    sampleRate: number,
+    frequency: number,
+    amplitude = 1,
+    phase = 0,
+    fadeFrames = 0,
+): Float32Array {
+    const out = new Float32Array(frames);
+    for (let i = 0; i < frames; i += 1) {
+        const fade = fadeFrames > 0 ? Math.min(1, i / fadeFrames, (frames - i) / fadeFrames) : 1;
+        out[i] = fade * amplitude * Math.sin((2 * Math.PI * frequency * i) / sampleRate + phase);
+    }
+    return out;
+}
+
+function samplePeakDb(channel: Float32Array): number {
+    let peak = 0;
+    for (const value of channel) {
+        const magnitude = Math.abs(value);
+        if (magnitude > peak) peak = magnitude;
+    }
+    return linearToDb(peak);
+}
+
+/** Run a signal through the limiter in 128-frame quanta, as the worklet does. */
+function runLimiter(
+    limiter: TruePeakLimiter,
+    channels: Float32Array[],
+): Float32Array[] {
+    const frames = channels[0].length;
+    const output = channels.map(() => new Float32Array(frames));
+    const inViews: Float32Array[] = new Array(channels.length);
+    const outViews: Float32Array[] = new Array(channels.length);
+    for (let offset = 0; offset < frames; offset += 128) {
+        const size = Math.min(128, frames - offset);
+        for (let ch = 0; ch < channels.length; ch += 1) {
+            inViews[ch] = channels[ch].subarray(offset, offset + size);
+            outViews[ch] = output[ch].subarray(offset, offset + size);
+        }
+        limiter.process(inViews, outViews, size);
+    }
+    return output;
+}
+
+describe('polyphase oversampler', () => {
+    it('keeps every branch at unit DC gain', () => {
+        for (const factor of [2, 4, 8]) {
+            for (const branch of buildPolyphaseCoefficients(factor)) {
+                const sum = branch.reduce((acc, value) => acc + value, 0);
+                expect(sum).toBeCloseTo(1, 5);
+            }
+        }
+    });
+
+    it('oversamples to at least 192 kHz at every supported rate', () => {
+        expect(44100 * oversamplingFactorFor(44100)).toBeGreaterThanOrEqual(192000);
+        expect(48000 * oversamplingFactorFor(48000)).toBeGreaterThanOrEqual(192000);
+        expect(96000 * oversamplingFactorFor(96000)).toBeGreaterThanOrEqual(192000);
+        expect(oversamplingFactorFor(48000)).toBe(4);
+        expect(oversamplingFactorFor(96000)).toBe(2);
+    });
+
+    it('does not invent peaks on steady DC', () => {
+        // Measured away from the buffer edges, where the step into DC produces a
+        // real (and correctly reported) inter-sample overshoot.
+        const detector = new TruePeakDetector(48000);
+        for (let i = 0; i < 512; i += 1) detector.processSample(0.5);
+        detector.resetPeak();
+        for (let i = 0; i < 512; i += 1) detector.processSample(0.5);
+        expect(linearToDb(detector.peak)).toBeCloseTo(linearToDb(0.5), 2);
+    });
+});
+
+describe('true-peak detection', () => {
+    it('reports +3.01 dBTP for a 0 dBFS fs/4 sine at 45°', () => {
+        const signal = sine(20000, 48000, 12000, 1, Math.PI / 4);
+        expect(samplePeakDb(signal)).toBeCloseTo(-3.01, 1);
+        const truePeak = measureTruePeakDbtp([signal], 48000);
+        expect(Math.abs(truePeak - 0)).toBeLessThanOrEqual(TOLERANCE_DB);
+    });
+
+    it('is close to 0 dBTP for a full-scale 997 Hz sine', () => {
+        const signal = sine(48000, 48000, 997, 1);
+        const truePeak = measureTruePeakDbtp([signal], 48000);
+        expect(Math.abs(truePeak)).toBeLessThanOrEqual(TOLERANCE_DB);
+    });
+
+    it('beats linear interpolation on high-frequency content', () => {
+        const signal = sine(20000, 48000, 12000, 1, Math.PI / 4);
+        // Linear interpolation between samples of this signal never exceeds the
+        // sample peak, i.e. it misses the ~3 dB of inter-sample energy entirely.
+        const linearEstimate = samplePeakDb(signal);
+        const truePeak = measureTruePeakDbtp([signal], 48000);
+        expect(truePeak - linearEstimate).toBeGreaterThan(2.5);
+    });
+
+    it('takes the maximum across channels', () => {
+        const quiet = sine(2048, 48000, 997, 0.1);
+        const loud = sine(2048, 48000, 997, 0.9);
+        expect(measureTruePeakDbtp([quiet, loud], 48000)).toBeCloseTo(
+            measureTruePeakDbtp([loud], 48000),
+            5,
+        );
+    });
+
+    it('treats non-finite samples as silence', () => {
+        const signal = sine(2048, 48000, 997, 0.5);
+        signal[100] = NaN;
+        signal[200] = Infinity;
+        const truePeak = measureTruePeakDbtp([signal], 48000);
+        expect(Number.isFinite(truePeak)).toBe(true);
+        expect(truePeak).toBeLessThan(0);
+    });
+
+    it('detects nothing above 0 for silence', () => {
+        const detector = new TruePeakDetector(48000);
+        for (let i = 0; i < 1024; i += 1) detector.processSample(0);
+        expect(detector.peak).toBe(0);
+    });
+});
+
+describe('TruePeakLimiter', () => {
+    const sampleRate = 48000;
+
+    it('holds a -1 dBTP ceiling on a hot high-frequency signal', () => {
+        const limiter = new TruePeakLimiter(sampleRate, 2, { ceilingDbtp: -1 });
+        // Worst-case ISP material: full-scale fs/4 tone at 45°.
+        const left = sine(48000, sampleRate, 12000, 1, Math.PI / 4, 2000);
+        const right = Float32Array.from(left);
+        const output = runLimiter(limiter, [left, right]);
+
+        const truePeak = measureTruePeakDbtp(output, sampleRate, 8);
+        expect(truePeak).toBeLessThanOrEqual(-1);
+    });
+
+    it('holds the ceiling on a hot broadband transient', () => {
+        const limiter = new TruePeakLimiter(sampleRate, 2, { ceilingDbtp: -1 });
+        const frames = 48000;
+        const left = new Float32Array(frames);
+        const right = new Float32Array(frames);
+        for (let i = 0; i < frames; i += 1) {
+            // Quiet bed with periodic full-scale clicks.
+            const fade = Math.min(1, i / 2000, (frames - i) / 2000);
+            const bed = 0.2 * Math.sin((2 * Math.PI * 220 * i) / sampleRate);
+            const click = i > 4800 && i % 4800 < 8 ? (i % 2 === 0 ? 1 : -1) : 0;
+            left[i] = fade * Math.max(-1, Math.min(1, bed + click));
+            right[i] = left[i];
+        }
+        const output = runLimiter(limiter, [left, right]);
+        expect(measureTruePeakDbtp(output, sampleRate, 8)).toBeLessThanOrEqual(-1);
+    });
+
+    it('honours a louder ceiling too', () => {
+        const limiter = new TruePeakLimiter(sampleRate, 2, { ceilingDbtp: -3 });
+        const signal = sine(24000, sampleRate, 8000, 1, Math.PI / 4, 2000);
+        const output = runLimiter(limiter, [signal, Float32Array.from(signal)]);
+        expect(measureTruePeakDbtp(output, sampleRate, 8)).toBeLessThanOrEqual(-3);
+    });
+
+    it('leaves signals below the ceiling untouched apart from the latency delay', () => {
+        const limiter = new TruePeakLimiter(sampleRate, 2, { ceilingDbtp: -1 });
+        const signal = sine(8192, sampleRate, 440, 0.25);
+        const output = runLimiter(limiter, [signal, Float32Array.from(signal)]);
+
+        const delay = Math.round(limiter.latencySeconds * sampleRate);
+        expect(delay).toBeGreaterThan(0);
+        for (let i = delay; i < 8192; i += 1) {
+            expect(output[0][i]).toBeCloseTo(signal[i - delay], 5);
+        }
+        expect(limiter.takeStats().gainReductionDb).toBe(0);
+    });
+
+    it('passes audio through unchanged when bypassed', () => {
+        const limiter = new TruePeakLimiter(sampleRate, 2, { enabled: false });
+        const signal = sine(2048, sampleRate, 12000, 1, Math.PI / 4);
+        const output = runLimiter(limiter, [signal, Float32Array.from(signal)]);
+        expect(limiter.latencySeconds).toBe(0);
+        for (let i = 0; i < signal.length; i += 1) {
+            expect(output[0][i]).toBe(signal[i]);
+        }
+    });
+
+    it('monitor-only mode is zero latency and clamps in the sample domain', () => {
+        const limiter = new TruePeakLimiter(sampleRate, 2, {
+            monitorOnly: true,
+            ceilingDbtp: -6,
+        });
+        expect(limiter.latencySeconds).toBe(0);
+
+        const signal = sine(2048, sampleRate, 997, 1);
+        const output = runLimiter(limiter, [signal, Float32Array.from(signal)]);
+        const ceiling = dbToLinear(-6);
+        for (const value of output[0]) {
+            expect(Math.abs(value)).toBeLessThanOrEqual(ceiling + 1e-6);
+        }
+        expect(limiter.takeStats().clipped).toBe(true);
+    });
+
+    it('reports gain reduction while limiting and clears it after reading', () => {
+        const limiter = new TruePeakLimiter(sampleRate, 2, { ceilingDbtp: -6 });
+        const signal = sine(24000, sampleRate, 997, 1, 0, 2000);
+        runLimiter(limiter, [signal, Float32Array.from(signal)]);
+
+        const stats = limiter.takeStats();
+        expect(stats.gainReductionDb).toBeLessThan(-4);
+        expect(limiter.takeStats().gainReductionDb).toBe(0);
+    });
+
+    it('reports lookahead as monitor latency and clamps absurd requests', () => {
+        const limiter = new TruePeakLimiter(sampleRate, 2, { lookaheadMs: 1.5 });
+        const lookaheadFrames = Math.round((1.5 / 1000) * sampleRate);
+        // Latency is lookahead plus the detector's group delay.
+        expect(limiter.latencySeconds * sampleRate).toBeGreaterThanOrEqual(lookaheadFrames);
+        expect(limiter.latencySeconds).toBeLessThan((MAX_LOOKAHEAD_MS + 1) / 1000);
+
+        limiter.setSettings({ lookaheadMs: 1000 });
+        expect(limiter.latencySeconds).toBeLessThanOrEqual((MAX_LOOKAHEAD_MS + 1) / 1000);
+    });
+
+    it('survives NaN input without muting or latching the master', () => {
+        const limiter = new TruePeakLimiter(sampleRate, 2);
+        const signal = sine(8192, sampleRate, 440, 0.5);
+        signal[1000] = NaN;
+        signal[1001] = Infinity;
+        const output = runLimiter(limiter, [signal, Float32Array.from(signal)]);
+        for (const value of output[0]) {
+            expect(Number.isFinite(value)).toBe(true);
+        }
+        // Audio after the glitch is still passing.
+        const tail = output[0].subarray(4096);
+        expect(Math.max(...tail)).toBeGreaterThan(0.1);
+    });
+
+    it('allocates nothing per render quantum', () => {
+        const limiter = new TruePeakLimiter(sampleRate, 2, DEFAULT_LIMITER_SETTINGS);
+        const input = [new Float32Array(128), new Float32Array(128)];
+        const output = [new Float32Array(128), new Float32Array(128)];
+        for (let i = 0; i < 128; i += 1) {
+            input[0][i] = Math.sin(i);
+            input[1][i] = Math.sin(i);
+        }
+        limiter.process(input, output, 128); // warm up
+
+        let allocations = 0;
+        const originals: Array<[string, unknown]> = [];
+        for (const name of ['Float32Array', 'Float64Array', 'Int32Array', 'Array']) {
+            const original = (globalThis as Record<string, unknown>)[name];
+            originals.push([name, original]);
+            (globalThis as Record<string, unknown>)[name] = new Proxy(original as object, {
+                construct(target, args, newTarget) {
+                    allocations += 1;
+                    return Reflect.construct(target as never, args, newTarget);
+                },
+            });
+        }
+        try {
+            limiter.process(input, output, 128);
+        } finally {
+            for (const [name, original] of originals) {
+                (globalThis as Record<string, unknown>)[name] = original;
+            }
+        }
+        expect(allocations).toBe(0);
+    });
+});

--- a/src/audio/loudness/index.ts
+++ b/src/audio/loudness/index.ts
@@ -1,0 +1,66 @@
+/**
+ * Master-bus loudness suite: BS.1770-5 metering + true-peak limiting.
+ *
+ * The same DSP runs in the real-time AudioWorklet and in the offline export
+ * path, which is what keeps the live meters and the rendered file in agreement.
+ */
+
+export { KWeightingFilter, shelfCoefficients, highPassCoefficients } from './kWeighting';
+export type { BiquadCoefficients } from './kWeighting';
+
+export {
+    TruePeakDetector,
+    buildPolyphaseCoefficients,
+    measureTruePeakDbtp,
+    oversamplingFactorFor,
+    linearToDb,
+    dbToLinear,
+    TAPS_PER_PHASE,
+} from './truePeak';
+
+export { LoudnessMeter, meanSquareToLufs } from './loudnessMeter';
+export type { LoudnessMeterOptions } from './loudnessMeter';
+
+export { TruePeakLimiter, MAX_LOOKAHEAD_MS } from './limiter';
+
+export {
+    analyzeLoudness,
+    analyzeAudioBufferLoudness,
+    normalizeToTarget,
+    formatLufs,
+} from './offline';
+export type { LoudnessReport, NormalizeResult } from './offline';
+
+export {
+    loadLimiterSettings,
+    saveLimiterSettings,
+    sanitizeLimiterSettings,
+    LIMITER_STORAGE_KEY,
+} from './settings';
+
+export {
+    MasterLoudnessStage,
+    createMasterLoudnessStage,
+    IDLE_LOUDNESS_STATS,
+} from './masterLoudnessStage';
+export type { LoudnessStatsListener, MasterLoudnessStageOptions } from './masterLoudnessStage';
+
+export {
+    setMasterLoudnessStage,
+    getMasterLoudnessStage,
+    subscribeMasterLoudnessStage,
+} from './registry';
+
+export {
+    DEFAULT_LIMITER_SETTINGS,
+    LOUDNESS_TARGETS,
+    MASTER_LOUDNESS_PROCESSOR_NAME,
+    SILENCE_LUFS,
+} from './types';
+export type {
+    LimiterSettings,
+    LoudnessStats,
+    LoudnessTargetKey,
+    MasterLoudnessCommand,
+    MasterLoudnessReport,
+} from './types';

--- a/src/audio/loudness/kWeighting.ts
+++ b/src/audio/loudness/kWeighting.ts
@@ -1,0 +1,121 @@
+/**
+ * ITU-R BS.1770-5 K-weighting.
+ *
+ * Two cascaded biquads: a high-shelf ("head model") followed by an RLB high-pass.
+ * The recommendation only tabulates coefficients at 48 kHz; the analog prototype
+ * parameters below are the standard ones that reproduce that table exactly at
+ * 48 kHz and generalise to any sample rate through the bilinear transform, so
+ * meters stay correct at 44.1 / 48 / 96 kHz without hard-coded tables.
+ */
+
+/** Direct-form-I biquad with normalised a0 (b0,b1,b2,a1,a2). */
+export interface BiquadCoefficients {
+    b0: number;
+    b1: number;
+    b2: number;
+    a1: number;
+    a2: number;
+}
+
+/** High-shelf stage prototype (BS.1770 pre-filter). */
+const SHELF_F0 = 1681.974450955533;
+const SHELF_G_DB = 3.999843853973347;
+const SHELF_Q = 0.7071752369554196;
+/** Empirical exponent relating shelf mid-gain to high-gain in the reference design. */
+const SHELF_VB_EXPONENT = 0.4996667741545416;
+
+/** RLB high-pass stage prototype. */
+const HPF_F0 = 38.13547087602444;
+const HPF_Q = 0.5003270373238773;
+
+/** High-shelf stage of the K-weighting filter at `sampleRate`. */
+export function shelfCoefficients(sampleRate: number): BiquadCoefficients {
+    const k = Math.tan((Math.PI * SHELF_F0) / sampleRate);
+    const vh = Math.pow(10, SHELF_G_DB / 20);
+    const vb = Math.pow(vh, SHELF_VB_EXPONENT);
+    const a0 = 1 + k / SHELF_Q + k * k;
+    return {
+        b0: (vh + (vb * k) / SHELF_Q + k * k) / a0,
+        b1: (2 * (k * k - vh)) / a0,
+        b2: (vh - (vb * k) / SHELF_Q + k * k) / a0,
+        a1: (2 * (k * k - 1)) / a0,
+        a2: (1 - k / SHELF_Q + k * k) / a0,
+    };
+}
+
+/** RLB high-pass stage of the K-weighting filter at `sampleRate`. */
+export function highPassCoefficients(sampleRate: number): BiquadCoefficients {
+    const k = Math.tan((Math.PI * HPF_F0) / sampleRate);
+    const denom = 1 + k / HPF_Q + k * k;
+    return {
+        b0: 1,
+        b1: -2,
+        b2: 1,
+        a1: (2 * (k * k - 1)) / denom,
+        a2: (1 - k / HPF_Q + k * k) / denom,
+    };
+}
+
+/**
+ * Cascaded K-weighting filter for one channel.
+ *
+ * State is double precision and lives in fixed fields — no allocation per sample
+ * or per render quantum. `reset()` clears the delay lines without reallocating.
+ */
+export class KWeightingFilter {
+    private readonly shelf: BiquadCoefficients;
+    private readonly hpf: BiquadCoefficients;
+
+    // Stage 1 (shelf) delay line.
+    private x1 = 0;
+    private x2 = 0;
+    private y1 = 0;
+    private y2 = 0;
+    // Stage 2 (RLB high-pass) delay line.
+    private u1 = 0;
+    private u2 = 0;
+    private v1 = 0;
+    private v2 = 0;
+
+    constructor(sampleRate: number) {
+        this.shelf = shelfCoefficients(sampleRate);
+        this.hpf = highPassCoefficients(sampleRate);
+    }
+
+    reset(): void {
+        this.x1 = this.x2 = this.y1 = this.y2 = 0;
+        this.u1 = this.u2 = this.v1 = this.v2 = 0;
+    }
+
+    /** Filter a single sample. Non-finite input is treated as silence. */
+    process(sample: number): number {
+        const x0 = Number.isFinite(sample) ? sample : 0;
+
+        const s = this.shelf;
+        const y0 = s.b0 * x0 + s.b1 * this.x1 + s.b2 * this.x2 - s.a1 * this.y1 - s.a2 * this.y2;
+        if (!Number.isFinite(y0)) {
+            this.reset();
+            return 0;
+        }
+        this.x2 = this.x1;
+        this.x1 = x0;
+        this.y2 = this.y1;
+        this.y1 = y0;
+
+        const h = this.hpf;
+        const v0 = h.b0 * y0 + h.b1 * this.u1 + h.b2 * this.u2 - h.a1 * this.v1 - h.a2 * this.v2;
+        if (!Number.isFinite(v0)) {
+            this.reset();
+            return 0;
+        }
+        this.u2 = this.u1;
+        this.u1 = y0;
+        this.v2 = this.v1;
+        this.v1 = v0;
+
+        return v0;
+    }
+}
+
+/** BS.1770 channel weights, indexed by channel for stereo/mono material. */
+export const STEREO_CHANNEL_WEIGHTS: readonly number[] = [1.0, 1.0];

--- a/src/audio/loudness/limiter.ts
+++ b/src/audio/loudness/limiter.ts
@@ -1,0 +1,323 @@
+/**
+ * True-peak aware brick-wall limiter for the master bus.
+ *
+ * Signal flow per sample:
+ *   1. a polyphase true-peak detector estimates the inter-sample magnitude,
+ *   2. the required gain (ceiling / peak) is pushed into a sliding-minimum
+ *      window covering the lookahead, so the gain is already down when the
+ *      transient arrives,
+ *   3. the sliding minimum is smoothed with attack/release one-poles,
+ *   4. the smoothed gain multiplies the delayed audio, and a final clamp at the
+ *      ceiling guarantees the brick wall even if the smoother lags.
+ *
+ * Latency is `lookahead + detector group delay` and is reported through
+ * `latencySeconds` for the engine's monitor-latency accounting.
+ *
+ * All buffers are sized for `MAX_LOOKAHEAD_MS` at construction: changing the
+ * lookahead at runtime re-slices existing storage and never allocates, and
+ * `process()` allocates nothing at all.
+ */
+
+import {
+    TruePeakDetector,
+    TAPS_PER_PHASE,
+    dbToLinear,
+    linearToDb,
+    oversamplingFactorFor,
+} from './truePeak';
+import { DEFAULT_LIMITER_SETTINGS, type LimiterSettings } from './types';
+
+/** Upper bound on lookahead — fixes the size of the preallocated delay lines. */
+export const MAX_LOOKAHEAD_MS = 10;
+
+/**
+ * Headroom the gain computation keeps below the user's ceiling, in dB.
+ *
+ * Two effects push the output above a naively computed ceiling (0.4 dB covers
+ * both, verified against an 8× offline measurement in the tests): oversampled ISP
+ * estimation still underestimates near-Nyquist content, and applying a
+ * time-varying gain creates inter-sample energy of its own. Targeting slightly
+ * under the ceiling keeps the brick wall intact when the file is measured by a
+ * stricter meter, at a cost far below the audible threshold.
+ */
+const DETECTION_HEADROOM_DB = 0.4;
+
+/** Group delay of the polyphase true-peak detector, in input samples. */
+const DETECTOR_LATENCY_FRAMES = TAPS_PER_PHASE >> 1;
+
+function clamp(value: number, min: number, max: number): number {
+    return value < min ? min : value > max ? max : value;
+}
+
+/** One-pole coefficient for a time constant in samples (1 = instantaneous). */
+function onePoleCoefficient(timeFrames: number): number {
+    if (!(timeFrames > 0)) return 1;
+    return 1 - Math.exp(-1 / timeFrames);
+}
+
+export class TruePeakLimiter {
+    readonly sampleRate: number;
+    readonly channelCount: number;
+
+    private settings: LimiterSettings;
+
+    private readonly detectors: TruePeakDetector[];
+    /** Per-channel delay lines, sized for max lookahead + detector delay + one quantum. */
+    private readonly delayLines: Float32Array[];
+    private readonly delayCapacity: number;
+    private delayWrite = 0;
+    private delayFrames: number;
+
+    /** Monotonic deque for the sliding minimum of the target gain. */
+    private readonly maxLookaheadFrames: number;
+    private readonly dequeCapacity: number;
+    private readonly dequeIndices: Int32Array;
+    private readonly dequeValues: Float64Array;
+    private dequeHead = 0;
+    private dequeTail = 0;
+    private sampleCounter = 0;
+    private lookaheadFrames: number;
+
+    private currentGain = 1;
+    private attackCoefficient = 1;
+    private releaseCoefficient = 1;
+    /** Hard wall applied to the output samples. */
+    private ceilingLinear: number;
+    /** Slightly lower target used to compute gain — see DETECTION_HEADROOM_DB. */
+    private targetCeilingLinear: number;
+
+    /** Minimum gain applied since the last `takeStats()`, linear. */
+    private minGainSinceReport = 1;
+    private clippedSinceReport = false;
+
+    constructor(sampleRate: number, channelCount = 2, settings?: Partial<LimiterSettings>) {
+        this.sampleRate = sampleRate;
+        this.channelCount = channelCount;
+        this.settings = { ...DEFAULT_LIMITER_SETTINGS, ...settings };
+
+        const maxLookahead = Math.ceil((MAX_LOOKAHEAD_MS / 1000) * sampleRate);
+        this.delayCapacity = maxLookahead + DETECTOR_LATENCY_FRAMES + 1;
+        this.delayLines = [];
+        for (let ch = 0; ch < channelCount; ch += 1) {
+            this.delayLines.push(new Float32Array(this.delayCapacity));
+        }
+        this.detectors = [];
+        for (let ch = 0; ch < channelCount; ch += 1) {
+            // The limiter detects at twice the metering factor: 4× ISP
+            // estimation underestimates near-Nyquist transients badly enough to
+            // break the brick wall, and one stereo pair can afford the taps.
+            this.detectors.push(
+                new TruePeakDetector(sampleRate, Math.min(8, oversamplingFactorFor(sampleRate) * 2)),
+            );
+        }
+
+        this.maxLookaheadFrames = maxLookahead;
+        // +2 so a strictly increasing full window still fits with head !== tail.
+        this.dequeCapacity = maxLookahead + 2;
+        this.dequeIndices = new Int32Array(this.dequeCapacity);
+        this.dequeValues = new Float64Array(this.dequeCapacity);
+
+        this.lookaheadFrames = 0;
+        this.delayFrames = 0;
+        this.ceilingLinear = dbToLinear(this.settings.ceilingDbtp);
+        this.targetCeilingLinear = this.ceilingLinear;
+        this.applySettings();
+    }
+
+    /** Current settings (copy — callers must not mutate limiter state directly). */
+    getSettings(): LimiterSettings {
+        return { ...this.settings };
+    }
+
+    /** Merge a partial settings update. Safe to call between render quanta. */
+    setSettings(update: Partial<LimiterSettings>): void {
+        const previousLookahead = this.lookaheadFrames;
+        this.settings = { ...this.settings, ...update };
+        this.applySettings();
+        if (this.lookaheadFrames !== previousLookahead) {
+            this.flush();
+        }
+    }
+
+    private applySettings(): void {
+        const requested = this.settings.monitorOnly
+            ? 0
+            : Math.round((clamp(this.settings.lookaheadMs, 0, MAX_LOOKAHEAD_MS) / 1000) * this.sampleRate);
+        this.lookaheadFrames = clamp(requested, 0, this.maxLookaheadFrames);
+        this.delayFrames =
+            this.settings.monitorOnly || !this.settings.enabled
+                ? 0
+                : this.lookaheadFrames + DETECTOR_LATENCY_FRAMES;
+
+        const ceilingDbtp = clamp(this.settings.ceilingDbtp, -24, 0);
+        this.ceilingLinear = dbToLinear(ceilingDbtp);
+        this.targetCeilingLinear = dbToLinear(ceilingDbtp - DETECTION_HEADROOM_DB);
+
+        // The gain must be able to reach its target within the lookahead window,
+        // otherwise the brick wall would be enforced by the safety clamp alone.
+        const attackFrames = Math.min(
+            (clamp(this.settings.attackMs, 0.01, 100) / 1000) * this.sampleRate,
+            Math.max(1, this.lookaheadFrames),
+        );
+        this.attackCoefficient = onePoleCoefficient(attackFrames);
+        this.releaseCoefficient = onePoleCoefficient(
+            (clamp(this.settings.releaseMs, 1, 5000) / 1000) * this.sampleRate,
+        );
+    }
+
+    /** Added monitor latency in seconds. */
+    get latencySeconds(): number {
+        return this.delayFrames / this.sampleRate;
+    }
+
+    /** Clear delay lines, detectors and gain state. */
+    flush(): void {
+        for (const line of this.delayLines) line.fill(0);
+        for (const detector of this.detectors) detector.reset();
+        this.delayWrite = 0;
+        this.dequeHead = 0;
+        this.dequeTail = 0;
+        this.sampleCounter = 0;
+        this.currentGain = 1;
+    }
+
+    /**
+     * Gain reduction (dB, ≤ 0) and clip flag since the previous call.
+     * Reading resets the accumulators so the UI sees per-report extremes.
+     */
+    takeStats(): { gainReductionDb: number; clipped: boolean } {
+        const gainReductionDb = this.minGainSinceReport >= 1 ? 0 : linearToDb(this.minGainSinceReport);
+        const clipped = this.clippedSinceReport;
+        this.minGainSinceReport = 1;
+        this.clippedSinceReport = false;
+        return { gainReductionDb, clipped };
+    }
+
+    /**
+     * Limit `frames` samples. `input` and `output` may be the same arrays.
+     * Channels beyond `channelCount` are copied through untouched by the caller.
+     */
+    process(input: readonly Float32Array[], output: Float32Array[], frames: number): void {
+        if (!this.settings.enabled) {
+            this.passThrough(input, output, frames);
+            return;
+        }
+        if (this.settings.monitorOnly) {
+            this.hardClip(input, output, frames);
+            return;
+        }
+
+        const ceiling = this.ceilingLinear;
+        const target = this.targetCeilingLinear;
+        const capacity = this.dequeCapacity;
+
+        for (let i = 0; i < frames; i += 1) {
+            // 1. Detect the inter-sample peak of this input frame (channel-linked).
+            let peak = 0;
+            for (let ch = 0; ch < this.channelCount; ch += 1) {
+                const source = input[ch];
+                const raw = source !== undefined ? source[i] : 0;
+                const sample = Number.isFinite(raw) ? raw : 0;
+                const detected = this.detectors[ch].processSample(sample);
+                if (detected > peak) peak = detected;
+
+                // 2. Buffer the (undelayed) sample.
+                this.delayLines[ch][this.delayWrite] = sample;
+            }
+
+            const gainTarget = peak > target ? target / peak : 1;
+            const index = this.sampleCounter;
+            this.pushSlidingMin(index, gainTarget, capacity);
+
+            // 3. The minimum gain over [index - lookahead, index] applies to the
+            //    sample leaving the delay line now.
+            const windowMin = this.slidingMin(index, capacity);
+            const coefficient =
+                windowMin < this.currentGain ? this.attackCoefficient : this.releaseCoefficient;
+            this.currentGain += (windowMin - this.currentGain) * coefficient;
+            if (!Number.isFinite(this.currentGain)) this.currentGain = 1;
+            const gain = this.currentGain < windowMin ? this.currentGain : windowMin;
+            if (gain < this.minGainSinceReport) this.minGainSinceReport = gain;
+
+            // 4. Emit the delayed sample with the gain, clamped to the ceiling.
+            const readIndex =
+                (this.delayWrite - this.delayFrames + this.delayCapacity) % this.delayCapacity;
+            for (let ch = 0; ch < this.channelCount; ch += 1) {
+                const out = output[ch];
+                if (out === undefined) continue;
+                let value = this.delayLines[ch][readIndex] * gain;
+                if (value > ceiling) {
+                    value = ceiling;
+                    this.clippedSinceReport = true;
+                } else if (value < -ceiling) {
+                    value = -ceiling;
+                    this.clippedSinceReport = true;
+                }
+                out[i] = value;
+            }
+
+            this.delayWrite = (this.delayWrite + 1) % this.delayCapacity;
+            this.sampleCounter = index + 1;
+        }
+    }
+
+    /** Monotonic deque push — keeps indices of increasing gains. */
+    private pushSlidingMin(index: number, value: number, capacity: number): void {
+        while (
+            this.dequeTail !== this.dequeHead &&
+            this.dequeValues[(this.dequeTail - 1 + capacity) % capacity] >= value
+        ) {
+            this.dequeTail = (this.dequeTail - 1 + capacity) % capacity;
+        }
+        this.dequeIndices[this.dequeTail] = index;
+        this.dequeValues[this.dequeTail] = value;
+        this.dequeTail = (this.dequeTail + 1) % capacity;
+    }
+
+    /** Minimum gain over the last `lookaheadFrames + 1` pushed targets. */
+    private slidingMin(index: number, capacity: number): number {
+        const oldest = index - this.lookaheadFrames;
+        while (this.dequeHead !== this.dequeTail && this.dequeIndices[this.dequeHead] < oldest) {
+            this.dequeHead = (this.dequeHead + 1) % capacity;
+        }
+        return this.dequeHead === this.dequeTail ? 1 : this.dequeValues[this.dequeHead];
+    }
+
+    private passThrough(input: readonly Float32Array[], output: Float32Array[], frames: number): void {
+        for (let ch = 0; ch < this.channelCount; ch += 1) {
+            const source = input[ch];
+            const out = output[ch];
+            if (out === undefined) continue;
+            for (let i = 0; i < frames; i += 1) {
+                const raw = source !== undefined ? source[i] : 0;
+                out[i] = Number.isFinite(raw) ? raw : 0;
+            }
+        }
+    }
+
+    /** Zero-latency safety mode for live monitoring: sample-domain hard clip. */
+    private hardClip(input: readonly Float32Array[], output: Float32Array[], frames: number): void {
+        const ceiling = this.ceilingLinear;
+        let minGain = 1;
+        for (let ch = 0; ch < this.channelCount; ch += 1) {
+            const source = input[ch];
+            const out = output[ch];
+            if (out === undefined) continue;
+            for (let i = 0; i < frames; i += 1) {
+                const raw = source !== undefined ? source[i] : 0;
+                const sample = Number.isFinite(raw) ? raw : 0;
+                const magnitude = sample < 0 ? -sample : sample;
+                if (magnitude > ceiling) {
+                    this.clippedSinceReport = true;
+                    const gain = ceiling / magnitude;
+                    if (gain < minGain) minGain = gain;
+                    out[i] = sample < 0 ? -ceiling : ceiling;
+                } else {
+                    out[i] = sample;
+                }
+            }
+        }
+        if (minGain < this.minGainSinceReport) this.minGainSinceReport = minGain;
+        this.currentGain = 1;
+    }
+}

--- a/src/audio/loudness/loudnessMeter.ts
+++ b/src/audio/loudness/loudnessMeter.ts
@@ -1,0 +1,253 @@
+/**
+ * BS.1770-5 loudness meter: momentary (400 ms), short-term (3 s) and gated
+ * integrated loudness, plus sample-peak and true-peak.
+ *
+ * Real-time constraints honoured throughout:
+ *  - every buffer is allocated in the constructor; `process()` allocates nothing
+ *  - all power accumulation is Float64
+ *  - integrated loudness uses a fixed-size histogram (libebur128's approach)
+ *    rather than a growing list of block powers, so an all-day session cannot
+ *    grow the worklet's memory
+ *  - non-finite input is coerced to silence so a NaN upstream cannot latch the
+ *    meter or the limiter that reads it
+ */
+
+import { KWeightingFilter } from './kWeighting';
+import { TruePeakDetector, linearToDb } from './truePeak';
+import { SILENCE_LUFS } from './types';
+
+/** BS.1770 loudness offset. */
+const LUFS_OFFSET = -0.691;
+
+/** Sub-block hop: 100 ms gives the 75 %-overlapped 400 ms gating blocks. */
+const SUB_BLOCK_SECONDS = 0.1;
+/** Momentary window = 4 sub-blocks. */
+const MOMENTARY_SUB_BLOCKS = 4;
+/** Short-term window = 30 sub-blocks. */
+const SHORT_TERM_SUB_BLOCKS = 30;
+
+/** Absolute gate (LUFS) from BS.1770-4 onwards. */
+const ABSOLUTE_GATE_LUFS = -70;
+/** Relative gate, in LU below the ungated mean. */
+const RELATIVE_GATE_LU = -10;
+
+/** Histogram covering [-70, +30) LUFS in 0.1 LU bins. */
+const HIST_MIN_LUFS = ABSOLUTE_GATE_LUFS;
+const HIST_BIN_LU = 0.1;
+const HIST_BINS = 1000;
+
+/** Mean square → loudness in LUFS. */
+export function meanSquareToLufs(meanSquare: number): number {
+    if (!(meanSquare > 0) || !Number.isFinite(meanSquare)) return SILENCE_LUFS;
+    return LUFS_OFFSET + 10 * Math.log10(meanSquare);
+}
+
+export interface LoudnessMeterOptions {
+    sampleRate: number;
+    channelCount?: number;
+    /** BS.1770 channel weights; defaults to 1.0 for every channel (L/R/C). */
+    channelWeights?: readonly number[];
+    /** Override the true-peak oversampling factor (offline renders may use 8×). */
+    truePeakFactor?: number;
+}
+
+export class LoudnessMeter {
+    readonly sampleRate: number;
+    readonly channelCount: number;
+
+    private readonly weights: Float64Array;
+    private readonly filters: KWeightingFilter[];
+    private readonly truePeakDetectors: TruePeakDetector[];
+
+    /** Frames per 100 ms sub-block, recomputed from the live sample rate. */
+    private readonly subBlockFrames: number;
+    /** Ring of per-sub-block weighted sums of squares. */
+    private readonly subBlockPower: Float64Array;
+    private subBlockCount = 0;
+    private subBlockWrite = 0;
+
+    /** Accumulator for the sub-block currently being filled. */
+    private pendingPower = 0;
+    private pendingFrames = 0;
+
+    /** Gating histogram: per-bin block count and summed mean-square. */
+    private readonly histogramCounts: Int32Array;
+    private readonly histogramPower: Float64Array;
+    private gatedBlockCount = 0;
+
+    private samplePeakLinear = 0;
+
+    constructor(options: LoudnessMeterOptions) {
+        const { sampleRate, channelCount = 2, channelWeights, truePeakFactor } = options;
+        this.sampleRate = sampleRate;
+        this.channelCount = channelCount;
+
+        this.weights = new Float64Array(channelCount);
+        for (let ch = 0; ch < channelCount; ch += 1) {
+            this.weights[ch] = channelWeights?.[ch] ?? 1.0;
+        }
+
+        this.filters = [];
+        this.truePeakDetectors = [];
+        for (let ch = 0; ch < channelCount; ch += 1) {
+            this.filters.push(new KWeightingFilter(sampleRate));
+            this.truePeakDetectors.push(new TruePeakDetector(sampleRate, truePeakFactor));
+        }
+
+        this.subBlockFrames = Math.max(1, Math.round(sampleRate * SUB_BLOCK_SECONDS));
+        this.subBlockPower = new Float64Array(SHORT_TERM_SUB_BLOCKS);
+        this.histogramCounts = new Int32Array(HIST_BINS);
+        this.histogramPower = new Float64Array(HIST_BINS);
+    }
+
+    /** Clear everything, including the integrated measurement. */
+    reset(): void {
+        for (const filter of this.filters) filter.reset();
+        for (const detector of this.truePeakDetectors) detector.reset();
+        this.subBlockPower.fill(0);
+        this.subBlockCount = 0;
+        this.subBlockWrite = 0;
+        this.pendingPower = 0;
+        this.pendingFrames = 0;
+        this.histogramCounts.fill(0);
+        this.histogramPower.fill(0);
+        this.gatedBlockCount = 0;
+        this.samplePeakLinear = 0;
+    }
+
+    /**
+     * Reset only the gated integrated measurement.
+     * Momentary/short-term keep running so the UI does not blink.
+     */
+    resetIntegrated(): void {
+        this.histogramCounts.fill(0);
+        this.histogramPower.fill(0);
+        this.gatedBlockCount = 0;
+    }
+
+    /** Clear held peaks (sample and true peak) without touching loudness state. */
+    resetPeaks(): void {
+        this.samplePeakLinear = 0;
+        for (const detector of this.truePeakDetectors) detector.resetPeak();
+    }
+
+    /**
+     * Consume `frames` of audio. `channels[ch]` must hold at least `frames`
+     * samples. Extra channels beyond `channelCount` are ignored; missing
+     * channels are treated as silence.
+     */
+    process(channels: readonly Float32Array[], frames: number): void {
+        for (let i = 0; i < frames; i += 1) {
+            let weighted = 0;
+            for (let ch = 0; ch < this.channelCount; ch += 1) {
+                const source = channels[ch];
+                const raw = source !== undefined ? source[i] : 0;
+                const sample = Number.isFinite(raw) ? raw : 0;
+
+                const magnitude = sample < 0 ? -sample : sample;
+                if (magnitude > this.samplePeakLinear) this.samplePeakLinear = magnitude;
+                this.truePeakDetectors[ch].processSample(sample);
+
+                const filtered = this.filters[ch].process(sample);
+                weighted += this.weights[ch] * filtered * filtered;
+            }
+
+            this.pendingPower += weighted;
+            this.pendingFrames += 1;
+            if (this.pendingFrames >= this.subBlockFrames) {
+                this.commitSubBlock();
+            }
+        }
+    }
+
+    private commitSubBlock(): void {
+        this.subBlockPower[this.subBlockWrite] = this.pendingPower;
+        this.subBlockWrite = (this.subBlockWrite + 1) % SHORT_TERM_SUB_BLOCKS;
+        this.subBlockCount += 1;
+        this.pendingPower = 0;
+        this.pendingFrames = 0;
+
+        if (this.subBlockCount >= MOMENTARY_SUB_BLOCKS) {
+            this.accumulateGatingBlock(this.windowMeanSquare(MOMENTARY_SUB_BLOCKS));
+        }
+    }
+
+    /** Mean square over the most recent `count` sub-blocks. */
+    private windowMeanSquare(count: number): number {
+        const available = Math.min(count, this.subBlockCount, SHORT_TERM_SUB_BLOCKS);
+        if (available <= 0) return 0;
+        let sum = 0;
+        for (let n = 1; n <= available; n += 1) {
+            const index = (this.subBlockWrite - n + SHORT_TERM_SUB_BLOCKS) % SHORT_TERM_SUB_BLOCKS;
+            sum += this.subBlockPower[index];
+        }
+        return sum / (available * this.subBlockFrames);
+    }
+
+    /** Add a completed 400 ms gating block to the histogram (absolute gate applied). */
+    private accumulateGatingBlock(meanSquare: number): void {
+        const loudness = meanSquareToLufs(meanSquare);
+        if (!(loudness > ABSOLUTE_GATE_LUFS)) return;
+        let bin = Math.floor((loudness - HIST_MIN_LUFS) / HIST_BIN_LU);
+        if (bin < 0) bin = 0;
+        if (bin >= HIST_BINS) bin = HIST_BINS - 1;
+        this.histogramCounts[bin] += 1;
+        this.histogramPower[bin] += meanSquare;
+        this.gatedBlockCount += 1;
+    }
+
+    /** Momentary loudness (400 ms), LUFS. */
+    get momentary(): number {
+        if (this.subBlockCount < MOMENTARY_SUB_BLOCKS) return SILENCE_LUFS;
+        return meanSquareToLufs(this.windowMeanSquare(MOMENTARY_SUB_BLOCKS));
+    }
+
+    /** Short-term loudness (3 s), LUFS. */
+    get shortTerm(): number {
+        if (this.subBlockCount < SHORT_TERM_SUB_BLOCKS) return SILENCE_LUFS;
+        return meanSquareToLufs(this.windowMeanSquare(SHORT_TERM_SUB_BLOCKS));
+    }
+
+    /** Gated integrated loudness since the last integrated reset, LUFS. */
+    get integrated(): number {
+        if (this.gatedBlockCount === 0) return SILENCE_LUFS;
+
+        let count = 0;
+        let power = 0;
+        for (let bin = 0; bin < HIST_BINS; bin += 1) {
+            count += this.histogramCounts[bin];
+            power += this.histogramPower[bin];
+        }
+        if (count === 0) return SILENCE_LUFS;
+
+        const relativeThreshold = meanSquareToLufs(power / count) + RELATIVE_GATE_LU;
+        if (!Number.isFinite(relativeThreshold)) return SILENCE_LUFS;
+
+        const firstBin = Math.max(
+            0,
+            Math.ceil((relativeThreshold - HIST_MIN_LUFS) / HIST_BIN_LU),
+        );
+        let gatedCount = 0;
+        let gatedPower = 0;
+        for (let bin = firstBin; bin < HIST_BINS; bin += 1) {
+            gatedCount += this.histogramCounts[bin];
+            gatedPower += this.histogramPower[bin];
+        }
+        if (gatedCount === 0) return SILENCE_LUFS;
+        return meanSquareToLufs(gatedPower / gatedCount);
+    }
+
+    /** Held sample peak, dBFS. */
+    get samplePeakDb(): number {
+        return linearToDb(this.samplePeakLinear);
+    }
+
+    /** Held true peak, dBTP. */
+    get truePeakDb(): number {
+        let peak = 0;
+        for (const detector of this.truePeakDetectors) {
+            if (detector.peak > peak) peak = detector.peak;
+        }
+        return linearToDb(peak);
+    }
+}

--- a/src/audio/loudness/masterLoudnessStage.ts
+++ b/src/audio/loudness/masterLoudnessStage.ts
@@ -1,0 +1,169 @@
+/**
+ * Main-thread handle for the master loudness worklet.
+ *
+ * Owns the AudioWorkletNode, the throttled stats stream and the (debounced)
+ * unidirectional UI → worklet parameter flow. The UI never reads audio state
+ * directly: it subscribes to scalar snapshots emitted by the worklet.
+ */
+
+import { attachWorkletPerf } from '../../utils/workletPerfBridge';
+import { loadLimiterSettings, saveLimiterSettings } from './settings';
+import {
+    DEFAULT_LIMITER_SETTINGS,
+    MASTER_LOUDNESS_PROCESSOR_NAME,
+    SILENCE_LUFS,
+    type LimiterSettings,
+    type LoudnessStats,
+    type MasterLoudnessCommand,
+    type MasterLoudnessReport,
+} from './types';
+
+const MASTER_LOUDNESS_PROCESSOR_URL = new URL(
+    '../../audio-worklets/master-loudness-processor.ts',
+    import.meta.url,
+).href;
+
+/** Coalesce rapid knob movements into one message per animation-ish frame. */
+const PARAM_DEBOUNCE_MS = 30;
+
+export const IDLE_LOUDNESS_STATS: LoudnessStats = {
+    momentary: SILENCE_LUFS,
+    shortTerm: SILENCE_LUFS,
+    integrated: SILENCE_LUFS,
+    truePeak: SILENCE_LUFS,
+    samplePeak: SILENCE_LUFS,
+    gainReduction: 0,
+    clipped: false,
+};
+
+export type LoudnessStatsListener = (stats: LoudnessStats) => void;
+
+export interface MasterLoudnessStageOptions {
+    /** Initial settings; defaults to the persisted ones. */
+    settings?: Partial<LimiterSettings>;
+    /** Persist settings changes to localStorage. Default true. */
+    persist?: boolean;
+}
+
+export class MasterLoudnessStage {
+    readonly node: AudioWorkletNode;
+    private settings: LimiterSettings;
+    private readonly listeners = new Set<LoudnessStatsListener>();
+    private readonly persist: boolean;
+    private pendingUpdate: Partial<LimiterSettings> | null = null;
+    private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+    latestStats: LoudnessStats = IDLE_LOUDNESS_STATS;
+    /** Lookahead latency reported by the worklet, seconds. */
+    latencySeconds = 0;
+
+    private readonly detachPerf: () => void;
+
+    constructor(node: AudioWorkletNode, settings: LimiterSettings, persist: boolean) {
+        this.node = node;
+        this.detachPerf = attachWorkletPerf(node, 'masterLoudness');
+        this.settings = settings;
+        this.persist = persist;
+        this.node.port.onmessage = (event: MessageEvent<MasterLoudnessReport>) => {
+            const message = event.data;
+            if (!message || message.type !== 'loudness-stats') return;
+            this.latestStats = message.data;
+            this.latencySeconds = message.latencySeconds;
+            for (const listener of this.listeners) listener(message.data);
+        };
+    }
+
+    getSettings(): LimiterSettings {
+        return { ...this.settings };
+    }
+
+    /** Subscribe to scalar meter updates. Returns an unsubscribe function. */
+    subscribe(listener: LoudnessStatsListener): () => void {
+        this.listeners.add(listener);
+        return () => {
+            this.listeners.delete(listener);
+        };
+    }
+
+    /** Update limiter settings (debounced towards the audio thread). */
+    update(update: Partial<LimiterSettings>): void {
+        this.settings = { ...this.settings, ...update };
+        this.pendingUpdate = { ...(this.pendingUpdate ?? {}), ...update };
+        if (this.persist) saveLimiterSettings(this.settings);
+        if (this.debounceTimer !== null) return;
+        this.debounceTimer = setTimeout(() => {
+            this.debounceTimer = null;
+            const data = this.pendingUpdate;
+            this.pendingUpdate = null;
+            if (data) this.post({ type: 'set-limiter', data });
+        }, PARAM_DEBOUNCE_MS);
+    }
+
+    /** Explicit user action: restart the gated integrated measurement. */
+    resetLoudness(): void {
+        this.latestStats = { ...this.latestStats, integrated: SILENCE_LUFS, truePeak: SILENCE_LUFS };
+        this.post({ type: 'reset-loudness' });
+    }
+
+    /** Change the meter report rate (capped at 30 Hz inside the worklet). */
+    setReportHz(hz: number): void {
+        this.post({ type: 'set-report-hz', data: hz });
+    }
+
+    dispose(): void {
+        if (this.debounceTimer !== null) {
+            clearTimeout(this.debounceTimer);
+            this.debounceTimer = null;
+        }
+        this.listeners.clear();
+        this.detachPerf();
+        this.node.port.onmessage = null;
+        try {
+            this.node.disconnect();
+        } catch {
+            // Already disconnected — nothing to do.
+        }
+    }
+
+    private post(command: MasterLoudnessCommand): void {
+        try {
+            this.node.port.postMessage(command);
+        } catch {
+            // A closed context must not take the UI down with it.
+        }
+    }
+}
+
+/**
+ * Load the master loudness worklet module and build its node.
+ *
+ * Returns `null` when the browser cannot register the worklet, so the caller
+ * can compile the graph without the limiter stage instead of failing playback.
+ */
+export async function createMasterLoudnessStage(
+    context: BaseAudioContext,
+    options: MasterLoudnessStageOptions = {},
+): Promise<MasterLoudnessStage | null> {
+    const persist = options.persist ?? true;
+    const settings: LimiterSettings = {
+        ...DEFAULT_LIMITER_SETTINGS,
+        ...(persist ? loadLimiterSettings() : {}),
+        ...options.settings,
+    };
+
+    try {
+        await context.audioWorklet.addModule(MASTER_LOUDNESS_PROCESSOR_URL);
+        const node = new AudioWorkletNode(context, MASTER_LOUDNESS_PROCESSOR_NAME, {
+            numberOfInputs: 1,
+            numberOfOutputs: 1,
+            outputChannelCount: [2],
+            channelCount: 2,
+            channelCountMode: 'explicit',
+            processorOptions: { limiter: settings },
+        });
+        return new MasterLoudnessStage(node, settings, persist);
+    } catch (error) {
+        console.warn('[loudness] master limiter/meter worklet unavailable', error);
+        return null;
+    }
+}

--- a/src/audio/loudness/offline.ts
+++ b/src/audio/loudness/offline.ts
@@ -1,0 +1,167 @@
+/**
+ * Offline loudness analysis and normalisation for the export / freeze paths.
+ *
+ * Uses exactly the same DSP as the real-time master worklet, so the numbers a
+ * user reads while monitoring and the numbers measured in the rendered file
+ * agree (the only permitted difference is a higher true-peak oversampling
+ * factor offline, which can only make the reported dBTP more accurate).
+ */
+
+import { LoudnessMeter } from './loudnessMeter';
+import { TruePeakLimiter } from './limiter';
+import { dbToLinear, linearToDb } from './truePeak';
+import {
+    DEFAULT_LIMITER_SETTINGS,
+    LOUDNESS_TARGETS,
+    SILENCE_LUFS,
+    type LimiterSettings,
+    type LoudnessTargetKey,
+} from './types';
+
+export interface LoudnessReport {
+    /** Gated integrated loudness, LUFS (`-Infinity` for silence). */
+    integrated: number;
+    /** Maximum short-term loudness observed, LUFS. */
+    maxShortTerm: number;
+    /** Maximum momentary loudness observed, LUFS. */
+    maxMomentary: number;
+    /** True peak, dBTP. */
+    truePeak: number;
+    /** Sample peak, dBFS. */
+    samplePeak: number;
+}
+
+function channelsOf(buffer: AudioBuffer): Float32Array[] {
+    const channels: Float32Array[] = [];
+    for (let ch = 0; ch < buffer.numberOfChannels; ch += 1) {
+        channels.push(buffer.getChannelData(ch));
+    }
+    return channels;
+}
+
+/** Analysis chunk size — matches the render quantum so results match live. */
+const ANALYSIS_BLOCK = 128;
+
+/**
+ * Measure BS.1770 loudness and true peak of raw channel data.
+ *
+ * `truePeakFactor` defaults to the real-time factor; pass 8 for a stricter
+ * offline reading (the delta versus live stays well inside 0.1 dBTP).
+ */
+export function analyzeLoudness(
+    channels: readonly Float32Array[],
+    sampleRate: number,
+    truePeakFactor?: number,
+): LoudnessReport {
+    const meter = new LoudnessMeter({
+        sampleRate,
+        channelCount: Math.max(1, channels.length),
+        truePeakFactor,
+    });
+
+    const frames = channels[0]?.length ?? 0;
+    const views: Float32Array[] = new Array(channels.length);
+    let maxMomentary = SILENCE_LUFS;
+    let maxShortTerm = SILENCE_LUFS;
+
+    for (let offset = 0; offset < frames; offset += ANALYSIS_BLOCK) {
+        const size = Math.min(ANALYSIS_BLOCK, frames - offset);
+        for (let ch = 0; ch < channels.length; ch += 1) {
+            views[ch] = channels[ch].subarray(offset, offset + size);
+        }
+        meter.process(views, size);
+        if (meter.momentary > maxMomentary) maxMomentary = meter.momentary;
+        if (meter.shortTerm > maxShortTerm) maxShortTerm = meter.shortTerm;
+    }
+
+    return {
+        integrated: meter.integrated,
+        maxShortTerm,
+        maxMomentary,
+        truePeak: meter.truePeakDb,
+        samplePeak: meter.samplePeakDb,
+    };
+}
+
+/** Convenience wrapper for an AudioBuffer (export / freeze render output). */
+export function analyzeAudioBufferLoudness(
+    buffer: AudioBuffer,
+    truePeakFactor?: number,
+): LoudnessReport {
+    return analyzeLoudness(channelsOf(buffer), buffer.sampleRate, truePeakFactor);
+}
+
+export interface NormalizeResult extends LoudnessReport {
+    /** Linear gain applied to reach the target. */
+    appliedGain: number;
+    /** Target the render was normalised to, LUFS. */
+    targetLufs: number;
+    /** Loudness after normalisation + limiting, LUFS. */
+    resultingIntegrated: number;
+    /** True peak after normalisation + limiting, dBTP. */
+    resultingTruePeak: number;
+}
+
+/**
+ * Normalise channel data in place to `target` LUFS, then run the true-peak
+ * limiter so the ceiling still holds after the gain change.
+ *
+ * Returns the pre-normalisation report plus what was actually achieved —
+ * a loud master pushed to -9 LUFS can fall short once the limiter engages,
+ * and the caller should surface that rather than assume the target was met.
+ */
+export function normalizeToTarget(
+    channels: Float32Array[],
+    sampleRate: number,
+    target: number | LoudnessTargetKey = 'streaming',
+    limiterSettings: Partial<LimiterSettings> = {},
+): NormalizeResult {
+    const targetLufs = typeof target === 'number' ? target : LOUDNESS_TARGETS[target];
+    const report = analyzeLoudness(channels, sampleRate);
+
+    let appliedGain = 1;
+    if (Number.isFinite(report.integrated)) {
+        appliedGain = dbToLinear(targetLufs - report.integrated);
+    }
+
+    const settings: LimiterSettings = {
+        ...DEFAULT_LIMITER_SETTINGS,
+        ...limiterSettings,
+        enabled: true,
+        monitorOnly: false,
+    };
+    const limiter = new TruePeakLimiter(sampleRate, Math.max(1, channels.length), settings);
+
+    const frames = channels[0]?.length ?? 0;
+    const scratch: Float32Array[] = channels.map(() => new Float32Array(ANALYSIS_BLOCK));
+    const outViews: Float32Array[] = new Array(channels.length);
+
+    for (let offset = 0; offset < frames; offset += ANALYSIS_BLOCK) {
+        const size = Math.min(ANALYSIS_BLOCK, frames - offset);
+        for (let ch = 0; ch < channels.length; ch += 1) {
+            const source = channels[ch];
+            const block = scratch[ch];
+            for (let i = 0; i < size; i += 1) {
+                block[i] = source[offset + i] * appliedGain;
+            }
+            outViews[ch] = source.subarray(offset, offset + size);
+        }
+        limiter.process(scratch, outViews, size);
+    }
+
+    const after = analyzeLoudness(channels, sampleRate);
+    return {
+        ...report,
+        appliedGain,
+        targetLufs,
+        resultingIntegrated: after.integrated,
+        resultingTruePeak: after.truePeak,
+    };
+}
+
+/** Format a loudness value for UI/report text (`-inf` for silence). */
+export function formatLufs(value: number, digits = 1): string {
+    return Number.isFinite(value) ? value.toFixed(digits) : '-inf';
+}
+
+export { linearToDb, dbToLinear };

--- a/src/audio/loudness/registry.ts
+++ b/src/audio/loudness/registry.ts
@@ -1,0 +1,35 @@
+/**
+ * Process-wide handle on the active master loudness stage.
+ *
+ * The stage is created during audio-engine initialisation, long before the
+ * meter UI mounts, and the UI must not reach into the audio graph itself. This
+ * tiny registry is the one place that connects them: the engine publishes the
+ * stage, components subscribe and receive it (immediately if it already exists).
+ */
+
+import type { MasterLoudnessStage } from './masterLoudnessStage';
+
+type StageListener = (stage: MasterLoudnessStage | null) => void;
+
+let currentStage: MasterLoudnessStage | null = null;
+const listeners = new Set<StageListener>();
+
+/** Publish (or clear) the active stage. Called by the engine lifecycle. */
+export function setMasterLoudnessStage(stage: MasterLoudnessStage | null): void {
+    currentStage = stage;
+    for (const listener of listeners) listener(stage);
+}
+
+/** The active stage, or `null` when the engine is not running. */
+export function getMasterLoudnessStage(): MasterLoudnessStage | null {
+    return currentStage;
+}
+
+/** Subscribe to stage availability. Fires immediately with the current value. */
+export function subscribeMasterLoudnessStage(listener: StageListener): () => void {
+    listeners.add(listener);
+    listener(currentStage);
+    return () => {
+        listeners.delete(listener);
+    };
+}

--- a/src/audio/loudness/settings.ts
+++ b/src/audio/loudness/settings.ts
@@ -1,0 +1,59 @@
+/**
+ * Persistence for the master limiter settings.
+ *
+ * Only primitives are stored, and every field is re-validated on load: a
+ * corrupted or hand-edited entry falls back to the default rather than feeding
+ * NaN into the audio thread.
+ */
+
+import { DEFAULT_LIMITER_SETTINGS, type LimiterSettings } from './types';
+import { MAX_LOOKAHEAD_MS } from './limiter';
+
+export const LIMITER_STORAGE_KEY = 'hyphon.masterLimiter.v1';
+
+function numberIn(value: unknown, min: number, max: number, fallback: number): number {
+    return typeof value === 'number' && Number.isFinite(value) && value >= min && value <= max
+        ? value
+        : fallback;
+}
+
+function boolOr(value: unknown, fallback: boolean): boolean {
+    return typeof value === 'boolean' ? value : fallback;
+}
+
+/** Coerce arbitrary parsed JSON into valid limiter settings. */
+export function sanitizeLimiterSettings(raw: unknown): LimiterSettings {
+    const source = (raw ?? {}) as Partial<Record<keyof LimiterSettings, unknown>>;
+    const d = DEFAULT_LIMITER_SETTINGS;
+    return {
+        enabled: boolOr(source.enabled, d.enabled),
+        monitorOnly: boolOr(source.monitorOnly, d.monitorOnly),
+        ceilingDbtp: numberIn(source.ceilingDbtp, -24, 0, d.ceilingDbtp),
+        attackMs: numberIn(source.attackMs, 0.01, 100, d.attackMs),
+        releaseMs: numberIn(source.releaseMs, 1, 5000, d.releaseMs),
+        lookaheadMs: numberIn(source.lookaheadMs, 0, MAX_LOOKAHEAD_MS, d.lookaheadMs),
+    };
+}
+
+/** Load persisted limiter settings; never throws. */
+export function loadLimiterSettings(storage?: Storage): LimiterSettings {
+    const store = storage ?? (typeof localStorage !== 'undefined' ? localStorage : undefined);
+    if (!store) return { ...DEFAULT_LIMITER_SETTINGS };
+    try {
+        const raw = store.getItem(LIMITER_STORAGE_KEY);
+        return raw ? sanitizeLimiterSettings(JSON.parse(raw)) : { ...DEFAULT_LIMITER_SETTINGS };
+    } catch {
+        return { ...DEFAULT_LIMITER_SETTINGS };
+    }
+}
+
+/** Persist limiter settings; never throws (private mode, quota, SSR). */
+export function saveLimiterSettings(settings: LimiterSettings, storage?: Storage): void {
+    const store = storage ?? (typeof localStorage !== 'undefined' ? localStorage : undefined);
+    if (!store) return;
+    try {
+        store.setItem(LIMITER_STORAGE_KEY, JSON.stringify(sanitizeLimiterSettings(settings)));
+    } catch {
+        // Persisting master settings must never break playback.
+    }
+}

--- a/src/audio/loudness/truePeak.ts
+++ b/src/audio/loudness/truePeak.ts
@@ -1,0 +1,176 @@
+/**
+ * True-peak (inter-sample peak) estimation per ITU-R BS.1770-5 Annex 2.
+ *
+ * A polyphase FIR interpolator raises the effective rate to ≥ 192 kHz before
+ * peak detection. Linear interpolation is deliberately *not* used: it
+ * underestimates inter-sample peaks on high-frequency content by well over the
+ * ±0.1 dBTP tolerance we hold ourselves to.
+ *
+ * The filter is a windowed-sinc low-pass (Blackman-Harris) split into `factor`
+ * phases of `TAPS_PER_PHASE` taps each. All buffers are allocated once at
+ * construction — `processSample` never allocates.
+ */
+
+/** Taps per polyphase branch. 32 × 4 phases = 128 total taps. */
+export const TAPS_PER_PHASE = 32;
+
+/** ITU asks for an effective rate of at least 192 kHz. */
+const MIN_EFFECTIVE_RATE = 192000;
+
+/** Oversampling factor for a given sample rate (power of two, ≥ 2). */
+export function oversamplingFactorFor(sampleRate: number): number {
+    let factor = 2;
+    while (sampleRate * factor < MIN_EFFECTIVE_RATE && factor < 8) {
+        factor *= 2;
+    }
+    return factor;
+}
+
+/** 4-term Blackman-Harris window value at position `n` of `length`. */
+function blackmanHarris(n: number, length: number): number {
+    const t = (2 * Math.PI * n) / (length - 1);
+    return (
+        0.35875 -
+        0.48829 * Math.cos(t) +
+        0.14128 * Math.cos(2 * t) -
+        0.01168 * Math.cos(3 * t)
+    );
+}
+
+function sinc(x: number): number {
+    if (x === 0) return 1;
+    const px = Math.PI * x;
+    return Math.sin(px) / px;
+}
+
+/**
+ * Build the polyphase coefficient bank for `factor`× interpolation.
+ *
+ * Returns `factor` branches of `TAPS_PER_PHASE` coefficients, each branch
+ * normalised to unit DC gain so a constant input interpolates to itself.
+ */
+export function buildPolyphaseCoefficients(factor: number): Float32Array[] {
+    const total = TAPS_PER_PHASE * factor;
+    const prototype = new Float64Array(total);
+    const center = (total - 1) / 2;
+    const cutoff = 0.5 / factor; // original Nyquist, normalised to the oversampled rate
+
+    for (let n = 0; n < total; n += 1) {
+        prototype[n] = 2 * cutoff * sinc(2 * cutoff * (n - center)) * blackmanHarris(n, total);
+    }
+
+    const phases: Float32Array[] = [];
+    for (let phase = 0; phase < factor; phase += 1) {
+        const branch = new Float64Array(TAPS_PER_PHASE);
+        let sum = 0;
+        for (let tap = 0; tap < TAPS_PER_PHASE; tap += 1) {
+            const value = prototype[tap * factor + phase];
+            branch[tap] = value;
+            sum += value;
+        }
+        // Normalising each branch independently removes the zero-stuffing gain
+        // loss and keeps a DC signal from reading as a false inter-sample peak.
+        const scale = sum !== 0 ? 1 / sum : 1;
+        const out = new Float32Array(TAPS_PER_PHASE);
+        for (let tap = 0; tap < TAPS_PER_PHASE; tap += 1) {
+            out[tap] = branch[tap] * scale;
+        }
+        phases.push(out);
+    }
+    return phases;
+}
+
+/**
+ * Single-channel true-peak detector.
+ *
+ * Feed samples one at a time; `processSample` returns the maximum absolute
+ * interpolated magnitude around that sample, which is also accumulated into
+ * `peak`.
+ */
+export class TruePeakDetector {
+    readonly factor: number;
+    private readonly phases: Float32Array[];
+    private readonly history: Float32Array;
+    private historyIndex = 0;
+    /** Running maximum absolute inter-sample magnitude (linear). */
+    peak = 0;
+
+    constructor(sampleRate: number, factor = oversamplingFactorFor(sampleRate)) {
+        this.factor = factor;
+        this.phases = buildPolyphaseCoefficients(factor);
+        this.history = new Float32Array(TAPS_PER_PHASE);
+    }
+
+    reset(): void {
+        this.history.fill(0);
+        this.historyIndex = 0;
+        this.peak = 0;
+    }
+
+    /** Clear the held peak without disturbing the filter state. */
+    resetPeak(): void {
+        this.peak = 0;
+    }
+
+    /**
+     * Push one input sample and return the largest interpolated magnitude it
+     * produced. Non-finite input is treated as silence so a stray NaN cannot
+     * latch the meter at +Infinity.
+     */
+    processSample(sample: number): number {
+        const x = Number.isFinite(sample) ? sample : 0;
+        this.history[this.historyIndex] = x;
+        this.historyIndex = (this.historyIndex + 1) % TAPS_PER_PHASE;
+
+        let localPeak = 0;
+        for (let phase = 0; phase < this.factor; phase += 1) {
+            const taps = this.phases[phase];
+            let acc = 0;
+            // history[historyIndex] is now the oldest sample; walk forward.
+            let idx = this.historyIndex;
+            for (let tap = TAPS_PER_PHASE - 1; tap >= 0; tap -= 1) {
+                acc += taps[tap] * this.history[idx];
+                idx += 1;
+                if (idx === TAPS_PER_PHASE) idx = 0;
+            }
+            const magnitude = acc < 0 ? -acc : acc;
+            if (magnitude > localPeak) localPeak = magnitude;
+        }
+        if (localPeak > this.peak) this.peak = localPeak;
+        return localPeak;
+    }
+}
+
+/** Convert a linear magnitude to dB, mapping 0 to -Infinity. */
+export function linearToDb(linear: number): number {
+    return linear > 0 ? 20 * Math.log10(linear) : -Infinity;
+}
+
+/** Convert dB to a linear magnitude. */
+export function dbToLinear(db: number): number {
+    return Math.pow(10, db / 20);
+}
+
+/**
+ * Offline true-peak of an interleaved-by-channel buffer, in dBTP.
+ * Used by the export path and by the ISP torture tests.
+ */
+export function measureTruePeakDbtp(
+    channels: readonly Float32Array[],
+    sampleRate: number,
+    factor?: number,
+): number {
+    let peak = 0;
+    for (const channel of channels) {
+        const detector = new TruePeakDetector(sampleRate, factor);
+        for (let i = 0; i < channel.length; i += 1) {
+            detector.processSample(channel[i]);
+        }
+        // Flush the FIR tail so the final samples are fully interpolated.
+        for (let i = 0; i < TAPS_PER_PHASE; i += 1) {
+            detector.processSample(0);
+        }
+        if (detector.peak > peak) peak = detector.peak;
+    }
+    return linearToDb(peak);
+}

--- a/src/audio/loudness/types.ts
+++ b/src/audio/loudness/types.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared types for the master-bus loudness suite (BS.1770-5 metering + true-peak limiter).
+ *
+ * Everything here is plain data: the same structures cross the AudioWorklet MessagePort,
+ * are persisted to localStorage, and are returned by the offline export analysis.
+ */
+
+/**
+ * Registered name of the master loudness AudioWorklet processor.
+ *
+ * Lives here rather than in the processor module so main-thread code can
+ * construct the node without importing the worklet source — importing it would
+ * pull `registerProcessor` into the main bundle and throw outside an
+ * AudioWorkletGlobalScope.
+ */
+export const MASTER_LOUDNESS_PROCESSOR_NAME = 'master-loudness-processor';
+
+/** Scalar meter snapshot emitted by the master worklet (≤ 30 Hz). */
+export interface LoudnessStats {
+    /** Momentary loudness (400 ms window), LUFS. `-Infinity` when silent. */
+    momentary: number;
+    /** Short-term loudness (3 s window), LUFS. */
+    shortTerm: number;
+    /** Gated integrated loudness since the last reset, LUFS. */
+    integrated: number;
+    /** Held true peak (inter-sample, oversampled), dBTP. */
+    truePeak: number;
+    /** Sample peak (no oversampling), dBFS. */
+    samplePeak: number;
+    /** Current limiter gain reduction, dB (≤ 0). */
+    gainReduction: number;
+    /** True when the limiter clamped at least one sample since the previous message. */
+    clipped: boolean;
+}
+
+/** Limiter configuration — primitives only, safe to persist. */
+export interface LimiterSettings {
+    /** Limiter active (false = pure metering pass-through). */
+    enabled: boolean;
+    /** Output ceiling in dBTP. Default -1.0. */
+    ceilingDbtp: number;
+    /** Attack time in milliseconds (gain reduction onset smoothing). */
+    attackMs: number;
+    /** Release time in milliseconds. */
+    releaseMs: number;
+    /** Lookahead in milliseconds — also the added monitor latency. */
+    lookaheadMs: number;
+    /**
+     * Monitor-only mode: zero lookahead, hard-clip at the ceiling.
+     * Trades transparency for latency during live performance.
+     */
+    monitorOnly: boolean;
+}
+
+export const DEFAULT_LIMITER_SETTINGS: LimiterSettings = {
+    enabled: true,
+    ceilingDbtp: -1.0,
+    attackMs: 1.0,
+    releaseMs: 60,
+    lookaheadMs: 1.5,
+    monitorOnly: false,
+};
+
+/** Loudness targets offered by the export path. */
+export const LOUDNESS_TARGETS = {
+    streaming: -14,
+    club: -9,
+    broadcast: -23,
+} as const;
+
+export type LoudnessTargetKey = keyof typeof LOUDNESS_TARGETS;
+
+/** Messages sent from the main thread to the master loudness worklet. */
+export type MasterLoudnessCommand =
+    | { type: 'set-limiter'; data: Partial<LimiterSettings> }
+    | { type: 'reset-loudness' }
+    | { type: 'set-report-hz'; data: number };
+
+/** Message sent from the worklet to the main thread. */
+export interface MasterLoudnessReport {
+    type: 'loudness-stats';
+    data: LoudnessStats;
+    /** Current lookahead latency in seconds, for monitor-latency accounting. */
+    latencySeconds: number;
+}
+
+/** Silence sentinel — BS.1770 loudness of a zero-power signal. */
+export const SILENCE_LUFS = -Infinity;

--- a/src/components/MasterLoudnessMeter.tsx
+++ b/src/components/MasterLoudnessMeter.tsx
@@ -1,0 +1,198 @@
+// MasterLoudnessMeter — broadcast-style master strip.
+//
+// Shows momentary / short-term / integrated LUFS, held true peak, a gain
+// reduction bar and the limiter controls (ceiling, bypass, monitor-only).
+// Values arrive as scalars from the master worklet at ≤ 30 Hz; this component
+// never touches an AudioNode.
+
+import React, { memo, useCallback } from 'react';
+
+import { useMasterLoudness } from '../hooks/useMasterLoudness';
+import { formatLufs, LOUDNESS_TARGETS } from '../audio/loudness';
+
+interface MasterLoudnessMeterProps {
+    className?: string;
+    /** Reference loudness drawn as the target marker. Default -14 (streaming). */
+    targetLufs?: number;
+}
+
+/** Map a loudness value onto a 0-1 scale spanning -40…0 LUFS. */
+function loudnessToFraction(lufs: number): number {
+    if (!Number.isFinite(lufs)) return 0;
+    return Math.max(0, Math.min(1, (lufs + 40) / 40));
+}
+
+const READOUT_CLASS = 'font-mono text-[11px] leading-none tabular-nums';
+
+interface ReadoutProps {
+    label: string;
+    value: number;
+    title: string;
+    highlight?: boolean;
+}
+
+const Readout: React.FC<ReadoutProps> = ({ label, value, title, highlight }) => (
+    <div className="flex flex-col items-center gap-0.5" title={title}>
+        <span className="text-[9px] uppercase tracking-wide text-neutral-400">{label}</span>
+        <span className={`${READOUT_CLASS} ${highlight ? 'text-amber-300' : 'text-neutral-100'}`}>
+            {formatLufs(value)}
+        </span>
+    </div>
+);
+
+export const MasterLoudnessMeter: React.FC<MasterLoudnessMeterProps> = memo(
+    ({ className = '', targetLufs = LOUDNESS_TARGETS.streaming }) => {
+        const { stats, settings, ready, latencySeconds, setSettings, resetLoudness } =
+            useMasterLoudness();
+
+        const onCeilingChange = useCallback(
+            (event: React.ChangeEvent<HTMLInputElement>) => {
+                setSettings({ ceilingDbtp: Number(event.target.value) });
+            },
+            [setSettings],
+        );
+
+        const overCeiling = stats.truePeak > settings.ceilingDbtp + 0.05;
+        // Gain reduction is negative; 12 dB fills the bar.
+        const grFraction = Math.min(1, Math.abs(stats.gainReduction) / 12);
+
+        return (
+            <section
+                className={`flex flex-col gap-2 rounded-md border border-neutral-700 bg-neutral-900/80 p-2 ${className}`}
+                aria-label="Master loudness"
+            >
+                <div className="flex items-center justify-between gap-3">
+                    <span className="text-[9px] uppercase tracking-widest text-neutral-400">
+                        Master LUFS
+                    </span>
+                    <button
+                        type="button"
+                        onClick={resetLoudness}
+                        className="rounded border border-neutral-600 px-1.5 py-0.5 text-[9px] uppercase text-neutral-300 hover:bg-neutral-700"
+                        title="Restart the gated integrated measurement and clear peak holds"
+                    >
+                        Reset
+                    </button>
+                </div>
+
+                <div className="flex items-end justify-between gap-3">
+                    <Readout label="M" value={stats.momentary} title="Momentary loudness (400 ms)" />
+                    <Readout label="S" value={stats.shortTerm} title="Short-term loudness (3 s)" />
+                    <Readout
+                        label="I"
+                        value={stats.integrated}
+                        title="Gated integrated loudness since last reset"
+                        highlight
+                    />
+                    <div
+                        className="flex flex-col items-center gap-0.5"
+                        title="Held true peak (inter-sample), dBTP"
+                    >
+                        <span className="text-[9px] uppercase tracking-wide text-neutral-400">
+                            dBTP
+                        </span>
+                        <span
+                            className={`${READOUT_CLASS} ${
+                                overCeiling ? 'text-red-400' : 'text-neutral-100'
+                            }`}
+                        >
+                            {formatLufs(stats.truePeak)}
+                        </span>
+                    </div>
+                </div>
+
+                {/* Momentary bar with the target marker. */}
+                <div
+                    className="relative h-2 w-full overflow-hidden rounded-sm bg-neutral-800"
+                    role="meter"
+                    aria-label="Momentary loudness"
+                    aria-valuenow={Number.isFinite(stats.momentary) ? stats.momentary : -40}
+                    aria-valuemin={-40}
+                    aria-valuemax={0}
+                >
+                    <div
+                        className="h-full bg-emerald-500"
+                        style={{ width: `${loudnessToFraction(stats.momentary) * 100}%` }}
+                    />
+                    <div
+                        className="absolute top-0 h-full w-px bg-amber-300"
+                        style={{ left: `${loudnessToFraction(targetLufs) * 100}%` }}
+                        title={`Target ${targetLufs} LUFS`}
+                    />
+                </div>
+
+                {/* Gain reduction, drawn right-to-left like a hardware GR meter. */}
+                <div className="flex items-center gap-2">
+                    <span className="text-[9px] uppercase tracking-wide text-neutral-400">GR</span>
+                    <div className="relative h-2 flex-1 overflow-hidden rounded-sm bg-neutral-800">
+                        <div
+                            className="absolute right-0 h-full bg-amber-500"
+                            style={{ width: `${grFraction * 100}%` }}
+                        />
+                    </div>
+                    <span className={`${READOUT_CLASS} w-10 text-right text-neutral-300`}>
+                        {stats.gainReduction.toFixed(1)}
+                    </span>
+                    <span
+                        className={`h-2 w-2 rounded-full ${
+                            stats.clipped ? 'bg-red-500' : 'bg-neutral-700'
+                        }`}
+                        title={stats.clipped ? 'Limiter clipped' : 'No clipping'}
+                        aria-label={stats.clipped ? 'Clip indicator lit' : 'Clip indicator off'}
+                    />
+                </div>
+
+                <div className="flex items-center gap-2">
+                    <label className="flex items-center gap-1 text-[9px] uppercase text-neutral-400">
+                        <input
+                            type="checkbox"
+                            checked={settings.enabled}
+                            onChange={(event) => setSettings({ enabled: event.target.checked })}
+                            disabled={!ready}
+                            aria-label="Limiter enabled"
+                        />
+                        Limiter
+                    </label>
+                    <label
+                        className="flex items-center gap-1 text-[9px] uppercase text-neutral-400"
+                        title="Zero-latency hard clip for live monitoring"
+                    >
+                        <input
+                            type="checkbox"
+                            checked={settings.monitorOnly}
+                            onChange={(event) => setSettings({ monitorOnly: event.target.checked })}
+                            disabled={!ready || !settings.enabled}
+                            aria-label="Monitor-only mode"
+                        />
+                        Live
+                    </label>
+                    <label className="ml-auto flex items-center gap-1 text-[9px] uppercase text-neutral-400">
+                        Ceiling
+                        <input
+                            type="range"
+                            min={-12}
+                            max={0}
+                            step={0.1}
+                            value={settings.ceilingDbtp}
+                            onChange={onCeilingChange}
+                            disabled={!ready}
+                            className="w-20"
+                            aria-label="Limiter ceiling in dBTP"
+                        />
+                        <span className={`${READOUT_CLASS} w-8 text-neutral-100`}>
+                            {settings.ceilingDbtp.toFixed(1)}
+                        </span>
+                    </label>
+                </div>
+
+                <p className="text-[9px] text-neutral-500">
+                    {ready
+                        ? `Lookahead latency ${(latencySeconds * 1000).toFixed(1)} ms`
+                        : 'Master meter offline'}
+                </p>
+            </section>
+        );
+    },
+);
+
+MasterLoudnessMeter.displayName = 'MasterLoudnessMeter';

--- a/src/components/__tests__/MasterLoudnessMeter.test.tsx
+++ b/src/components/__tests__/MasterLoudnessMeter.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Master meter UI: reads scalar stats from the stage registry, writes settings
+ * back through it, and stays mounted (disabled) when no stage exists.
+ */
+
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+
+import { MasterLoudnessMeter } from '../MasterLoudnessMeter';
+import {
+    setMasterLoudnessStage,
+    DEFAULT_LIMITER_SETTINGS,
+    IDLE_LOUDNESS_STATS,
+    type LimiterSettings,
+    type LoudnessStats,
+    type LoudnessStatsListener,
+    type MasterLoudnessStage,
+} from '../../audio/loudness';
+
+/** Minimal stand-in for the worklet-backed stage. */
+function createFakeStage() {
+    const listeners = new Set<LoudnessStatsListener>();
+    const updates: Array<Partial<LimiterSettings>> = [];
+    let settings: LimiterSettings = { ...DEFAULT_LIMITER_SETTINGS };
+    let resets = 0;
+
+    const stage = {
+        latestStats: IDLE_LOUDNESS_STATS,
+        latencySeconds: 0.0015,
+        getSettings: () => ({ ...settings }),
+        subscribe(listener: LoudnessStatsListener) {
+            listeners.add(listener);
+            return () => listeners.delete(listener);
+        },
+        update(update: Partial<LimiterSettings>) {
+            updates.push(update);
+            settings = { ...settings, ...update };
+        },
+        resetLoudness() {
+            resets += 1;
+        },
+    } as unknown as MasterLoudnessStage;
+
+    return {
+        stage,
+        updates,
+        get resets() {
+            return resets;
+        },
+        emit(stats: Partial<LoudnessStats>) {
+            const next = { ...IDLE_LOUDNESS_STATS, ...stats };
+            (stage as { latestStats: LoudnessStats }).latestStats = next;
+            for (const listener of listeners) listener(next);
+        },
+    };
+}
+
+describe('MasterLoudnessMeter', () => {
+    beforeEach(() => {
+        setMasterLoudnessStage(null);
+    });
+
+    afterEach(() => {
+        setMasterLoudnessStage(null);
+        vi.restoreAllMocks();
+    });
+
+    it('renders an offline strip when the engine is not running', () => {
+        render(<MasterLoudnessMeter />);
+        expect(screen.getByText('Master meter offline')).toBeInTheDocument();
+        expect(screen.getByLabelText('Limiter ceiling in dBTP')).toBeDisabled();
+    });
+
+    it('shows momentary, short-term, integrated and true peak from the worklet', () => {
+        const fake = createFakeStage();
+        act(() => setMasterLoudnessStage(fake.stage));
+        render(<MasterLoudnessMeter />);
+
+        act(() => {
+            fake.emit({
+                momentary: -12.34,
+                shortTerm: -13.5,
+                integrated: -14.02,
+                truePeak: -1.2,
+                gainReduction: -2.5,
+            });
+        });
+
+        expect(screen.getByText('-12.3')).toBeInTheDocument();
+        expect(screen.getByText('-13.5')).toBeInTheDocument();
+        expect(screen.getByText('-14.0')).toBeInTheDocument();
+        expect(screen.getByText('-1.2')).toBeInTheDocument();
+        expect(screen.getByText('-2.5')).toBeInTheDocument();
+    });
+
+    it('renders silence as -inf rather than NaN', () => {
+        const fake = createFakeStage();
+        act(() => setMasterLoudnessStage(fake.stage));
+        render(<MasterLoudnessMeter />);
+        expect(screen.getAllByText('-inf').length).toBeGreaterThan(0);
+    });
+
+    it('sends limiter changes one way, to the stage', () => {
+        const fake = createFakeStage();
+        act(() => setMasterLoudnessStage(fake.stage));
+        render(<MasterLoudnessMeter />);
+
+        fireEvent.change(screen.getByLabelText('Limiter ceiling in dBTP'), {
+            target: { value: '-2.5' },
+        });
+        fireEvent.click(screen.getByLabelText('Limiter enabled'));
+
+        expect(fake.updates).toContainEqual({ ceilingDbtp: -2.5 });
+        expect(fake.updates.some((u) => u.enabled === false)).toBe(true);
+    });
+
+    it('asks the stage to restart the integrated measurement', () => {
+        const fake = createFakeStage();
+        act(() => setMasterLoudnessStage(fake.stage));
+        render(<MasterLoudnessMeter />);
+
+        fireEvent.click(screen.getByText('Reset'));
+        expect(fake.resets).toBe(1);
+    });
+
+    it('reports the limiter lookahead as monitor latency', () => {
+        const fake = createFakeStage();
+        act(() => setMasterLoudnessStage(fake.stage));
+        render(<MasterLoudnessMeter />);
+        act(() => fake.emit({ momentary: -20 }));
+        expect(screen.getByText(/Lookahead latency 1\.5 ms/)).toBeInTheDocument();
+    });
+});

--- a/src/hooks/audioEngine/engineLifecycle.ts
+++ b/src/hooks/audioEngine/engineLifecycle.ts
@@ -22,6 +22,10 @@ import { engineTelemetry } from '../../utils/engineTelemetry';
 import { loadingProgressStore } from '../../stores/loadingProgressStore';
 import { startGlitchMonitor } from '../../utils/workletPerfBridge';
 import { buildClassicElectribeGraph } from '../../audio/graph';
+import {
+    createMasterLoudnessStage,
+    setMasterLoudnessStage,
+} from '../../audio/loudness';
 import type { TrackAnalysers } from '../../types';
 import { getStoredLatencyMode, type LatencyMode } from '../../utils/audioLatencyMode';
 import { createAudioContext } from './audioContextFactory';
@@ -107,7 +111,14 @@ export async function initializeAudioContextAndEngines(
     }
 
     loadingProgressStore.startStep('masterChain');
-    const { masterBusInput } = buildClassicElectribeGraph(context, refs);
+    // The master true-peak limiter / loudness meter is an AudioWorklet, so its
+    // module has to be registered before the graph is compiled. If it fails to
+    // load the graph is compiled without it and playback continues unmetered.
+    const loudnessStage = await createMasterLoudnessStage(context);
+    setMasterLoudnessStage(loudnessStage);
+    const { masterBusInput } = buildClassicElectribeGraph(context, refs, {
+        masterLimiterNode: loudnessStage?.node ?? null,
+    });
     loadingProgressStore.completeStep('masterChain');
 
     // Initialize oscillator backends through the shared registry. Every engine

--- a/src/hooks/useMasterLoudness.ts
+++ b/src/hooks/useMasterLoudness.ts
@@ -1,0 +1,70 @@
+// useMasterLoudness — subscribes the UI to the master-bus loudness worklet.
+//
+// The worklet pushes scalar snapshots at ≤ 30 Hz; this hook mirrors the latest
+// one into React state and exposes the (unidirectional) settings writer. No
+// audio buffers and no AudioNodes are handed to components.
+
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+    DEFAULT_LIMITER_SETTINGS,
+    IDLE_LOUDNESS_STATS,
+    subscribeMasterLoudnessStage,
+    type LimiterSettings,
+    type LoudnessStats,
+    type MasterLoudnessStage,
+} from '../audio/loudness';
+
+export interface UseMasterLoudnessResult {
+    stats: LoudnessStats;
+    settings: LimiterSettings;
+    /** True once the worklet is running — the UI shows a disabled strip until then. */
+    ready: boolean;
+    /** Added monitor latency from the limiter lookahead, in seconds. */
+    latencySeconds: number;
+    setSettings: (update: Partial<LimiterSettings>) => void;
+    resetLoudness: () => void;
+}
+
+export function useMasterLoudness(): UseMasterLoudnessResult {
+    const [stage, setStage] = useState<MasterLoudnessStage | null>(null);
+    const [stats, setStats] = useState<LoudnessStats>(IDLE_LOUDNESS_STATS);
+    const [settings, setLocalSettings] = useState<LimiterSettings>(DEFAULT_LIMITER_SETTINGS);
+    const [latencySeconds, setLatencySeconds] = useState(0);
+
+    useEffect(() => subscribeMasterLoudnessStage(setStage), []);
+
+    useEffect(() => {
+        if (!stage) {
+            setStats(IDLE_LOUDNESS_STATS);
+            return;
+        }
+        setLocalSettings(stage.getSettings());
+        setStats(stage.latestStats);
+        return stage.subscribe((next) => {
+            setStats(next);
+            setLatencySeconds(stage.latencySeconds);
+        });
+    }, [stage]);
+
+    const setSettings = useCallback(
+        (update: Partial<LimiterSettings>) => {
+            setLocalSettings((previous) => ({ ...previous, ...update }));
+            stage?.update(update);
+        },
+        [stage],
+    );
+
+    const resetLoudness = useCallback(() => {
+        stage?.resetLoudness();
+    }, [stage]);
+
+    return {
+        stats,
+        settings,
+        ready: stage !== null,
+        latencySeconds,
+        setSettings,
+        resetLoudness,
+    };
+}

--- a/src/utils/stemExport.ts
+++ b/src/utils/stemExport.ts
@@ -18,6 +18,14 @@ import {
     type PatternRenderEngines,
 } from './patternRenderer';
 import { createZipBlob } from './zipStore';
+import {
+    analyzeLoudness,
+    normalizeToTarget,
+    DEFAULT_LIMITER_SETTINGS,
+    type LoudnessReport,
+    type LoudnessTargetKey,
+    type NormalizeResult,
+} from '../audio/loudness';
 
 export type StemExportSampleRate = 44100 | 48000;
 
@@ -28,6 +36,28 @@ export interface StemExportOptions {
     useSongMode?: boolean;
     signal?: AbortSignal;
     onProgress?: (progress: number, label: string) => void;
+    /**
+     * Loudness handling for the master stem.
+     *
+     * The report is always computed (and written into metadata.json); passing
+     * `normalizeTo` additionally gain-matches the master stem to that target
+     * and re-limits it so the ceiling still holds.
+     */
+    loudness?: {
+        normalizeTo?: number | LoudnessTargetKey;
+        ceilingDbtp?: number;
+        /** Oversampling for the offline true-peak measurement. Default 8×. */
+        truePeakFactor?: number;
+    };
+}
+
+/** Channel data of an AudioBuffer, mutable in place. */
+function bufferChannels(buffer: AudioBuffer): Float32Array[] {
+    const channels: Float32Array[] = [];
+    for (let ch = 0; ch < buffer.numberOfChannels; ch += 1) {
+        channels.push(buffer.getChannelData(ch));
+    }
+    return channels;
 }
 
 export interface StemExportParams {
@@ -250,6 +280,22 @@ export async function exportStemsToZip(
     }
 
     throwIfAborted(signal);
+
+    // Measure (and optionally normalise) the master stem with the same DSP the
+    // real-time master bus runs, so the exported file and the live meters agree.
+    const masterStem = stems.get('master');
+    let masterLoudness: LoudnessReport | NormalizeResult | null = null;
+    if (masterStem) {
+        const channels = bufferChannels(masterStem);
+        const target = options.loudness?.normalizeTo;
+        masterLoudness =
+            target === undefined
+                ? analyzeLoudness(channels, sampleRate, options.loudness?.truePeakFactor ?? 8)
+                : normalizeToTarget(channels, sampleRate, target, {
+                      ceilingDbtp: options.loudness?.ceilingDbtp ?? DEFAULT_LIMITER_SETTINGS.ceilingDbtp,
+                  });
+    }
+
     onProgress?.(0.95, 'Encoding WAV files…');
 
     const wavOptions = { sampleRate, bitDepth };
@@ -264,6 +310,7 @@ export async function exportStemsToZip(
 
     const metadata = {
         tempo: input.tempo,
+        loudness: masterLoudness,
         measureCount: timeline.measureCount,
         totalSteps: timeline.totalSteps,
         sampleRate,


### PR DESCRIPTION
Implements the master-bus loudness suite: momentary / short-term / gated integrated LUFS, true-peak metering, and a real-time true-peak brick-wall limiter. First-party DSP, no runtime dependency, no network use.

## Where it sits

```
… → masterCompressor → masterGain → masterPanner → masterLimiter → destination
```

Last insert before `destination`, so it covers everything — including the choir buses that bypass the master FX chain by entering at `masterGain`. The node is an AudioWorklet, so it is created before the graph is compiled; if it cannot be registered, `compileAudioGraph` bridges `masterPanner → destination` and playback continues unmetered.

## What's here

**DSP** (`src/audio/loudness/`, shared by the worklet and the offline export path — this is what keeps live and file in agreement):

- K-weighting derived per sample rate from the analog prototypes. A test asserts the 48 kHz result equals the coefficient table printed in BS.1770-5, which is the only rate the recommendation tabulates.
- Momentary (400 ms), short-term (3 s) and gated integrated LUFS. Gating blocks go into a fixed-size 0.1 LU histogram rather than a growing list, so an all-day session cannot grow worklet memory. Power accumulation is Float64.
- True peak via a 128-tap polyphase windowed-sinc interpolator: 4× at ≤ 48 kHz, 2× at 96 kHz, i.e. ≥ 192 kHz effective.
- Lookahead brick-wall limiter (sliding-minimum gain + attack/release smoothing), with bypass and a zero-latency monitor-only hard-clip mode. Latency is reported for monitor-latency accounting.

**Wiring**: optional `masterLimiter` graph node; `master-loudness-processor` worklet that limits then meters its own output and posts scalar stats at ≤ 30 Hz (never audio buffers), reporting CPU through the existing worklet perf bridge.

**UI**: `MasterLoudnessMeter` strip — M/S/I readouts, true-peak hold, GR bar, clip LED, ceiling, bypass, monitor-only, reset. State flows one way (UI → debounced postMessage → worklet). Settings persist as primitives and are re-validated on load, so a corrupted entry falls back to defaults rather than feeding NaN to the audio thread.

**Export**: `exportStemsToZip` measures the master stem with the same DSP (8× offline) into `metadata.json`, and `options.loudness.normalizeTo` gain-matches and re-limits to a target, reporting what was *actually* achieved rather than assuming the target was met.

## Verification

`src/audio/loudness/__tests__/` — 48 tests, plus 6 UI tests and 4 new graph tests:

- LUFS within ±0.1 on BS.1770 / TECH 3341 tone and gating cases (absolute gate, relative gate, reset semantics) and across a 44.1 / 48 / 96 kHz sweep.
- The canonical ISP case: a 0 dBFS fs/4 sine at 45° reads +3.01 dBTP where a sample-peak meter reads 0 dBFS.
- An 8× offline check confirms no inter-sample peak exceeds the ceiling on full-scale HF tone and on transient material.
- Live-vs-offline parity within 0.1 LU / 0.1 dBTP; NaN and Infinity input cannot latch or mute the master; the DSP allocates nothing per render quantum (asserted via a typed-array construction proxy).

Full suite: 1462 passing. The 9 failing test files are pre-existing and identical on a clean tree — they need built `.wasm` artifacts. `tsc -b` and eslint are clean.

## Decisions worth a look

- **Internal headroom.** The limiter targets 0.4 dB under the requested ceiling and detects at 8× rather than 4×. Two effects push the output above a naively computed ceiling: 4× estimation underestimates near-Nyquist content, and applying a time-varying gain creates inter-sample energy of its own. Consequence: under heavy limiting the output measures a few tenths below the number on the knob — deliberately, in the safe direction. Happy to trade this for a knob if you'd rather.
- **Performance.** ~0.35 ms per 128-frame stereo quantum, ~13 % of the 2.67 ms budget at 48 kHz — higher than the issue's 2–3 µs estimate, so it is recorded in `docs/PERFORMANCE_BUDGET.md` along with the two ways to reclaim it. It still doesn't justify the SAB-worker complexity for one stereo pair, but it's the number that would reopen that question.
- **Test signals need faded edges** when a measurement must be accurate to 0.1 dB: a buffer starting or ending mid-cycle is a step, and the band-limited reconstruction of a step genuinely overshoots by ~1 dB. That is the signal, not the meter — it cost a few false failures to pin down and is commented where it matters.

## Open questions from the issue

- *Vendor coefficient tables?* Not needed — coefficients are derived and validated against the BS.1770-5 table at 48 kHz, so there is no license question.
- *Lookahead default?* 1.5 ms (tighter latency). Listening tests still to do.
- *Higher offline oversampling?* The limiter detects at 8× live, so live and file agree; the offline export report also measures at 8×. Parity is asserted within 0.1.
- *Insertion point?* After all master inserts, before `destination` — asserted by a test rather than left as convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGVsSCyAfWCio6B3QLU7h4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added master-bus loudness monitoring with momentary, short-term, and integrated LUFS readings.
  * Added true-peak limiting with adjustable ceiling, lookahead, bypass, and monitor-only controls.
  * Added loudness and clipping status displays, gain-reduction feedback, latency information, and reset controls.
  * Added optional loudness normalization for stem exports, with results included in export metadata.

* **Documentation**
  * Documented loudness processing, limiter behavior, validation, and performance considerations.

* **Tests**
  * Added comprehensive coverage for loudness metering, true-peak detection, limiting, graph routing, exports, and UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->