### PR TITLE
Fix TUNE knob having no effect on sounding pitch

### DIFF
--- a/src/audio/playback/drumPlayback.ts
+++ b/src/audio/playback/drumPlayback.ts
@@ -49,7 +49,8 @@ export function playDrum(
         const osc = context.createOscillator();
         const gain = context.createGain();
 
-        osc.frequency.setValueAtTime(150, now);
+        // TUNE knob sets the kick's base pitch in Hz
+        osc.frequency.setValueAtTime(Math.max(20, p.pitch || 150), now);
         osc.frequency.exponentialRampToValueAtTime(0.01, now + p.decay);
 
         gain.gain.setValueAtTime(p.volume, now);
@@ -66,8 +67,9 @@ export function playDrum(
         const osc = context.createOscillator();
         const oscGain = context.createGain();
         osc.type = 'triangle';
-        osc.frequency.setValueAtTime(250, now);
-        oscGain.gain.setValueAtTime(p.tone * p.volume, now);
+        // TUNE knob sets the body tone frequency in Hz
+        osc.frequency.setValueAtTime(Math.max(20, p.tone || 250), now);
+        oscGain.gain.setValueAtTime(p.volume * 0.6, now);
         oscGain.gain.exponentialRampToValueAtTime(0.001, now + p.decay); // Using decay for tone too
 
         // Noise
@@ -76,9 +78,10 @@ export function playDrum(
             noise.buffer = noiseBuffer;
             const noiseFilter = context.createBiquadFilter();
             noiseFilter.type = 'highpass';
+            // SNAPPY knob is a Hz-valued amount (~1000-8000); normalize to gain
             noiseFilter.frequency.value = 1000;
             const noiseGain = context.createGain();
-            noiseGain.gain.setValueAtTime(p.noise * p.volume, now);
+            noiseGain.gain.setValueAtTime(Math.min(1, p.noise / 5000) * p.volume, now);
             noiseGain.gain.exponentialRampToValueAtTime(0.001, now + p.decay);
 
             noise.connect(noiseFilter);
@@ -101,7 +104,7 @@ export function playDrum(
             src.buffer = noiseBuffer;
             const filter = context.createBiquadFilter();
             filter.type = 'highpass';
-            filter.frequency.value = 5000; // Metallic
+            filter.frequency.value = Math.max(20, p.pitch || 5000); // Metallic (TONE knob)
             const gain = context.createGain();
             gain.gain.setValueAtTime(p.volume, now);
             gain.gain.exponentialRampToValueAtTime(0.001, now + p.decay);

--- a/src/audio/playback/synthPlayback.ts
+++ b/src/audio/playback/synthPlayback.ts
@@ -10,6 +10,7 @@
 import type { SynthParams } from '../../types';
 import { tunedNoteToFrequency } from '../../constants';
 import { noteToMidi } from '../../utils/musicTheory';
+import { getPitchOffsetSemitones, transposeMidi, transposeFrequency } from '../../utils/pitchOffset';
 import type { ScaleDefinition } from '../../utils/musicTheory';
 import type { Open303Oscillator } from '../../engines/Open303Oscillator';
 import type { ProphecyOscillator } from '../../engines/ProphecyOscillator';
@@ -81,7 +82,7 @@ export function playSynth(
         if (open303Engine) {
             apply303Params(open303Engine, params, params.waveform === '303-sqr' ? 'sqr' : 'saw');
 
-            const midi = noteToMidi(note);
+            const midi = transposeMidi(noteToMidi(note), getPitchOffsetSemitones(params));
             const now = context.currentTime;
             const startDelay = Math.max(0, time - now);
             const duration = durationSteps * stepTime;
@@ -98,7 +99,7 @@ export function playSynth(
         if (prophecyEngine) {
             applyProphecyParams(prophecyEngine, params, prophecyWaveType);
 
-            const midi = noteToMidi(note);
+            const midi = transposeMidi(noteToMidi(note), getPitchOffsetSemitones(params));
             const now = context.currentTime;
             const startDelay = Math.max(0, time - now);
             const duration = durationSteps * stepTime;
@@ -110,7 +111,7 @@ export function playSynth(
     }
 
     // === Frequency with Microtonal Tuning ===
-    const freq = tunedNoteToFrequency(note, tuning);
+    const freq = transposeFrequency(tunedNoteToFrequency(note, tuning), getPitchOffsetSemitones(params));
 
     const gain = context.createGain();
     const filter = context.createBiquadFilter();
@@ -240,7 +241,7 @@ export function noteOnSynth(
         if (ctx.open303Engine) {
             apply303Params(ctx.open303Engine, params, params.waveform === '303-sqr' ? 'sqr' : 'saw');
 
-            const midi = noteToMidi(note);
+            const midi = transposeMidi(noteToMidi(note), getPitchOffsetSemitones(params));
             ctx.open303Engine.noteOn(midi, 100);
 
             const id = state.nextNoteId++;
@@ -256,7 +257,7 @@ export function noteOnSynth(
         if (ctx.prophecyEngine) {
             applyProphecyParams(ctx.prophecyEngine, params, prophecyWaveType);
 
-            const midi = noteToMidi(note);
+            const midi = transposeMidi(noteToMidi(note), getPitchOffsetSemitones(params));
             ctx.prophecyEngine.noteOn(midi, 100);
 
             const id = state.nextNoteId++;

--- a/src/engines/VoiceManager.ts
+++ b/src/engines/VoiceManager.ts
@@ -12,6 +12,7 @@ import {
     type PyodideLike,
 } from '../utils/pyodideBuffers';
 import { VoicePool, type PoolableVoice } from './base/VoicePool';
+import { getPitchOffsetSemitones, transposeFrequency } from '../utils/pitchOffset';
 
 export interface VoiceEngineDeps {
     wasmEngine?: WasmOscillator | null;
@@ -121,7 +122,14 @@ export class Voice implements PoolableVoice {
         }
 
         const now = time;
-        const freq = tunedNoteToFrequency(note, tuning);
+        // Module TUNE knob (semitones) transposes the sounding pitch.
+        const pitchSemis = getPitchOffsetSemitones(params);
+        const freq = transposeFrequency(tunedNoteToFrequency(note, tuning), pitchSemis);
+        // Slide source frequencies are computed from the untransposed note, so
+        // shift them by the same amount to keep glides in tune.
+        const slideFrom = slideFromFreq !== undefined
+            ? transposeFrequency(slideFromFreq, pitchSemis)
+            : undefined;
 
         const waveform = params.waveform;
         const parsed = parseWaveform(waveform);
@@ -135,11 +143,11 @@ export class Voice implements PoolableVoice {
             // === LEGATO / SLIDE ===
             if (this.source instanceof OscillatorNode) {
                 this.source.frequency.cancelScheduledValues(now);
-                this.source.frequency.setValueAtTime(slideFromFreq!, now);
+                this.source.frequency.setValueAtTime(slideFrom!, now);
                 this.source.frequency.exponentialRampToValueAtTime(freq, now + 0.1);
             } else if (this.source instanceof AudioBufferSourceNode) {
                 const baseFreq = 261.63; // C4
-                const startRate = slideFromFreq! / baseFreq;
+                const startRate = slideFrom! / baseFreq;
                 const endRate = freq / baseFreq;
                 this.source.playbackRate.cancelScheduledValues(now);
                 this.source.playbackRate.setValueAtTime(startRate, now);

--- a/src/hooks/audioEngine/audioPlayback/noteControls.ts
+++ b/src/hooks/audioEngine/audioPlayback/noteControls.ts
@@ -1,5 +1,6 @@
 import type { AudioEngine } from "../../../types";
 import { noteToMidi } from "../../../utils/musicTheory";
+import { getPitchOffsetSemitones, transposeMidi } from "../../../utils/pitchOffset";
 import { PROPHECY_WAVEFORM_SUFFIX } from "../../../engines/ProphecyParams";
 import { engineTelemetry } from "../../../utils/engineTelemetry";
 import { pulseExpressionLed } from "../../../audio/expressionLedPulse";
@@ -33,7 +34,7 @@ export function createNoteOnSynth(
 
     if (track === "bass2") {
       if (refs.open303ManagerRef.current?.isBass2Ready()) {
-        const midi = noteToMidi(note);
+        const midi = transposeMidi(noteToMidi(note), getPitchOffsetSemitones(params));
         triggerBassEQDuck(
           context,
           refs.bassSidechainEQBusRef.current,
@@ -65,7 +66,7 @@ export function createNoteOnSynth(
           params,
           params.waveform === "303-sqr" ? "sqr" : "saw",
         );
-        const midi = noteToMidi(note);
+        const midi = transposeMidi(noteToMidi(note), getPitchOffsetSemitones(params));
         triggerBassEQDuck(
           context,
           refs.bassSidechainEQBusRef.current,
@@ -96,7 +97,7 @@ export function createNoteOnSynth(
           params,
           params.waveform === "303-sqr" ? "sqr" : "saw",
         );
-        const midi = noteToMidi(note);
+        const midi = transposeMidi(noteToMidi(note), getPitchOffsetSemitones(params));
         const t0 = performance.now();
         refs.open303ManagerRef.current.setLead303Drive(params.drive || 0);
         refs.open303ManagerRef.current.noteOnLead303(midi, 100);
@@ -120,7 +121,7 @@ export function createNoteOnSynth(
           params,
           prophecyWaveTypeNoteOn,
         );
-        const midi = noteToMidi(note);
+        const midi = transposeMidi(noteToMidi(note), getPitchOffsetSemitones(params));
         triggerBassEQDuck(
           context,
           refs.bassSidechainEQBusRef.current,
@@ -147,7 +148,7 @@ export function createNoteOnSynth(
           params,
           prophecyWaveTypeNoteOn,
         );
-        const midi = noteToMidi(note);
+        const midi = transposeMidi(noteToMidi(note), getPitchOffsetSemitones(params));
         const t0 = performance.now();
         refs.prophecyManagerRef.current.noteOnPartA(midi, 100);
         const t1 = performance.now();

--- a/src/hooks/audioEngine/audioPlayback/playSynth.ts
+++ b/src/hooks/audioEngine/audioPlayback/playSynth.ts
@@ -1,5 +1,6 @@
 import type { SynthParams } from "../../../types";
 import { noteToMidi } from "../../../utils/musicTheory";
+import { getPitchOffsetSemitones, transposeMidi } from "../../../utils/pitchOffset";
 import { PROPHECY_WAVEFORM_SUFFIX } from "../../../engines/ProphecyParams";
 import type { Voice } from "../../../engines/VoiceManager";
 import { pulseExpressionLed } from "../../../audio/expressionLedPulse";
@@ -111,6 +112,9 @@ export function createPlaySynth(
       pulseExpressionLed(SYNTH_TRACK_TO_LED[track], noteStr);
     }
     const midi = noteToMidi(noteStr);
+    // TUNE (module pitch offset, semitones) applies to the engine-driven voices.
+    // The VoiceManager path applies it itself from params, so it is not used there.
+    const engineMidi = transposeMidi(midi, getPitchOffsetSemitones(effectiveParams));
     const velocity = Math.round((noteParams?.velocity ?? 0.8) * 127);
     const prophecyWaveType = PROPHECY_WAVEFORM_SUFFIX[params.waveform];
 
@@ -177,10 +181,10 @@ export function createPlaySynth(
           setTimeout(() => {
             refs.open303ManagerRef.current?.setBass2Drive(driveAmount);
           }, startDelay * 1000);
-          refs.open303ManagerRef.current?.noteOnBass2(midi, velocity, noteTime);
+          refs.open303ManagerRef.current?.noteOnBass2(engineMidi, velocity, noteTime);
 
           if (slideFromFreq === undefined) {
-            refs.open303ManagerRef.current?.noteOffBass2(midi, noteTime + noteDuration);
+            refs.open303ManagerRef.current?.noteOffBass2(engineMidi, noteTime + noteDuration);
           }
         }
         continue;
@@ -209,10 +213,10 @@ export function createPlaySynth(
           setTimeout(() => {
             refs.open303ManagerRef.current?.setBass1Drive(driveAmount);
           }, startDelay * 1000);
-          refs.open303ManagerRef.current?.noteOnBass1(midi, velocity, noteTime);
+          refs.open303ManagerRef.current?.noteOnBass1(engineMidi, velocity, noteTime);
 
           if (slideFromFreq === undefined) {
-            refs.open303ManagerRef.current?.noteOffBass1(midi, noteTime + noteDuration);
+            refs.open303ManagerRef.current?.noteOffBass1(engineMidi, noteTime + noteDuration);
           }
 
           continue;
@@ -235,10 +239,10 @@ export function createPlaySynth(
           setTimeout(() => {
             refs.open303ManagerRef.current?.setLead303Drive(driveAmount);
           }, startDelay * 1000);
-          refs.open303ManagerRef.current?.noteOnLead303(midi, velocity, noteTime);
+          refs.open303ManagerRef.current?.noteOnLead303(engineMidi, velocity, noteTime);
 
           if (slideFromFreq === undefined) {
-            refs.open303ManagerRef.current?.noteOffLead303(midi, noteTime + noteDuration);
+            refs.open303ManagerRef.current?.noteOffLead303(engineMidi, noteTime + noteDuration);
           }
 
           continue;
@@ -259,10 +263,10 @@ export function createPlaySynth(
             noteDuration,
           );
 
-          refs.prophecyManagerRef?.current?.noteOnPartB(midi, 100, noteTime);
+          refs.prophecyManagerRef?.current?.noteOnPartB(engineMidi, 100, noteTime);
 
           if (slideFromFreq === undefined) {
-            refs.prophecyManagerRef?.current?.noteOffPartB(midi, noteTime + noteDuration);
+            refs.prophecyManagerRef?.current?.noteOffPartB(engineMidi, noteTime + noteDuration);
           }
 
           continue;
@@ -275,10 +279,10 @@ export function createPlaySynth(
           const startDelay = Math.max(0, noteTime - now);
           const noteDuration = subDuration;
 
-          refs.prophecyManagerRef?.current?.noteOnPartA(midi, 100, noteTime);
+          refs.prophecyManagerRef?.current?.noteOnPartA(engineMidi, 100, noteTime);
 
           if (slideFromFreq === undefined) {
-            refs.prophecyManagerRef?.current?.noteOffPartA(midi, noteTime + noteDuration);
+            refs.prophecyManagerRef?.current?.noteOffPartA(engineMidi, noteTime + noteDuration);
           }
 
           continue;

--- a/src/utils/__tests__/pitchOffset.test.ts
+++ b/src/utils/__tests__/pitchOffset.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import {
+    getPitchOffsetSemitones,
+    transposeMidi,
+    transposeFrequency,
+} from '../pitchOffset';
+
+describe('pitchOffset', () => {
+    it('reads the TUNE offset from params', () => {
+        expect(getPitchOffsetSemitones({ pitch: 7 })).toBe(7);
+        expect(getPitchOffsetSemitones({ pitch: -12 })).toBe(-12);
+    });
+
+    it('defaults to 0 for params without a usable pitch', () => {
+        expect(getPitchOffsetSemitones({})).toBe(0);
+        expect(getPitchOffsetSemitones(null)).toBe(0);
+        expect(getPitchOffsetSemitones({ pitch: NaN })).toBe(0);
+    });
+
+    it('clamps to the knob range', () => {
+        expect(getPitchOffsetSemitones({ pitch: 99 })).toBe(24);
+        expect(getPitchOffsetSemitones({ pitch: -99 })).toBe(-24);
+    });
+
+    it('transposes MIDI by whole semitones', () => {
+        expect(transposeMidi(60, 0)).toBe(60);
+        expect(transposeMidi(60, 12)).toBe(72);
+        expect(transposeMidi(60, -5)).toBe(55);
+    });
+
+    it('transposes frequency by equal temperament ratio', () => {
+        expect(transposeFrequency(440, 0)).toBe(440);
+        expect(transposeFrequency(440, 12)).toBeCloseTo(880, 6);
+        expect(transposeFrequency(440, -12)).toBeCloseTo(220, 6);
+        expect(transposeFrequency(440, 7)).toBeCloseTo(659.255, 2);
+    });
+});

--- a/src/utils/pitchOffset.ts
+++ b/src/utils/pitchOffset.ts
@@ -1,0 +1,33 @@
+/**
+ * Module-level TUNE offset helpers.
+ *
+ * Synth A/B and Bass 2 expose a TUNE knob (`params.pitch`) expressed in
+ * semitones (-24..+24). The knob only writes into params state, so every
+ * playback path has to fold that offset into the pitch it actually sounds.
+ */
+
+/** Clamp range of the TUNE knob, matching the knob config mapping. */
+export const PITCH_OFFSET_MIN = -24;
+export const PITCH_OFFSET_MAX = 24;
+
+/**
+ * Read a module's TUNE offset in semitones from its params, tolerating
+ * params objects that predate the field (older saved patterns).
+ */
+export function getPitchOffsetSemitones(params: { pitch?: number } | null | undefined): number {
+    const raw = params?.pitch;
+    if (typeof raw !== 'number' || !Number.isFinite(raw)) return 0;
+    return Math.max(PITCH_OFFSET_MIN, Math.min(PITCH_OFFSET_MAX, raw));
+}
+
+/** Transpose a MIDI note number by a semitone offset. */
+export function transposeMidi(midi: number, semitones: number): number {
+    if (!semitones) return midi;
+    return midi + semitones;
+}
+
+/** Transpose a frequency (Hz) by a semitone offset. */
+export function transposeFrequency(freq: number, semitones: number): number {
+    if (!semitones) return freq;
+    return freq * Math.pow(2, semitones / 12);
+}


### PR DESCRIPTION
## Summary

The TUNE knob wrote `params.pitch` into state correctly, but **no playback path ever read it** — so the label updated and the audio didn't. Cause #2 from the issue's hint list.

## Changes

**New `src/utils/pitchOffset.ts`** — shared helpers: `getPitchOffsetSemitones` (reads + clamps to ±24, tolerates params missing the field), `transposeMidi`, `transposeFrequency`.

**`VoiceManager.startNote`** — transposes the note frequency by `params.pitch` semitones. Also transposes the slide source frequency by the same amount, so legato glides land in tune instead of sliding from an untransposed pitch. Covers the oscillator and WAV-buffer voices used by Synth A/B.

**`audioPlayback/playSynth.ts`** (sequenced notes) and **`audioPlayback/noteControls.ts`** (live keyboard) — transpose the MIDI note handed to the Open303 engines (Bass 1, Bass 2, Lead 303) and the Prophecy engines. Note-off uses the same transposed value, and for live notes it's captured in the stop closure, so a held note still releases if the knob moves mid-note.

**`src/audio/playback/synthPlayback.ts`** — the same offset applied on the offline/worker rendering path, for both the engine (MIDI) and plain-oscillator (frequency) branches.

**`src/audio/playback/drumPlayback.ts`** — the legacy no-kit-engine fallback hardcoded 150 Hz kick / 250 Hz snare / 5 kHz hat, and read snare `tone` and `noise` (Hz-valued, 100–400 and 1000–8000) as if they were 0–1 gains. It now uses kick `pitch`, snare `tone` and hat `pitch` as frequencies and normalizes `noise` to a gain, matching what `DrumKitEngine` already does. The kit engine is the primary path and already honored these.

## Acceptance criteria

- [x] TUNE on Synth A/B shifts pitch by the displayed semitone amount, live and sequenced
- [x] TUNE on Bass 2 does the same through its Open303 path
- [x] Drum TUNE audibly changes the sound — already true via `DrumKitEngine`; the legacy fallback now matches
- [x] Value persists — synth params are saved wholesale via `useSongStorage`, `pitch` included; no change needed
- [x] No regression to LEVEL or other knobs — all edits are confined to pitch/frequency computation

## Behavior change worth flagging

`DEFAULT_SYNTH_PARAMS_B` and `DEFAULT_BASS2_PARAMS` both ship `pitch: -12`, which was previously inaudible. With the knob wired up, those parts now sound an octave lower — which is what their knobs have always displayed. Saved patterns storing `-12` shift the same way. I left the defaults alone since the intent looks deliberate, but say the word and I'll reset them to `0` to preserve the current out-of-the-box sound.

## Testing

- New unit tests for the offset helpers (5 passing)
- `tsc --noEmit` clean
- ESLint clean on all touched files
- Existing suites pass: `DrumKitEngine`, `Open303Config`, `projectPersistence`, `src/utils/__tests__` — 110 passing. One pre-existing unrelated failure, `fft.spec.ts`, from a missing `src/wasm/fft.wasm` build artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsjyRNqiRdhQM5Scr43bCj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsjyRNqiRdhQM5Scr43bCj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent pitch transposition across synthesized instruments, interactive playback, MIDI notes, and legato slides.
  * Added safe pitch-offset handling with bounded semitone adjustments.
  * Improved fallback drum synthesis with tuned kick, snare, and hi-hat parameters.

* **Bug Fixes**
  * Corrected snare tone and noise volume behavior.
  * Added safeguards to prevent invalid or excessively low drum frequencies.

* **Tests**
  * Added coverage for pitch-offset defaults, limits, MIDI transposition, and frequency calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->