### PR TITLE
Add octave shifting to the live keyboard

### DIFF
--- a/src/__tests__/LiveKeyboard.test.tsx
+++ b/src/__tests__/LiveKeyboard.test.tsx
@@ -2,6 +2,10 @@ import { render, fireEvent } from '@testing-library/react';
 import { LiveKeyboard } from '../components/LiveKeyboard';
 
 describe('LiveKeyboard', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   test('calls onPlayNote and onStopNote on key events', () => {
     const onPlay = vi.fn();
     const onStop = vi.fn();
@@ -46,5 +50,107 @@ describe('LiveKeyboard', () => {
 
     fireEvent.keyUp(input, { code: 'F7', bubbles: true });
     expect(onStop).not.toHaveBeenCalled();
+  });
+
+  describe('octave shifting', () => {
+    test('PC keys respect the octave offset', () => {
+      const onPlay = vi.fn();
+      const { getByLabelText } = render(
+        <LiveKeyboard onPlayNote={onPlay} onStopNote={vi.fn()} activeTrackColor="#fff" />
+      );
+
+      fireEvent.keyDown(window, { code: 'F8' });
+      expect(onPlay).toHaveBeenCalledWith('C5');
+      fireEvent.keyUp(window, { code: 'F8' });
+
+      onPlay.mockClear();
+      fireEvent.click(getByLabelText('Octave down'));
+      fireEvent.keyDown(window, { code: 'F8' });
+      expect(onPlay).toHaveBeenCalledWith('C4');
+    });
+
+    test('mouse keys respect the octave offset', () => {
+      const onPlay = vi.fn();
+      const { getByLabelText, getByText } = render(
+        <LiveKeyboard onPlayNote={onPlay} onStopNote={vi.fn()} activeTrackColor="#fff" />
+      );
+
+      fireEvent.click(getByLabelText('Octave up'));
+      // Key labels re-render at the new octave
+      fireEvent.mouseDown(getByText('C6'));
+      expect(onPlay).toHaveBeenCalledWith('C6');
+    });
+
+    test('bracket shortcuts shift the octave down and up', () => {
+      const onPlay = vi.fn();
+      const { getByText } = render(
+        <LiveKeyboard onPlayNote={onPlay} onStopNote={vi.fn()} activeTrackColor="#fff" />
+      );
+
+      fireEvent.keyDown(window, { code: 'BracketLeft' });
+      expect(getByText('OCT 4')).toBeTruthy();
+
+      fireEvent.keyDown(window, { code: 'BracketRight' });
+      fireEvent.keyDown(window, { code: 'BracketRight' });
+      expect(getByText('OCT 6')).toBeTruthy();
+
+      fireEvent.keyDown(window, { code: 'F8' });
+      expect(onPlay).toHaveBeenCalledWith('C6');
+    });
+
+    test('ignores octave shortcuts while typing in an input', () => {
+      const { getByTestId, getByText } = render(
+        <div>
+          <input data-testid="test-input" />
+          <LiveKeyboard onPlayNote={vi.fn()} onStopNote={vi.fn()} activeTrackColor="#fff" />
+        </div>
+      );
+
+      fireEvent.keyDown(getByTestId('test-input'), { code: 'BracketLeft', bubbles: true });
+      expect(getByText('OCT 5')).toBeTruthy();
+    });
+
+    test('re-triggers held notes at the new octave when shifted mid-hold', () => {
+      const onPlay = vi.fn();
+      const onStop = vi.fn();
+      render(<LiveKeyboard onPlayNote={onPlay} onStopNote={onStop} activeTrackColor="#fff" />);
+
+      fireEvent.keyDown(window, { code: 'F8' });
+      expect(onPlay).toHaveBeenCalledWith('C5');
+
+      onPlay.mockClear();
+      fireEvent.keyDown(window, { code: 'BracketLeft' });
+      expect(onStop).toHaveBeenCalledWith('C5');
+      expect(onPlay).toHaveBeenCalledWith('C4');
+    });
+
+    test('clamps at the range bounds and disables the button', () => {
+      const { getByLabelText, getByText } = render(
+        <LiveKeyboard onPlayNote={vi.fn()} onStopNote={vi.fn()} activeTrackColor="#fff" />
+      );
+
+      for (let i = 0; i < 10; i++) fireEvent.keyDown(window, { code: 'BracketLeft' });
+      expect(getByText('OCT 1')).toBeTruthy();
+      expect((getByLabelText('Octave down') as HTMLButtonElement).disabled).toBe(true);
+
+      for (let i = 0; i < 20; i++) fireEvent.keyDown(window, { code: 'BracketRight' });
+      expect(getByText('OCT 7')).toBeTruthy();
+      expect((getByLabelText('Octave up') as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    test('persists the octave across remounts', () => {
+      const first = render(
+        <LiveKeyboard onPlayNote={vi.fn()} onStopNote={vi.fn()} activeTrackColor="#fff" />
+      );
+      fireEvent.keyDown(window, { code: 'BracketLeft' });
+      fireEvent.keyDown(window, { code: 'BracketLeft' });
+      expect(first.getByText('OCT 3')).toBeTruthy();
+      first.unmount();
+
+      const second = render(
+        <LiveKeyboard onPlayNote={vi.fn()} onStopNote={vi.fn()} activeTrackColor="#fff" />
+      );
+      expect(second.getByText('OCT 3')).toBeTruthy();
+    });
   });
 });

--- a/src/components/LiveKeyboard.tsx
+++ b/src/components/LiveKeyboard.tsx
@@ -1,24 +1,31 @@
 import { useState, useEffect, memo, useRef, useMemo, useCallback } from 'react';
 import { getNoteColor } from '../utils/noteColors';
 import { useFocusTrap } from '../hooks/useFocusTrap';
+import {
+    clampOctave, noteForOffset, loadStoredOctave, storeOctave,
+    MIN_KEYBOARD_OCTAVE, MAX_KEYBOARD_OCTAVE,
+} from '../utils/keyboardOctave';
 
 interface LiveKeyboardProps { onPlayNote: (note: string) => void; onStopNote?: (note: string) => void; activeTrackColor?: string; }
 
-// PC Key Mapping for Classic Piano Layout
-// Top row: 5 black keys (C#5, D#5, F#5, G#5, A#5) - mapped to keys 9, 8, 6, 5, 4
-// Bottom row: 8 white keys (C5, D5, E5, F5, G5, A5, B5, C6) - mapped to F8-F1
-const PC_KEY_MAPPING: Record<string, string> = {
+// PC Key Mapping for Classic Piano Layout.
+// Values are semitone offsets from the C of the current base octave, so the
+// whole layout follows the octave shift. At the default octave (5) these are
+// C5..C6 with black keys C#5, D#5, F#5, G#5, A#5.
+// Top row: 5 black keys - mapped to keys 9, 8, 6, 5, 4
+// Bottom row: 8 white keys - mapped to F8-F1
+const PC_KEY_MAPPING: Record<string, number> = {
     // F-key row (bottom) - White keys
-    'F8': 'C5',   'F7': 'D5',   'F6': 'E5',   'F5': 'F5',
-    'F4': 'G5',   'F3': 'A5',   'F2': 'B5',   'F1': 'C6',
+    'F8': 0,   'F7': 2,   'F6': 4,   'F5': 5,
+    'F4': 7,   'F3': 9,   'F2': 11,  'F1': 12,
     // Digit row (top) - Black keys (staggered between white keys)
-    'Digit9': 'C#5',  'Digit8': 'D#5',  'Digit6': 'F#5',  'Digit5': 'G#5',  'Digit4': 'A#5',
+    'Digit9': 1,  'Digit8': 3,  'Digit6': 6,  'Digit5': 8,  'Digit4': 10,
 };
 
-const NOTE_TO_KEY = Object.entries(PC_KEY_MAPPING).reduce((acc, [keyCode, note]) => {
-    acc[note] = keyCode;
-    return acc;
-}, {} as Record<string, string>);
+// Octave shift shortcuts. Chosen to avoid the F-key and digit-row piano
+// mapping above: [ shifts down, ] shifts up.
+const OCTAVE_DOWN_CODE = 'BracketLeft';
+const OCTAVE_UP_CODE = 'BracketRight';
 
 const formatKeyLabel = (code: string) => {
     if (code.startsWith('Digit')) return code.replace('Digit', '');
@@ -58,6 +65,7 @@ const KeyboardGuide = ({ onClose }: { onClose: () => void }) => {
                 <div className="text-center mb-8">
                     <h3 id="keyboard-guide-title" className="text-2xl font-orbitron font-bold text-cyan-400 mb-2 tracking-widest">PIANO KEYBOARD</h3>
                     <p className="text-gray-400 font-mono text-sm">Classic piano layout with 5 black keys and 8 white keys.</p>
+                    <p className="text-gray-500 font-mono text-xs mt-2">Press <span className="text-cyan-400">[</span> and <span className="text-cyan-400">]</span> to shift the keyboard down or up an octave.</p>
                 </div>
 
                 {/* Visual Schematic — two groups: {C D E F} and {G A B C} */}
@@ -147,6 +155,8 @@ const KeyboardGuide = ({ onClose }: { onClose: () => void }) => {
 // --- PIANO KEY COMPONENT ---
 interface PianoKeyProps {
     note: string;
+    /** Semitone offset from the base octave's C — what the handlers receive. */
+    offset: number;
     x: number;
     y: number;
     width: number;
@@ -156,13 +166,13 @@ interface PianoKeyProps {
     isActive: boolean;
     isHeldByMouse: boolean;
     activeColor: string;
-    onMouseDown: (note: string) => void;
-    onMouseEnter: (note: string) => void;
+    onMouseDown: (offset: number) => void;
+    onMouseEnter: (offset: number) => void;
     onStopMouse: () => void;
 }
 
 const PianoKey = memo(({
-    note, x, y, width, height, label, isBlack,
+    note, offset, x, y, width, height, label, isBlack,
     isActive, activeColor, onMouseDown, onMouseEnter, onStopMouse
 }: PianoKeyProps) => {
     const noteBase = getNoteBase(note);
@@ -175,7 +185,7 @@ const PianoKey = memo(({
     const handleKeyDown = (e: React.KeyboardEvent) => {
         if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
-            onMouseDown(note);
+            onMouseDown(offset);
         } else if (e.key === 'Escape') {
             e.preventDefault();
             onStopMouse();
@@ -189,11 +199,11 @@ const PianoKey = memo(({
             aria-label={`Play ${note}`}
             aria-pressed={isActive}
             tabIndex={0}
-            onMouseDown={(e) => { if (e.button === 0) onMouseDown(note); }}
-            onMouseEnter={(e) => { if (e.buttons === 1) onMouseEnter(note); else onStopMouse(); }}
+            onMouseDown={(e) => { if (e.button === 0) onMouseDown(offset); }}
+            onMouseEnter={(e) => { if (e.buttons === 1) onMouseEnter(offset); else onStopMouse(); }}
             onMouseUp={onStopMouse}
             onMouseLeave={onStopMouse}
-            onTouchStart={(e) => { e.preventDefault(); onMouseDown(note); }}
+            onTouchStart={(e) => { e.preventDefault(); onMouseDown(offset); }}
             onTouchEnd={(e) => { e.preventDefault(); onStopMouse(); }}
             onKeyDown={handleKeyDown}
             cursor="pointer"
@@ -297,20 +307,31 @@ const PianoKey = memo(({
 });
 
 export const LiveKeyboard = memo(({ onPlayNote, onStopNote, activeTrackColor: _activeTrackColor }: LiveKeyboardProps) => {
-    const [heldByKeys, setHeldByKeys] = useState<Set<string>>(new Set());
-    const [heldByMouse, setHeldByMouse] = useState<string | null>(null);
+    // Held keys are tracked as semitone offsets, not note names, so shifting
+    // the octave re-derives every sounding note. The diffing effect below then
+    // stops the old pitches and starts the new ones.
+    const [heldByKeys, setHeldByKeys] = useState<Set<number>>(new Set());
+    const [heldByMouse, setHeldByMouse] = useState<number | null>(null);
     const [showGuide, setShowGuide] = useState(false);
+    const [octave, setOctave] = useState(() => loadStoredOctave());
 
     const heldByMouseRef = useRef(heldByMouse);
     useEffect(() => { heldByMouseRef.current = heldByMouse; }, [heldByMouse]);
 
     const playingNotesRef = useRef<Set<string>>(new Set());
 
+    useEffect(() => { storeOctave(octave); }, [octave]);
+
+    const shiftOctave = useCallback((delta: number) => {
+        setOctave(prev => clampOctave(prev + delta));
+    }, []);
+
     const targetActiveNotes = useMemo(() => {
-        const active = new Set(heldByKeys);
-        if (heldByMouse) active.add(heldByMouse);
+        const active = new Set<string>();
+        heldByKeys.forEach(offset => active.add(noteForOffset(offset, octave)));
+        if (heldByMouse !== null) active.add(noteForOffset(heldByMouse, octave));
         return active;
-    }, [heldByKeys, heldByMouse]);
+    }, [heldByKeys, heldByMouse, octave]);
 
     useEffect(() => {
         const currentlyPlaying = playingNotesRef.current;
@@ -335,20 +356,29 @@ export const LiveKeyboard = memo(({ onPlayNote, onStopNote, activeTrackColor: _a
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
-            const note = PC_KEY_MAPPING[e.code];
-            if (note && !e.repeat) {
+            if (e.target instanceof HTMLElement && e.target.isContentEditable) return;
+
+            if (e.code === OCTAVE_DOWN_CODE || e.code === OCTAVE_UP_CODE) {
                 e.preventDefault();
-                setHeldByKeys(prev => new Set(prev).add(note));
+                if (!e.repeat) shiftOctave(e.code === OCTAVE_UP_CODE ? 1 : -1);
+                return;
+            }
+
+            const offset = PC_KEY_MAPPING[e.code];
+            if (offset !== undefined && !e.repeat) {
+                e.preventDefault();
+                setHeldByKeys(prev => new Set(prev).add(offset));
             }
         };
         const handleKeyUp = (e: KeyboardEvent) => {
             if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
-            const note = PC_KEY_MAPPING[e.code];
-            if (note) {
+            if (e.target instanceof HTMLElement && e.target.isContentEditable) return;
+            const offset = PC_KEY_MAPPING[e.code];
+            if (offset !== undefined) {
                 e.preventDefault();
                 setHeldByKeys(prev => {
                     const next = new Set(prev);
-                    next.delete(note);
+                    next.delete(offset);
                     return next;
                 });
             }
@@ -364,12 +394,12 @@ export const LiveKeyboard = memo(({ onPlayNote, onStopNote, activeTrackColor: _a
             window.removeEventListener('keyup', handleKeyUp);
             window.removeEventListener('blur', handleBlur);
         };
-    }, []);
+    }, [shiftOctave]);
 
     // --- MOUSE EVENT HANDLERS ---
-    const handleMouseDownStable = useCallback((note: string) => setHeldByMouse(note), []);
-    const handleMouseEnterStable = useCallback((note: string) => {
-        if (heldByMouseRef.current !== null) setHeldByMouse(note);
+    const handleMouseDownStable = useCallback((offset: number) => setHeldByMouse(offset), []);
+    const handleMouseEnterStable = useCallback((offset: number) => {
+        if (heldByMouseRef.current !== null) setHeldByMouse(offset);
     }, []);
     const handleStopMouseStable = useCallback(() => setHeldByMouse(null), []);
 
@@ -384,19 +414,19 @@ export const LiveKeyboard = memo(({ onPlayNote, onStopNote, activeTrackColor: _a
     const blackKeyHeight = whiteKeyHeight * 0.75; // Increased from 0.65 to 0.75
     const rowGap = 5;
 
-    // White keys (bottom row)
-    const whiteNotes = ['C5', 'D5', 'E5', 'F5', 'G5', 'A5', 'B5', 'C6'];
+    // White keys (bottom row) — semitone offsets from the base octave's C
+    const whiteOffsets = [0, 2, 4, 5, 7, 9, 11, 12];
     const whiteKeyCodes = ['F8', 'F7', 'F6', 'F5', 'F4', 'F3', 'F2', 'F1'];
 
     // Black keys (top row) - positioned between specific white keys
     // C# between C-D, D# between D-E, F# between F-G, G# between G-A, A# between A-B
     // Positions: after key 0 (C), after key 1 (D), after key 3 (F), after key 4 (G), after key 5 (A)
     const blackKeyData = [
-        { note: 'C#5', keyCode: 'Digit9', position: 0 }, // Between C and D
-        { note: 'D#5', keyCode: 'Digit8', position: 1 }, // Between D and E
-        { note: 'F#5', keyCode: 'Digit6', position: 3 }, // Between F and G
-        { note: 'G#5', keyCode: 'Digit5', position: 4 }, // Between G and A
-        { note: 'A#5', keyCode: 'Digit4', position: 5 }, // Between A and B
+        { offset: 1,  keyCode: 'Digit9', position: 0 }, // C# between C and D
+        { offset: 3,  keyCode: 'Digit8', position: 1 }, // D# between D and E
+        { offset: 6,  keyCode: 'Digit6', position: 3 }, // F# between F and G
+        { offset: 8,  keyCode: 'Digit5', position: 4 }, // G# between G and A
+        { offset: 10, keyCode: 'Digit4', position: 5 }, // A# between A and B
     ];
 
     const whiteRowY = blackKeyHeight + rowGap;
@@ -404,7 +434,36 @@ export const LiveKeyboard = memo(({ onPlayNote, onStopNote, activeTrackColor: _a
 
     return (
         <div className="w-full max-w-[820px] mx-auto mt-4 select-none relative">
-            {/* PIANO LAYOUT INFO Banner */}
+            {/* OCTAVE CONTROLS + PIANO LAYOUT INFO Banner */}
+            <div className="absolute -top-7 left-0 flex items-center gap-1 z-40">
+                <button
+                    type="button"
+                    onClick={() => shiftOctave(-1)}
+                    disabled={octave <= MIN_KEYBOARD_OCTAVE}
+                    aria-label="Octave down"
+                    title="Octave down ( [ )"
+                    className="text-[10px] text-cyan-500/80 hover:text-cyan-400 disabled:text-gray-700 disabled:hover:text-gray-700 font-mono px-2 py-1 rounded border border-cyan-900/30 bg-black/20 hover:bg-black/40 disabled:bg-black/10 transition-all"
+                >
+                    <span aria-hidden="true">−</span>
+                </button>
+                <span className="text-[10px] font-mono tracking-wider text-cyan-400 px-2 py-1 rounded border border-cyan-900/30 bg-black/30 tabular-nums">
+                    OCT {octave}
+                </span>
+                <button
+                    type="button"
+                    onClick={() => shiftOctave(1)}
+                    disabled={octave >= MAX_KEYBOARD_OCTAVE}
+                    aria-label="Octave up"
+                    title="Octave up ( ] )"
+                    className="text-[10px] text-cyan-500/80 hover:text-cyan-400 disabled:text-gray-700 disabled:hover:text-gray-700 font-mono px-2 py-1 rounded border border-cyan-900/30 bg-black/20 hover:bg-black/40 disabled:bg-black/10 transition-all"
+                >
+                    <span aria-hidden="true">+</span>
+                </button>
+                <span role="status" aria-live="polite" className="sr-only">
+                    {`Octave ${octave}, keys ${noteForOffset(0, octave)} to ${noteForOffset(12, octave)}`}
+                </span>
+            </div>
+
             <div className="absolute -top-7 right-0 flex items-center gap-2 z-40">
                 <button type="button" onClick={() => setShowGuide(true)} aria-label="Show Keyboard Layout Guide" title="Show Keyboard Layout Guide" className="flex items-center gap-1 text-[10px] text-cyan-500/80 hover:text-cyan-400 font-mono tracking-wider px-2 py-1 rounded border border-cyan-900/30 bg-black/20 hover:bg-black/40 transition-all">
                     <span className="text-xs" aria-hidden="true">⌨</span> PIANO LAYOUT INFO
@@ -416,34 +475,40 @@ export const LiveKeyboard = memo(({ onPlayNote, onStopNote, activeTrackColor: _a
             {/* Piano Keyboard SVG */}
             <svg aria-hidden="true" viewBox={`0 0 ${totalWidth} ${svgHeight}`} className="w-full drop-shadow-2xl bg-black/20 rounded-lg p-2">
                 {/* White keys (bottom row) — group 1: C D E F (i=0–3), group 2: G A B C (i=4–7) */}
-                {whiteNotes.map((note, i) => (
-                    <PianoKey
-                        key={note}
-                        note={note}
-                        x={i < 4 ? i * whiteKeyWidth : i * whiteKeyWidth + fKeyGap}
-                        y={whiteRowY}
-                        width={whiteKeyWidth - 2}
-                        height={whiteKeyHeight}
-                        label={whiteKeyCodes[i].replace('F', 'F')}
-                        isBlack={false}
-                        isActive={targetActiveNotes.has(note)}
-                        isHeldByMouse={heldByMouse === note}
-                        activeColor={getNoteColor(note)}
-                        onMouseDown={handleMouseDownStable}
-                        onMouseEnter={handleMouseEnterStable}
-                        onStopMouse={handleStopMouseStable}
-                    />
-                ))}
+                {whiteOffsets.map((offset, i) => {
+                    const note = noteForOffset(offset, octave);
+                    return (
+                        <PianoKey
+                            key={offset}
+                            note={note}
+                            offset={offset}
+                            x={i < 4 ? i * whiteKeyWidth : i * whiteKeyWidth + fKeyGap}
+                            y={whiteRowY}
+                            width={whiteKeyWidth - 2}
+                            height={whiteKeyHeight}
+                            label={whiteKeyCodes[i]}
+                            isBlack={false}
+                            isActive={targetActiveNotes.has(note)}
+                            isHeldByMouse={heldByMouse === offset}
+                            activeColor={getNoteColor(note)}
+                            onMouseDown={handleMouseDownStable}
+                            onMouseEnter={handleMouseEnterStable}
+                            onStopMouse={handleStopMouseStable}
+                        />
+                    );
+                })}
 
                 {/* Black keys (top row) - positioned between white keys */}
                 {/* positions 0,1 → left group (C#,D#); positions 3,4,5 → right group (F#,G#,A#) */}
-                {blackKeyData.map(({ note, keyCode, position }) => {
+                {blackKeyData.map(({ offset, keyCode, position }) => {
+                    const note = noteForOffset(offset, octave);
                     // Shift right-group black keys by fKeyGap to align with the offset white keys
                     const x = (position + 1) * whiteKeyWidth - (blackKeyWidth / 2) + (position >= 3 ? fKeyGap : 0);
                     return (
                         <PianoKey
-                            key={note}
+                            key={offset}
                             note={note}
+                            offset={offset}
                             x={x}
                             y={0}
                             width={blackKeyWidth}
@@ -451,7 +516,7 @@ export const LiveKeyboard = memo(({ onPlayNote, onStopNote, activeTrackColor: _a
                             label={keyCode.replace('Digit', '')}
                             isBlack={true}
                             isActive={targetActiveNotes.has(note)}
-                            isHeldByMouse={heldByMouse === note}
+                            isHeldByMouse={heldByMouse === offset}
                             activeColor={getNoteColor(note)}
                             onMouseDown={handleMouseDownStable}
                             onMouseEnter={handleMouseEnterStable}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -233,7 +233,13 @@ const noteFrequencies: { [key: string]: number } = {
 };
 
 export const noteToFrequency = (note: string): number => {
-  return noteFrequencies[note] || 440.00; // Default to A4 if not found
+  const table = noteFrequencies[note];
+  if (table) return table;
+  // Outside the C2-B5 table (e.g. the live keyboard shifted up or down an
+  // octave): derive from MIDI rather than silently collapsing to A4.
+  const midi = noteToMidi(note);
+  if (midi > 0) return 440.00 * Math.pow(2, (midi - 69) / 12);
+  return 440.00;
 };
 
 

--- a/src/utils/__tests__/keyboardOctave.test.ts
+++ b/src/utils/__tests__/keyboardOctave.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    clampOctave,
+    noteForOffset,
+    loadStoredOctave,
+    storeOctave,
+    KEYBOARD_OCTAVE_STORAGE_KEY,
+    DEFAULT_KEYBOARD_OCTAVE,
+    MIN_KEYBOARD_OCTAVE,
+    MAX_KEYBOARD_OCTAVE,
+} from '../keyboardOctave';
+import { noteToMidi } from '../musicTheory';
+
+describe('keyboardOctave', () => {
+    describe('clampOctave', () => {
+        it('keeps in-range octaves', () => {
+            expect(clampOctave(5)).toBe(5);
+            expect(clampOctave(MIN_KEYBOARD_OCTAVE)).toBe(MIN_KEYBOARD_OCTAVE);
+            expect(clampOctave(MAX_KEYBOARD_OCTAVE)).toBe(MAX_KEYBOARD_OCTAVE);
+        });
+
+        it('clamps beyond the playable range', () => {
+            expect(clampOctave(-3)).toBe(MIN_KEYBOARD_OCTAVE);
+            expect(clampOctave(99)).toBe(MAX_KEYBOARD_OCTAVE);
+        });
+
+        it('falls back to the default for non-finite input', () => {
+            expect(clampOctave(NaN)).toBe(DEFAULT_KEYBOARD_OCTAVE);
+        });
+    });
+
+    describe('noteForOffset', () => {
+        it('reproduces the original C5-C6 layout at the default octave', () => {
+            const white = [0, 2, 4, 5, 7, 9, 11, 12];
+            expect(white.map(o => noteForOffset(o, 5)))
+                .toEqual(['C5', 'D5', 'E5', 'F5', 'G5', 'A5', 'B5', 'C6']);
+            const black = [1, 3, 6, 8, 10];
+            expect(black.map(o => noteForOffset(o, 5)))
+                .toEqual(['C#5', 'D#5', 'F#5', 'G#5', 'A#5']);
+        });
+
+        it('shifts every key with the octave', () => {
+            expect(noteForOffset(0, 4)).toBe('C4');
+            expect(noteForOffset(12, 4)).toBe('C5');
+            expect(noteForOffset(10, 2)).toBe('A#2');
+        });
+
+        it('clamps the octave so notes stay in range', () => {
+            expect(noteForOffset(0, 0)).toBe(`C${MIN_KEYBOARD_OCTAVE}`);
+            expect(noteForOffset(12, 42)).toBe(`C${MAX_KEYBOARD_OCTAVE + 1}`);
+        });
+
+        it('produces notes the synth engines can resolve to valid MIDI', () => {
+            for (let oct = MIN_KEYBOARD_OCTAVE; oct <= MAX_KEYBOARD_OCTAVE; oct++) {
+                for (let offset = 0; offset <= 12; offset++) {
+                    const midi = noteToMidi(noteForOffset(offset, oct));
+                    expect(midi).toBeGreaterThanOrEqual(0);
+                    expect(midi).toBeLessThanOrEqual(127);
+                }
+            }
+        });
+    });
+
+    describe('persistence', () => {
+        beforeEach(() => {
+            localStorage.clear();
+        });
+
+        it('defaults when nothing is stored', () => {
+            expect(loadStoredOctave()).toBe(DEFAULT_KEYBOARD_OCTAVE);
+        });
+
+        it('round-trips a stored octave', () => {
+            storeOctave(3);
+            expect(localStorage.getItem(KEYBOARD_OCTAVE_STORAGE_KEY)).toBe('3');
+            expect(loadStoredOctave()).toBe(3);
+        });
+
+        it('clamps and ignores garbage values', () => {
+            storeOctave(99);
+            expect(loadStoredOctave()).toBe(MAX_KEYBOARD_OCTAVE);
+            localStorage.setItem(KEYBOARD_OCTAVE_STORAGE_KEY, 'nonsense');
+            expect(loadStoredOctave()).toBe(DEFAULT_KEYBOARD_OCTAVE);
+        });
+    });
+});

--- a/src/utils/keyboardOctave.ts
+++ b/src/utils/keyboardOctave.ts
@@ -1,0 +1,59 @@
+/**
+ * Live keyboard octave shifting.
+ *
+ * The on-screen keyboard spans one octave plus the closing C (C..C of the
+ * next octave). Keys are stored as semitone offsets from the base octave's
+ * C so that a note name can be re-derived whenever the octave shifts.
+ */
+
+import { NOTES } from './musicTheory';
+
+/** Lowest selectable base octave — the keyboard then starts at C1. */
+export const MIN_KEYBOARD_OCTAVE = 1;
+/** Highest selectable base octave — the keyboard then ends at C8 (MIDI 108). */
+export const MAX_KEYBOARD_OCTAVE = 7;
+/** Base octave the keyboard starts on (C5..C6), matching the original layout. */
+export const DEFAULT_KEYBOARD_OCTAVE = 5;
+
+export const KEYBOARD_OCTAVE_STORAGE_KEY = 'webSequencer.liveKeyboard.octave';
+
+/** Clamp a base octave into the playable range. */
+export function clampOctave(octave: number): number {
+    if (!Number.isFinite(octave)) return DEFAULT_KEYBOARD_OCTAVE;
+    return Math.max(MIN_KEYBOARD_OCTAVE, Math.min(MAX_KEYBOARD_OCTAVE, Math.round(octave)));
+}
+
+/**
+ * Resolve a semitone offset from the base octave's C into a note name.
+ * Offset 0 is C of `octave`; offset 12 is C of the next octave up.
+ */
+export function noteForOffset(semitoneOffset: number, octave: number): string {
+    const base = clampOctave(octave);
+    const absolute = base * 12 + semitoneOffset;
+    const noteOctave = Math.floor(absolute / 12);
+    const index = ((absolute % 12) + 12) % 12;
+    return `${NOTES[index]}${noteOctave}`;
+}
+
+/** Read the persisted base octave, falling back to the default. */
+export function loadStoredOctave(): number {
+    try {
+        const raw = globalThis.localStorage?.getItem(KEYBOARD_OCTAVE_STORAGE_KEY);
+        if (raw === null || raw === undefined) return DEFAULT_KEYBOARD_OCTAVE;
+        const parsed = Number.parseInt(raw, 10);
+        if (Number.isNaN(parsed)) return DEFAULT_KEYBOARD_OCTAVE;
+        return clampOctave(parsed);
+    } catch {
+        // Storage can be unavailable (private mode, blocked cookies) — not fatal.
+        return DEFAULT_KEYBOARD_OCTAVE;
+    }
+}
+
+/** Persist the base octave; failures are ignored. */
+export function storeOctave(octave: number): void {
+    try {
+        globalThis.localStorage?.setItem(KEYBOARD_OCTAVE_STORAGE_KEY, String(clampOctave(octave)));
+    } catch {
+        // Ignore storage failures — the octave still applies for this session.
+    }
+}


### PR DESCRIPTION
## Summary

The live keyboard was fixed at C5–C6: note names were hard-coded into `PC_KEY_MAPPING` and into the SVG layout arrays. It can now be shifted an octave at a time, C1 through C8.

## Approach

The key change is that **held keys are tracked as semitone offsets, not note names**. `PC_KEY_MAPPING` and the white/black layout arrays now hold offsets from the base octave's C, and note names are derived at render time from `(offset, octave)`.

That makes the mid-hold question answer itself: when the octave changes, `targetActiveNotes` re-derives, and the component's existing diffing effect stops the old pitch and starts the new one. So **shifting while keys are held re-triggers them at the new octave** — no separate re-mapping code, and there's a test pinning the behavior.

## Controls

- **UI**: `− / OCT 5 / +` cluster at the top-left of the keyboard. Buttons disable at the bounds.
- **Shortcuts**: `[` down, `]` up. I picked brackets over `Z`/`X` because the piano mapping already occupies the F-key row and digits 4/5/6/8/9, and `KeyZ` is claimed by `useGamepad`. Both shortcuts are ignored while focus is in an input, textarea, or contenteditable — the existing guard only covered input/textarea, so I extended it to contenteditable for the note keys too.
- **Visual feedback**: SVG key labels re-render with the new note names; the `OCT n` readout updates.
- **Range**: base octave clamped to 1–7, so the span is C1–C8 and every generated note stays within valid MIDI. A test asserts this across the whole grid.
- **Persistence**: stored in `localStorage`; read failures (private mode, blocked storage) fall back to the default rather than throwing.
- **a11y**: `Octave down` / `Octave up` labels, plus an `aria-live="polite"` status announcing the octave and its note range.

`KeyboardNode` needs no changes — the state lives in `LiveKeyboard` and no octave props are required.

## Drive-by fix

`noteToFrequency` returned a flat 440 Hz for anything outside its C2–B5 table — including **C6, the keyboard's existing top key**, which has always sounded as A4 on the plain-oscillator path. It now derives the frequency from MIDI. Without this, shifting the octave would have produced 440 Hz across whole ranges.

## Testing

- `src/utils/__tests__/keyboardOctave.test.ts` — offset resolution (including that octave 5 reproduces the original layout exactly), clamping, persistence round-trip and garbage handling, and a sweep asserting every key at every octave lands in valid MIDI.
- `src/__tests__/LiveKeyboard.test.tsx` — PC keys and mouse keys both respect the offset, bracket shortcuts work, shortcuts are ignored while typing, mid-hold shifts stop-then-restart, bounds clamp and disable the buttons, octave survives a remount.
- Full suite: **1484 passing**, up from 1467 on `main`, no test failures. The 9 failing test *files* are pre-existing collection errors — all from `src/wasm/fft.wasm`, a build artifact not checked into the repo — and fail identically on `main`.
- `tsc --noEmit` and ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsjyRNqiRdhQM5Scr43bCj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsjyRNqiRdhQM5Scr43bCj)_