### PR TITLE
Fix PLAY transport never starting when Pyodide readiness gates the clock

### DIFF
--- a/src/hooks/__tests__/useScheduler.test.ts
+++ b/src/hooks/__tests__/useScheduler.test.ts
@@ -1,0 +1,110 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useScheduler } from '../useScheduler';
+
+// vitest.setup.ts installs a plain (non-spy) AudioContext / AudioWorkletNode mock
+// on `window`. These tests need to assert on construction + port messages, so we
+// swap in a spy-friendly AudioWorkletNode for the duration of this file.
+class FakeWorkletNode {
+    port: { postMessage: ReturnType<typeof vi.fn>; onmessage: unknown; addEventListener: ReturnType<typeof vi.fn>; removeEventListener: ReturnType<typeof vi.fn> };
+    connect = vi.fn();
+    disconnect = vi.fn();
+    constructor(..._args: unknown[]) {
+        this.port = {
+            postMessage: vi.fn(),
+            onmessage: null,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+        };
+        createdNodes.push(this);
+    }
+}
+
+let createdNodes: FakeWorkletNode[] = [];
+
+function makeContext(state: AudioContextState = 'running'): AudioContext {
+    const context = new (window.AudioContext as unknown as { new (): AudioContext })();
+    (context as { state: AudioContextState }).state = state;
+    return context;
+}
+
+describe('useScheduler', () => {
+    let originalWorkletNode: unknown;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        createdNodes = [];
+        originalWorkletNode = window.AudioWorkletNode;
+        (window as unknown as { AudioWorkletNode: unknown }).AudioWorkletNode = FakeWorkletNode;
+    });
+
+    afterEach(() => {
+        (window as unknown as { AudioWorkletNode: unknown }).AudioWorkletNode = originalWorkletNode;
+    });
+
+    it('does not start the AudioWorklet clock and logs a clear warning when the engine is not ready', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const context = makeContext();
+        const onStep = vi.fn();
+
+        const { result } = renderHook(() =>
+            useScheduler(120, 32, onStep, /* isAudioReady */ false, context),
+        );
+
+        act(() => {
+            result.current.setIsPlaying(true);
+        });
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(createdNodes).toHaveLength(0);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[useScheduler]'));
+    });
+
+    it('starts the AudioWorklet clock and posts a start message once the engine is ready', async () => {
+        const context = makeContext();
+        const onStep = vi.fn();
+
+        const { result } = renderHook(() =>
+            useScheduler(120, 32, onStep, /* isAudioReady */ true, context),
+        );
+
+        act(() => {
+            result.current.setIsPlaying(true);
+        });
+
+        await waitFor(() => expect(createdNodes).toHaveLength(1));
+
+        expect(createdNodes[0].port.postMessage).toHaveBeenCalledWith({ type: 'start' });
+        expect(createdNodes[0].connect).toHaveBeenCalledWith(context.destination);
+        expect(result.current.isPlaying).toBe(true);
+    });
+
+    it('stops the clock and leaves no orphan node when toggled off', async () => {
+        const context = makeContext();
+        const onStep = vi.fn();
+
+        const { result } = renderHook(() =>
+            useScheduler(120, 32, onStep, /* isAudioReady */ true, context),
+        );
+
+        act(() => {
+            result.current.setIsPlaying(true);
+        });
+
+        await waitFor(() => expect(createdNodes).toHaveLength(1));
+        const node = createdNodes[0];
+
+        act(() => {
+            result.current.setIsPlaying(false);
+        });
+
+        await waitFor(() => {
+            expect(node.port.postMessage).toHaveBeenCalledWith({ type: 'stop' });
+        });
+        expect(node.disconnect).toHaveBeenCalled();
+        expect(result.current.isPlaying).toBe(false);
+    });
+});

--- a/src/hooks/__tests__/useScheduler.test.ts
+++ b/src/hooks/__tests__/useScheduler.test.ts
@@ -30,6 +30,11 @@ function makeContext(state: AudioContextState = 'running'): AudioContext {
 
 describe('useScheduler', () => {
     let originalWorkletNode: unknown;
+    // Tracked explicitly (rather than via `vi.restoreAllMocks()`) because that
+    // would also wipe the shared `window.AudioContext` mock from
+    // vitest.setup.ts — it's a plain `vi.fn()`, not a spy, so "restoring" it
+    // clears its implementation and breaks every later test in this file.
+    let warnSpy: ReturnType<typeof vi.spyOn> | null = null;
 
     beforeEach(() => {
         vi.clearAllMocks();
@@ -40,10 +45,12 @@ describe('useScheduler', () => {
 
     afterEach(() => {
         (window as unknown as { AudioWorkletNode: unknown }).AudioWorkletNode = originalWorkletNode;
+        warnSpy?.mockRestore();
+        warnSpy = null;
     });
 
     it('does not start the AudioWorklet clock and logs a clear warning when the engine is not ready', async () => {
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
         const context = makeContext();
         const onStep = vi.fn();
 

--- a/src/hooks/useAppState.tsx
+++ b/src/hooks/useAppState.tsx
@@ -85,7 +85,10 @@ export function useAppState() {
     } = useTransportMixState();
 
     const { audioEngine, isReady, initializeAudio, onParamChange, drumKitEngineRef, prophecyManagerRef } = useAudioEngine(pyodide, tempo)
-    const isEngineReady = isReady && isPyodideReady
+    // Core sequencer transport only needs the Web Audio engine — it never touches
+    // Pyodide ("Spectral Puppet"), so gating playback on Python readiness left the
+    // clock permanently blocked whenever Pyodide was slow or failed to load.
+    const isEngineReady = isReady
 
     useTTSPreloader()
 

--- a/src/hooks/useAppState.tsx
+++ b/src/hooks/useAppState.tsx
@@ -226,7 +226,7 @@ export function useAppState() {
                 automationSchedulerRef.current.setOpen303Manager(mgr ?? null);
             }
             automationSchedulerRef.current.setPcfEffect(pcf);
-            automationSchedulerRef.current.setProphecyManager(prophecyManagerRef.current ?? null);
+            automationSchedulerRef.current.setProphecyManager(prophecyManagerRef?.current ?? null);
         }
     }, [audioEngine, prophecyManagerRef]);
 

--- a/src/hooks/useScheduler.ts
+++ b/src/hooks/useScheduler.ts
@@ -83,7 +83,14 @@ export const useScheduler = (
     }, [swing]);
 
     const startClock = useCallback(async () => {
-        if (!context || !isAudioReady) return;
+        if (!context || !isAudioReady) {
+            console.warn(
+                '[useScheduler] startClock called before the audio engine was ready — ' +
+                `context: ${context ? 'present' : 'null'}, isAudioReady: ${isAudioReady}. ` +
+                'Transport will not advance until the engine finishes initializing.',
+            );
+            return;
+        }
 
         if (context.state === 'suspended') {
             try {
@@ -148,6 +155,12 @@ export const useScheduler = (
         if (isPlaying && isAudioReady) {
             startClock();
         } else {
+            if (isPlaying && !isAudioReady) {
+                console.warn(
+                    '[useScheduler] Play was requested but the audio engine is not ready yet — ' +
+                    'the clock will start automatically once it is.',
+                );
+            }
             stopClock();
         }
         return () => stopClock();


### PR DESCRIPTION
## Summary

Pressing **▶ PLAY** did not start the 32-step sequencer: the playhead never advanced and programmed steps never fired.

## Root cause

`useAppState` derived the audio-engine readiness flag passed into `useScheduler` as:

```ts
const isEngineReady = isReady && isPyodideReady
```

`isReady` reflects the Web Audio engine (the thing `useScheduler`'s AudioWorklet clock actually needs), but `isPyodideReady` reflects the separate "Spectral Puppet" Python/Pyodide engine — which `useScheduler`, `clock-processor`, and `useStepHandler` never reference at all. Whenever Pyodide was slow to boot or failed to load, `isAudioReady` stayed `false` forever, so `useScheduler`'s internal effect kept calling `startClock()`'s guard clause (`if (!context || !isAudioReady) return;`) and silently no-op'd — no console output, no UI feedback, just a dead transport, matching the reported symptom exactly (UI may toggle to "playing" while nothing actually runs, since `isPlaying` in the scheduler is independent of whether the clock could actually start).

This was introduced in the most recent commit touching `useAppState.tsx` (`c326514`), which tightened the condition from a permissive `isReady && (isPyodideReady || !!pyodideStatus)` (effectively always-true, since `pyodideStatus` is never falsy) to a hard `isReady && isPyodideReady`.

## Fix

- **`src/hooks/useAppState.tsx`** — `isEngineReady` now derives from `isReady` alone; the sequencer transport no longer waits on the unrelated Pyodide engine.
- **`src/hooks/useScheduler.ts`** — added `console.warn` diagnostics for the previously-silent no-op paths (`startClock` invoked before the engine is ready, and play requested while not ready), per the issue's acceptance criteria that failure modes surface a clear error instead of a silent no-op.
- **`src/hooks/__tests__/useScheduler.test.ts`** (new) — regression coverage:
  - play requested while not ready → no `AudioWorkletNode` created, warning logged
  - play requested while ready → `AudioWorkletNode` created, `'start'` posted, `connect()` called
  - stopping → `'stop'` posted, node disconnected (no orphan node)

## Test plan

- [x] `npx vitest run src/hooks/__tests__/useScheduler.test.ts` — new tests pass on the fix, and the "silent no-op" test fails on the pre-fix code (verified via `git stash`), confirming it catches the regression.
- [x] `npx vitest run` — full suite: 1487 passed, 0 failed (9 pre-existing unrelated failures from missing local WASM build artifacts, present on `main` too).
- [x] `npx tsc -b` — clean.
- [x] `npx eslint` on changed files — clean.
- [ ] Manual browser smoke test (init → program step → play → playhead advances) not performed in this sandbox (no reachable dev/browser environment); recommend verifying in a full deploy before merge.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VgT5nLbcZ4UaRnrNLatiDf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Playback now starts as soon as the audio engine is ready, without waiting for unrelated initialization.
  * Added clear warnings when playback is requested before audio is available.
  * Improved playback start and stop behavior, including proper audio connection cleanup.

* **Tests**
  * Added coverage for audio readiness, playback controls, worklet startup, stopping, and disconnection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->