### PR TITLE
⚡ Bolt: Remove setTimeout from harmonizer audio dispatch

### DIFF
--- a/src/hooks/audioEngine/samplerPlayback.ts
+++ b/src/hooks/audioEngine/samplerPlayback.ts
@@ -888,9 +888,8 @@ const playSampler = (
 
             // Play this voice with pitch offset and slight delay for natural ensemble effect
             const delayMs = voice.index * 5;
-            setTimeout(() => {
-                playSamplerVoice(voiceParams, note, time + (delayMs / 1000), durationSteps, stepTime, undefined, voice.pitchOffset, tuning);
-            }, delayMs);
+            // ⚡ Bolt Optimization: Replace main-thread setTimeout with worklet/API-scheduled delayed start time
+            playSamplerVoice(voiceParams, note, time + (delayMs / 1000), durationSteps, stepTime, undefined, voice.pitchOffset, tuning);
         }
         return;
     }


### PR DESCRIPTION
💡 **What**: Removed the `setTimeout` wrapper around `playSamplerVoice` in the `samplerPlayback.ts` harmonizer dispatch loop.
🎯 **Why**: The JS `setTimeout` causes main thread scheduling jitter which misaligns with the sample-accurate Web Audio clock. Furthermore, allocating an anonymous arrow function inside `setTimeout` for every harmony voice on every triggered step creates significant main-thread garbage collection (GC) pressure. `playSamplerVoice` already correctly delays playback using its `time` argument, so the JS timer is redundant.
📊 **Impact**: Eliminates main-thread closure memory allocations and event loop jitter for polyphonic sampler playback, resulting in tighter audio timing and fewer audio micro-stutters during high-BPM playback.
🔬 **Measurement**: Verified the change successfully compiles and doesn't introduce breakages on top of existing `main` failures. (Note: pre-existing syntax errors in `WebGpu303Engine.test.ts` and `VoiceManager.ts` remain untouched).

---
*PR created automatically by Jules for task [15708191120607229987](https://jules.google.com/task/15708191120607229987) started by @ford442*