### PR TITLE
Fix TS1005 parse error in WebGpu303Engine.test.ts

### DIFF
--- a/src/__tests__/WebGpu303Engine.test.ts
+++ b/src/__tests__/WebGpu303Engine.test.ts
@@ -53,8 +53,6 @@ describe('gpu-highfid registry', () => {
     ).toBe(true);
   });
 
-  it('normalizeTB303Model falls back to stock for offline-only voices', () => {
-    expect(normalizeTB303Model('gpu-highfid')).toBe('stock-open303');
   it('normalizeTB303Model preserves gpu-highfid for persistence', () => {
     expect(normalizeTB303Model('gpu-highfid')).toBe('gpu-highfid');
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a TypeScript parse error (`TS1005: '}' expected`) in `src/__tests__/WebGpu303Engine.test.ts`.

A duplicate `normalizeTB303Model` test was missing its closing `});`, which left the `describe('gpu-highfid registry')` block unclosed. The removed test also had an incorrect expectation (`stock-open303`) — `normalizeTB303Model` preserves `gpu-highfid` for persistence; realtime fallback to stock is handled by `resolveRealtimeTB303Model` (already covered in `TB303Models.test.ts`).

## Test plan

- [x] `npx tsc -b` — no parse errors in this file
- [x] `CI=true pnpm exec vitest run src/__tests__/WebGpu303Engine.test.ts --pool forks` — 12/12 passing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d557146-52c4-4b16-bb84-e4c9ea3eb242?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d557146-52c4-4b16-bb84-e4c9ea3eb242&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the selected GPU high-fidelity TB-303 model when saving and restoring settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->