### PR TITLE
refactor(audio): centralize VoiceManager state syncing into VoicePool

### DIFF
--- a/.Jules/agent_plan.md
+++ b/.Jules/agent_plan.md
@@ -8,6 +8,7 @@
 - [ ] Add granular synthesis window shape control for TTS playback
 
 ## Innovation Lab
+- [ ] What if we could link voice affinity directly to WebGPU/WASM buffers, preventing redundant host-to-device memory copies on voice steal?
 - [x] Implement reverse TTS sample per step
 - [x] Implement Phoneme Envelope shaping per step
 - [x] Implement Expressive Note Transitions for Vowels
@@ -19,13 +20,13 @@
 - [x] Add Formant Modulation LFO
 - [x] Add Formant Glide per phoneme
 - [ ] Add granular random jitter per phoneme
-- [ ] Optimize Voice Manager state syncing
 - [x] Optimize Voice Manager state syncing
 - [x] Add granular synthesis window shape control for TTS playback
 - [x] What if we could apply an LFO to the TTS formant shift directly from the step sequencer?
 
 ## Refactoring Roadblocks
 - Ensure all VoiceManagers (e.g., VoiceManager, SingingVoiceManager) use similar logic patterns for acquiring/releasing/stopping voices to prevent unexpected UI/Audio desync issues.
+- Now that VoicePool centralizes state syncing, consider abstracting fallback engine management from VoiceManager into a general sub-manager.
 
 ## Architecture Review
 - Velocity Check: The optimization task was straightforward. For the next run, I should consider a more complex architectural goal, such as unifying the voice allocation logic across all Synth and Sampler engines into a generic VoicePool base class to reduce duplication.

--- a/src/__tests__/playbackStress.test.ts
+++ b/src/__tests__/playbackStress.test.ts
@@ -183,9 +183,9 @@ describe('playback stress — voice allocation', () => {
     const ctx = new AudioContext();
     const mgr = new SingingVoiceManager(ctx, 2);
     const noteOff = vi.fn();
-    (mgr as unknown as { voices: Array<{ noteOff: typeof noteOff }> }).voices = [
-      { noteOff },
-      { noteOff: vi.fn() },
+    (mgr as unknown as { voices: Array<{ noteOff: typeof noteOff, isActive: boolean }> }).voices = [
+      { noteOff, isActive: true },
+      { noteOff: vi.fn(), isActive: true },
     ];
 
     mgr.registerActiveVoice(0, 'C4', 0);

--- a/src/engines/SingingVoiceManager.ts
+++ b/src/engines/SingingVoiceManager.ts
@@ -61,11 +61,15 @@ export class SingingVoiceManager extends VoicePool<SingingVoice> {
     protected override onStolen(voice: SingingVoice, index: number, time?: number): void {
         super.onStolen(voice, index, time);
         playbackHealthMonitor.recordVoiceSteal('singingVoice');
-        this.activeVoices.delete(index);
     }
 
     protected override stopVoice(voice: SingingVoice, time?: number): void {
         voice.noteOff(time ?? this.audioContext.currentTime);
+    }
+
+    protected override markInactive(index: number): void {
+        super.markInactive(index);
+        this.activeVoices.delete(index);
     }
 
     /**
@@ -111,7 +115,6 @@ export class SingingVoiceManager extends VoicePool<SingingVoice> {
      */
     releaseVoice(index: number) {
         this.markInactive(index);
-        this.activeVoices.delete(index);
     }
 
     /**
@@ -138,6 +141,5 @@ export class SingingVoiceManager extends VoicePool<SingingVoice> {
 
     override stopAll(time?: number) {
         super.stopAll(time ?? this.audioContext.currentTime);
-        this.activeVoices.clear();
     }
 }

--- a/src/engines/VoiceManager.ts
+++ b/src/engines/VoiceManager.ts
@@ -487,14 +487,6 @@ export class VoiceManager extends VoicePool<Voice> {
 
     /** Prefer idle voices; stop and steal the round-robin victim when saturated. */
     private pickVoice(time: number): Voice {
-        // We can optionally clean up `activeIndices` if `voice.isActive` went false externally.
-        // E.g., Voice has an internal timeout for release. Let's sync `activeIndices` with real `isActive`.
-        for (let i = 0; i < this.voices.length; i++) {
-            if (!this.voices[i]!.isActive && this.activeIndices.has(i)) {
-                this.markInactive(i);
-            }
-        }
-
         if (this.monophonic) {
             const result = this.acquire({ steal: 'round-robin', time });
             // Since it's monophonic, maxVoices is 1, so index is always 0.

--- a/src/engines/__tests__/SingingVoiceManager.test.ts
+++ b/src/engines/__tests__/SingingVoiceManager.test.ts
@@ -7,6 +7,7 @@ vi.mock('../SingingVoice', () => {
         // vitest 4 invokes mock implementations with `new` via Reflect.construct,
         // so the implementation must be a constructable function, not an arrow.
         SingingVoice: vi.fn().mockImplementation(function () { return {
+            isActive: false,
             initWorklet: vi.fn().mockResolvedValue(undefined),
             connectOutput: vi.fn(),
             disconnectOutput: vi.fn(),
@@ -54,10 +55,12 @@ describe('SingingVoiceManager', () => {
 
         const v1 = manager.acquireVoice();
         manager.registerActiveVoice(v1.index, 'C4', 0);
+        v1.voice.isActive = true;
         expect(v1.index).toBe(0);
 
         const v2 = manager.acquireVoice();
         manager.registerActiveVoice(v2.index, 'E4', 0);
+        v2.voice.isActive = true;
         expect(v2.index).toBe(1);
     });
 
@@ -68,6 +71,7 @@ describe('SingingVoiceManager', () => {
         for (let i = 0; i < 4; i++) {
             const v = manager.acquireVoice();
             manager.registerActiveVoice(v.index, `Note${i}`, i * 10); // Start times: 0, 10, 20, 30
+            v.voice.isActive = true;
         }
 
         // Try to acquire 5th voice
@@ -84,6 +88,7 @@ describe('SingingVoiceManager', () => {
         manager.registerActiveVoice(v1.index, 'C4', 0);
 
         manager.releaseVoice(v1.index);
+        v1.voice.isActive = false;
 
         // Should get index 0 again as it's free
         const v2 = manager.acquireVoice();

--- a/src/engines/base/VoicePool.ts
+++ b/src/engines/base/VoicePool.ts
@@ -37,10 +37,24 @@ export abstract class VoicePool<TVoice extends PoolableVoice> {
     }
 
     /**
+     * Synchronizes the pool's internal active tracking with the actual state of the voices.
+     * Useful if voices can go inactive internally (e.g. self-terminating envelopes).
+     */
+    public syncActiveState(): void {
+        for (let i = 0; i < this.maxVoices; i++) {
+            if (this.voices[i] && !this.voices[i]!.isActive && this.activeIndices.has(i)) {
+                this.markInactive(i);
+            }
+        }
+    }
+
+    /**
      * Core allocation logic. Finds an idle voice, optionally matching an affinity key,
      * or steals one based on the specified policy.
      */
     protected acquire(options: AcquireOptions = {}): AcquireResult<TVoice> {
+        this.syncActiveState();
+
         const { affinityKey, steal = 'round-robin', time } = options;
 
         // 1. Find free voice with affinity match


### PR DESCRIPTION
This PR refactors the polyphonic `VoicePool` to centrally handle the synchronization of active voice states, instead of relying on `VoiceManager` and `SingingVoiceManager` to manually duplicate this logic or rely on potentially stale `.delete()` calls. 

This architectural improvement enforces a cleaner state flow by checking `isActive` locally inside `acquire()`, ensuring out-of-band envelope terminations don't lead to UI/Audio desync issues or orphaned internal reference maps. It also updates the agent plan with a completed task and logs a new potential refactor for fallback engines.

---
*PR created automatically by Jules for task [780246277633334895](https://jules.google.com/task/780246277633334895) started by @ford442*