### PR TITLE
🎨 Palette: Voice Editor empty state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -26,3 +26,6 @@
 ## 2026-08-04 - Consistent Empty States for Filtered Lists
 **Learning:** When creating empty states for search or filter results (like in CloudLibrary where `filteredSongs.length === 0`), it's not enough to just add text. Following the standardized empty state pattern (dashed border, circular background with an SVG icon, clear text, and a CTA) significantly improves the UX and maintains visual consistency across the app, especially in contrast to completely blank empty states.
 **Action:** When asked to improve a zero-data or filtered list state, look for the standard components: `<div className="w-12 h-12 bg-gray-800 rounded-full flex items-center justify-center">` surrounding an SVG, along with the `border-dashed` container style.
+## 2026-08-10 - Apply standardized empty states universally
+**Learning:** Certain UI regions, such as the initial state of the Voice Editor canvas (which was just a black box when no voice was loaded), heavily benefit from the standard dashed-border empty state pattern. Without it, users may think the application has frozen or an error occurred. The standard pattern gives immediate visual feedback on the state and clarifies next actions.
+**Action:** Identify blank spaces or placeholders that represent "no active selection" and implement the unified empty state design to reinforce application consistency.

--- a/src/components/VoiceEditor.tsx
+++ b/src/components/VoiceEditor.tsx
@@ -113,10 +113,26 @@ export const VoiceEditor: React.FC<VoiceEditorProps> = React.memo(({ onClose }) 
 
                 {/* Heatmap Area */}
                 <div className="border border-gray-700 bg-black mb-4 h-48 relative rounded overflow-hidden">
+                    {status === "No Voice Loaded" || status === "Ready" ? (
+                        <div className="absolute inset-0 flex flex-col items-center justify-center p-4 text-center bg-gray-800/20 border border-dashed border-gray-700">
+                            <div className="w-12 h-12 rounded-full bg-purple-900/30 flex items-center justify-center mb-4 text-purple-500" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
+                                </svg>
+                            </div>
+                            <h3 className="text-gray-300 font-bold mb-2">No Voice Loaded</h3>
+                            <p className="text-gray-500 text-xs max-w-[250px]">
+                                Select a TTS voice from the library to view and edit its characteristics.
+                            </p>
+                        </div>
+                    ) : null}
                     <canvas
                         ref={canvasRef}
                         className="w-full h-full block"
-                        style={{ imageRendering: 'pixelated' }}
+                        style={{
+                            imageRendering: 'pixelated',
+                            display: (status === "No Voice Loaded" || status === "Ready") ? 'none' : 'block'
+                        }}
                         role="img"
                         aria-label="Voice Heatmap Visualization - Interactive Canvas"
                     />


### PR DESCRIPTION
💡 What: The UX enhancement added: Added the standardized dashed-border empty state pattern to the VoiceEditor's heatmap canvas when no voice is loaded.
🎯 Why: The user problem it solves: Previously, when no voice was loaded, the canvas area was just a blank black box. This could be confusing to users, who might think the component was broken or hadn't loaded fully. The empty state clearly explains that a voice needs to be loaded first to view and edit its characteristics.
♿ Accessibility: Ensure decorative elements are hidden from screen readers (`aria-hidden="true"`).

---
*PR created automatically by Jules for task [12688547229281338150](https://jules.google.com/task/12688547229281338150) started by @ford442*