### PR TITLE
feat: Add granular synthesis window shape control for TTS playback

### DIFF
--- a/.Jules/agent_plan.md
+++ b/.Jules/agent_plan.md
@@ -5,7 +5,7 @@
 - [x] Add granular random jitter per phoneme
 - [x] Add multi-voice unison detune
 - [ ] Optimize TTS memory footprint
-- [ ] Add granular synthesis window shape control for TTS playback
+- [x] Add granular synthesis window shape control for TTS playback
 
 ## Innovation Lab
 - [ ] What if we could link voice affinity directly to WebGPU/WASM buffers, preventing redundant host-to-device memory copies on voice steal?
@@ -21,8 +21,9 @@
 - [x] Add Formant Glide per phoneme
 - [ ] Add granular random jitter per phoneme
 - [x] Optimize Voice Manager state syncing
-- [ ] Add granular synthesis window shape control for TTS playback
+- [x] Add granular synthesis window shape control for TTS playback
 - [x] What if we could apply an LFO to the TTS formant shift directly from the step sequencer?
+- [ ] Could we create a visually interactive overlay on the sequencer for modifying TTS granular envelope shapes directly per note?
 
 ## Refactoring Roadblocks
 - Ensure all VoiceManagers (e.g., VoiceManager, SingingVoiceManager) use similar logic patterns for acquiring/releasing/stopping voices to prevent unexpected UI/Audio desync issues.

--- a/src/audio-worklets/rubberband-processor.ts
+++ b/src/audio-worklets/rubberband-processor.ts
@@ -88,7 +88,8 @@ class RubberBandProcessor extends AudioWorkletProcessor {
       { name: 'granularPitchShift', defaultValue: 0.0, minValue: -24.0, maxValue: 24.0 },
       { name: 'tranceGate', defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },
       { name: 'bitcrush', defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },
-      { name: 'downsample', defaultValue: 1.0, minValue: 1.0, maxValue: 32.0 }
+      { name: 'downsample', defaultValue: 1.0, minValue: 1.0, maxValue: 32.0 },
+      { name: 'windowShape', defaultValue: 0.0, minValue: 0.0, maxValue: 3.0 }
     ];
   }
 
@@ -424,6 +425,7 @@ class RubberBandProcessor extends AudioWorkletProcessor {
         const freezeLfoDepth = parameters.freezeLfoDepth ? parameters.freezeLfoDepth[0] : 0.0;
         const freezeEnvDepth = parameters.freezeEnvDepth ? parameters.freezeEnvDepth[0] : 0.0;
         const grainEnvDepth = parameters.grainEnvDepth ? parameters.grainEnvDepth[0] : 0.0;
+        const windowShape = parameters.windowShape ? parameters.windowShape[0] : 0.0;
 
         // Advance LFO phase (we can do this per block/process call rather than per sample since block is 128 samples (~2.9ms at 44.1kHz),
         // which is fast enough for low-frequency LFOs up to 20Hz. We'll add the increment based on the block size).
@@ -487,8 +489,25 @@ class RubberBandProcessor extends AudioWorkletProcessor {
 
             if (actualGrainSize > 0) {
               for (let i = 0; i < samplesToFeed; i++) {
-                // Apply a simple Hann window to the grain to avoid buzzing/clicks at the loop boundaries
-                const windowVal = 0.5 * (1 - Math.cos((2 * Math.PI * this.freezePhase) / (actualGrainSize - 1)));
+                // Apply a window to the grain to avoid buzzing/clicks at the loop boundaries
+                const phase = this.freezePhase / (actualGrainSize - 1);
+                let windowVal = 1.0;
+
+                // 0: Hann, 1: Hamming, 2: Blackman, 3: Rectangular (None)
+                if (windowShape < 0.5) {
+                    // Hann
+                    windowVal = 0.5 * (1 - Math.cos(2 * Math.PI * phase));
+                } else if (windowShape < 1.5) {
+                    // Hamming
+                    windowVal = 0.54 - 0.46 * Math.cos(2 * Math.PI * phase);
+                } else if (windowShape < 2.5) {
+                    // Blackman
+                    windowVal = 0.42 - 0.5 * Math.cos(2 * Math.PI * phase) + 0.08 * Math.cos(4 * Math.PI * phase);
+                } else {
+                    // Rectangular / None
+                    windowVal = 1.0;
+                }
+
                 heap[ptr + i] = buf[grainStart + this.freezePhase] * windowVal;
 
                 this.freezePhase++;


### PR DESCRIPTION
This pull request implements granular synthesis window shape control for TTS playback in the `RubberBandProcessor`. It adds a new `windowShape` AudioParam that allows users to select between Hann, Hamming, Blackman, and Rectangular (none) window shapes.

This fulfills the backlog item: "Add granular synthesis window shape control for TTS playback".

- `src/audio-worklets/rubberband-processor.ts`: Added `windowShape` AudioParam and updated window calculation logic.
- `.Jules/agent_plan.md`: Checked off completed task and added a new Innovation Lab idea.

---
*PR created automatically by Jules for task [8563544085845442411](https://jules.google.com/task/8563544085845442411) started by @ford442*