### PR TITLE
ci: fail-fast source-integrity gate + test-dupe cleanup (#1075)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,46 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  source-integrity:
+    name: Source Integrity (fail-fast)
+    runs-on: ubuntu-latest
+    # Pure TS syntax/type sweep with no WASM/native build. Ambient module
+    # declarations (src/custom.d.ts `*.wasm`) let tsc resolve wasm imports
+    # without physical .wasm artifacts, so a broken .ts/.tsx fails here in
+    # seconds instead of after minutes of WASM/Rust/Emscripten compilation
+    # in the Lint + Test job below (see #1075).
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          # Pins to pnpm 9 to match pnpm-lock.yaml lockfileVersion '9.0'.
+          # Avoids the Apr-2026 pnpm-lock mutation bug in setup-node + pnpm
+          # cache interaction — see: pnpm/action-setup#226.
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type-check (tsc, no WASM build)
+        run: pnpm exec tsc -b --pretty false
+
   ci:
     name: Lint + Test
+    needs: source-integrity
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          # Phase 1 only: no WASM build, no submodule source needed.
-          # Phase 2 will add submodules: true with fetch-depth: 1.
+          # jc303_wasm is a git submodule; build:wasm:jc303 below needs its
+          # source. (This job builds WASM — source-integrity above does not.)
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
     # in the Lint + Test job below (see #1075).
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v4
         with:
@@ -56,6 +58,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          persist-credentials: false
           # jc303_wasm is a git submodule; build:wasm:jc303 below needs its
           # source. (This job builds WASM — source-integrity above does not.)
 

--- a/.swarm-state.md
+++ b/.swarm-state.md
@@ -1,33 +1,60 @@
-# Swarm State — E2E Playwright matrix (#1036 / #1039)
+# Swarm State — CI integrity (#1075)
 
 ## Status
-**DONE** — chromium + firefox + webkit green. Full matrix `--repeat-each=2`: **84 passed**, 18 skipped. `tsc -b` + `pnpm lint` green.
+**GREEN** — `tsc -b`, `pnpm lint`, and `pnpm exec vitest run --pool forks` are all clean at HEAD. The
+suspected parse/type errors from #1075 were **already fixed** before this session started (main went
+green sometime around 08-09/08-10, matching the note in `docs/weekly_plan.md`'s 08-10 entry). Effort
+was pivoted to: (a) a small leftover test-duplication cleanup, and (b) building the fail-fast
+`source-integrity` CI job, which was the one item from the P0 list that was definitely *not* done yet.
 
-## Projects
-| Project   | Status | Notes |
-|-----------|--------|-------|
-| chromium  | green | `--repeat-each=2` |
-| firefox   | green | needs PulseAudio sink; e2e resume unlock |
-| webkit    | green | Chromium-only autoplay arg; PulseAudio |
+## Gate table
 
-## What was flaky and how fixed
-1. **Missing `webServer`** → Playwright owns Vite (`reuseExistingServer`, 180s).
-2. **WebKit launch crash** → `--autoplay-policy=…` Chromium-only (WebKit rejects the flag).
-3. **Firefox/WebKit LoadingOverlay hang** → `await context.resume()` never resolved after React setState lost the gesture. StartOverlay `?e2e=1` patches `resume()` to be non-blocking + gesture capture-phase native resume.
-4. **Firefox RBS playhead stuck** → without PulseAudio, AC stayed `suspended` forever so the worklet clock never ticked. `tests/global-setup.ts` starts PulseAudio; RBS helper awaits `running` after Start Playback.
-5. **Stale selectors** → rack single-track mount, `.hyphon-rack-surface`, OscillatorTypeSelector badges, native DOM clicks.
-6. **`.orig` purge** → five merge artifacts removed (isolated commit).
-7. **Root `weekly_plan.md`** → duplicate of `docs/weekly_plan.md`; removed so `check:root` passes.
+| Gate step | Pass/fail | Note |
+|---|---|---|
+| `pnpm install --frozen-lockfile` | ✅ pass | clean install |
+| `pnpm run build:wasm` (AssemblyScript targets) | ✅ pass | oscillators/trackFreezer/audioExport/xmExport/fft all built |
+| `pnpm run build:wasm` (`build:wasm:rust`, wasm-pack) | ⚠️ out of scope | sandbox proxy sends a non-CONNECT request to `github.com` (405) inside wasm-pack's release-fetch step — environment/network issue, not a source defect. Real CI (direct internet) is unaffected. Did not touch `rust-audio/**`. |
+| `pnpm run build:wasm:jc303` | ⚠️ out of scope | `emcc` is not installed in this sandbox (no emsdk). Real CI installs it via `mymindstorm/setup-emsdk@v14`. Did not touch `jc303_wasm/**` or `emscripten/**`. |
+| `pnpm exec tsc -b` | ✅ **0 errors** | Confirmed clean, including with `src/wasm/` deleted entirely (ambient `declare module '*.wasm'` in `src/custom.d.ts` means tsc never touches the physical binary) — this is what makes the new fail-fast job valid. |
+| `pnpm lint` (eslint + check-root) | ✅ pass | clean |
+| `pnpm exec vitest run --pool forks` | ✅ **1557 passed, 13 skipped, 0 failed** (169 files passed, 3 skipped) | Skips are all `describe.skipIf(!hasNativeJs)` gated on `public/hyphon_native.js`, which needs the emcc build above. |
+| `src/__tests__/workletPerf.test.ts` (audio-thread budget) in isolation | ✅ pass (6/6) | Re-ran solo per instructions before trusting the full-suite result — not flaky, no threshold bump needed. |
+| `pnpm run build` (`tsc -b && vite build`) | ⚠️ blocked by same emcc/wasm-pack gap | `tsc -b` and Rollup's TS/JSX transform succeed; Rollup then fails to resolve `/hyphon_native.js?url` because that file doesn't exist locally (needs the emcc build above). This is the same out-of-scope native gap, not a new regression — will succeed in real CI where emsdk/rust toolchains are present. |
+| New `source-integrity` CI job fails fast on a broken `.ts` file | ✅ verified locally | Appended a type error to `src/engines/VoiceManager.ts`, ran `pnpm exec tsc -b --pretty false` → exit code 2 in <1s, then reverted with `git checkout --`. Did not push a scratch commit to avoid spending a real Actions run for no reason; local repro is exact since the new job runs the identical command with no other steps before it. |
 
 ## Changed since last checkpoint
-- Removed root `weekly_plan.md` (lint gate)
-- Verified full matrix 84 passed / lint / tsc
+
+- `src/__tests__/WebGpu303Engine.test.ts`: removed one literal duplicate `it('normalizeTB303Model preserves gpu-highfid for persistence', …)` block (byte-identical twin at the old lines 61–67) — a leftover from a partial merge. Suite still closes correctly and all 13 (was 14, one was a dupe) tests pass.
+- `.github/workflows/ci.yml`: added a new first job, `source-integrity` ("Source Integrity (fail-fast)"), that checks out (no submodules — none needed), installs deps, and runs `pnpm exec tsc -b --pretty false` with **no WASM/native build step**. The existing `Lint + Test` job (`ci`) now has `needs: source-integrity`, so the multi-minute WASM/Rust/Emscripten build path never starts when the TS is malformed. Also tightened the stale/contradictory comment on the `ci` job's checkout step (it said "no submodule source needed" while setting `submodules: true`; clarified that `jc303_wasm` is a submodule the WASM build step needs).
+
+### Not touched (confirmed already correct, no fix needed)
+- `src/components/EngineHUD.tsx` — single coherent implementation, no duplicate template/merge artifacts found.
+- `src/engines/VoiceManager.ts` — single `stopAll()` override (line ~478), no duplicate.
+- `src/engines/singing-voice/playback.ts` — single `schedulePhonemeFormantGlides`/formant-glide call path, no duplication.
+- `src/engines/TB303Models.ts` — `TB303_MODELS` ids already unique; single `gpu-highfid` entry with the offline label/description intact.
+- `src/components/note-selector/SynthModulationEffects.tsx` — `currentFormantShift = 0` is already defaulted in the destructuring (line 27), which narrows the value to `number` (not `number | undefined`) at both read sites (L67, L85 in the original issue numbering); `tsc -b` confirms 0 errors here. No behavior change needed to preserve "voice" track rendering.
+- `src/__tests__/engineInitPaths.test.ts` — already asserts `map.jc303_init_handle` in the release export-map test (`describe.skipIf(!hasNativeJs)`); no separate release-vs-debug legacy `jc303_init` check exists to conflict with it. This test is currently skipped in *this* sandbox only because `public/hyphon_native.js` isn't built here (see emcc gap above); it will run for real in CI.
+
+## OWNER ACTION REQUIRED
+
+1. **Make `source-integrity` AND `Lint + Test` required status checks on `main`.** This cannot be done from code — it's a GitHub repo-settings action:
+   - Go to the repo's **Settings → Branches → Branch protection rules** (or **Rulesets** if the repo uses the newer rules UI).
+   - Edit (or create) the rule covering `main`.
+   - Enable **"Require status checks to pass before merging"**.
+   - Add both `Source Integrity (fail-fast)` and `Lint + Test` as required checks (their job names as they'll appear after this PR's first run — GitHub only lists checks that have run at least once, so this PR needs to run once before they're selectable).
+   - Recommended: also enable **"Require branches to be up to date before merging"** so a stale branch can't merge around a check that would now fail.
+   - This directly closes the "bot/direct pushes bypass the local pre-push hook" gap described in #1075 — branch protection is enforced server-side regardless of how the push was made (bot, `--no-verify`, direct push, etc.), which husky cannot do.
+
+2. **wasm-pack network gap in sandboxed dev containers** (not this repo's CI, just noting for anyone else hitting it locally in a similar restricted-network dev box): `pnpm run build:wasm:rust` fails with a proxy 405 because wasm-pack's release-fetch step issues a non-CONNECT HTTP request to `github.com`. Real GitHub Actions runners have unrestricted internet, so `ci.yml`'s existing `Lint + Test` job is unaffected — no action needed there.
 
 ## Resume commands
+
 ```bash
-cd /workspace
-git checkout cursor/e2e-playwright-matrix-2ef1
-pulseaudio --check || pulseaudio --start --exit-idle-time=-1
-pnpm exec tsc -b && pnpm lint
-pnpm exec playwright test --repeat-each=2 --workers=1
+cd /path/to/web_sequencer
+git checkout claude/web-sequencer-ci-integrity-wxit1g
+pnpm install --frozen-lockfile
+pnpm run build:wasm            # AS targets only will succeed without emsdk/network; rust+jc303 need those toolchains
+pnpm exec tsc -b                # expect 0 errors
+pnpm lint                       # expect clean
+pnpm exec vitest run --pool forks   # expect all-pass (some describe.skipIf skips without hyphon_native.js)
 ```

--- a/src/__tests__/WebGpu303Engine.test.ts
+++ b/src/__tests__/WebGpu303Engine.test.ts
@@ -61,10 +61,6 @@ describe('gpu-highfid registry', () => {
   it('normalizeTB303Model preserves gpu-highfid for persistence', () => {
     expect(normalizeTB303Model('gpu-highfid', undefined, { reportFallback: false })).toBe('gpu-highfid');
   });
-
-  it('normalizeTB303Model preserves gpu-highfid for persistence', () => {
-    expect(normalizeTB303Model('gpu-highfid', undefined, { reportFallback: false })).toBe('gpu-highfid');
-  });
 });
 
 describe('WGSL 303 shader source', () => {


### PR DESCRIPTION
## Summary

Addresses #1075 (P0: restore parse/build/test integrity on `main`, make CI structurally incapable of letting a TS syntax/type error land again).

Investigation found `tsc -b`, `pnpm lint`, and `pnpm exec vitest run --pool forks` are **already clean at HEAD** — the parse/type errors described in #1075 predate this session (main appears to have gone green around 08-09/08-10). Effort was pivoted to the items that were genuinely not done:

- **`.github/workflows/ci.yml`**: added a new first job, `source-integrity`, that installs deps and runs `pnpm exec tsc -b --pretty false` with **no WASM/native build**. Verified locally that `tsc` resolves `*.wasm` imports via the ambient module declaration in `src/custom.d.ts` regardless of whether the physical `.wasm` files exist, and that it fails in under a second on a deliberately-broken `.ts` fixture (added a type error to `VoiceManager.ts`, ran the exact command, got exit code 2, then reverted — no scratch commit was pushed). The existing `Lint + Test` job now `needs: source-integrity`, so the multi-minute WASM/Rust/Emscripten build path never starts on malformed TypeScript.
- **`src/__tests__/WebGpu303Engine.test.ts`**: removed one literal duplicate `it('normalizeTB303Model preserves gpu-highfid for persistence', …)` block — a leftover partial-merge artifact. Suite still closes correctly; 13 tests (was 14 with the dupe) all pass.

The other four files called out in the issue (`EngineHUD.tsx`, `VoiceManager.ts`, `singing-voice/playback.ts`, `TB303Models.ts`, `SynthModulationEffects.tsx`, `engineInitPaths.test.ts`) were individually reviewed and are already correct — single coherent implementations, unique `TB303_MODELS` ids, the `currentFormantShift = 0` destructuring default already narrows the type away from `undefined`. No changes needed there.

Full details, gate-by-gate results, and the out-of-scope native/WASM build gaps hit in the sandbox (missing `emcc`, wasm-pack blocked by a dev-proxy network quirk — both environment-only, not source defects, and irrelevant to real CI which has emsdk/rust toolchains) are recorded in `.swarm-state.md`.

## Owner action required

Making `source-integrity` and `Lint + Test` required branch-protection checks on `main` is a GitHub repo-settings action that can't be done from code. Exact steps are in `.swarm-state.md` under "OWNER ACTION REQUIRED":

1. Settings → Branches (or Rulesets) → edit the rule covering `main`.
2. Enable "Require status checks to pass before merging".
3. Add both `Source Integrity (fail-fast)` and `Lint + Test` as required checks (selectable only after this PR's first CI run).
4. Recommended: also enable "Require branches to be up to date before merging".

## Test plan

- [x] `pnpm exec tsc -b` → 0 errors
- [x] `pnpm lint` → clean
- [x] `pnpm exec vitest run --pool forks` → 1557 passed, 13 skipped, 0 failed (169 files passed, 3 skipped)
- [x] `src/__tests__/workletPerf.test.ts` (audio-thread budget) re-run in isolation → 6/6 pass, not flaky
- [x] Confirmed `tsc -b` needs no physical `.wasm` files (deleted `src/wasm/` entirely, still 0 errors) — validates the new job's approach
- [x] Confirmed the new job's exact command fails fast (<1s, exit 2) on a deliberately broken `.ts` file, then reverted
- [ ] `pnpm run build` — blocked in this sandbox only by the missing `emcc`/wasm-pack toolchains (same out-of-scope gap); `tsc -b` and Rollup's TS/JSX transform succeed up to that point

---
_Generated by [Claude Code](https://claude.ai/code/session_014xGVAF2LoDX9vdFsrmNRhB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved continuous integration checks to detect source and type errors earlier.
  * Updated CI validation for projects requiring WebAssembly components.

* **Tests**
  * Removed an obsolete GPU model persistence test.

* **Documentation**
  * Updated CI integrity status records and related verification guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->