### PR TITLE
⚡ Bolt: Prevent closure allocations in GamepadDebugger rAF loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -63,3 +63,6 @@
 ## 2024-05-18 - Replacing Math.max(...buffer.map(Math.abs))
 **Learning:** Using `Math.max(...buffer.map(Math.abs))` on large `Float32Array` audio buffers allocates an intermediate array and a closure on every frame. Spreading the resulting array `...` pushes every single item onto the call stack, which can easily trigger a `RangeError: Maximum call stack size exceeded` and crash the thread (especially in Web Workers).
 **Action:** When finding the maximum amplitude of an audio buffer, always use a standard `for` loop to iterate over the items directly. This runs in O(N) time and O(1) space, avoiding all memory allocation and call stack limits.
+## 2026-08-12 - Prevent closure allocations in requestAnimationFrame GamepadDebugger rAF loop
+**Learning:** In the `src/components/GamepadDebugger.tsx` game loop running via `requestAnimationFrame`, `Array.from().filter()` was creating unnecessary array allocations and closures for every frame, putting garbage collection pressure on the main thread and resulting in potential frame drops or micro-stutters during intensive rendering.
+**Action:** Replaced `Array.from().filter()` with a standard `for` loop pushing to a new valid gamepads array within main-thread rendering hot paths like `requestAnimationFrame` ticks to avoid closure and intermediate array instantiation.

--- a/src/components/GamepadDebugger.tsx
+++ b/src/components/GamepadDebugger.tsx
@@ -22,7 +22,15 @@ export const GamepadDebugger: React.FC<{ onClose: () => void }> = React.memo(({ 
       const gps = navigator.getGamepads();
       // Filter out nulls for state, but keep indices for display accuracy if needed
       // Here we just grab all non-nulls to show what the browser sees
-      setGamepads(Array.from(gps).filter((gp): gp is Gamepad => gp !== null));
+      // ⚡ Bolt: Using standard for loop instead of Array.from().filter() to prevent closure allocation
+      const validGamepads: Gamepad[] = [];
+      for (let i = 0; i < gps.length; i++) {
+        const gp = gps[i];
+        if (gp !== null) {
+          validGamepads.push(gp);
+        }
+      }
+      setGamepads(validGamepads);
       reqRef.current = requestAnimationFrame(loop);
     };
 


### PR DESCRIPTION
💡 What: Refactored the GamepadDebugger requestAnimationFrame loop to use a standard for loop instead of Array.from().filter(). 
🎯 Why: Array.from() and .filter() create unnecessary array and closure allocations 60 times a second, increasing GC pressure and causing potential micro-stutters. 
📊 Impact: Eliminates closure and array allocations in this rAF loop, reducing GC pressure. 
🔬 Measurement: Profile the Gamepad Debugger component with the Chrome DevTools Memory tab and observe reduced GC events.

---
*PR created automatically by Jules for task [1876817787993035601](https://jules.google.com/task/1876817787993035601) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved gamepad polling efficiency by reducing unnecessary processing during each update.
* **Bug Fixes**
  * Preserved existing gamepad detection and display behavior while streamlining how connected devices are identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->