### PR TITLE
feat: visually interactive overlay for TTS granular envelope shapes

### DIFF
--- a/.Jules/agent_plan.md
+++ b/.Jules/agent_plan.md
@@ -7,13 +7,16 @@
 - [ ] Optimize TTS memory footprint
 - [x] Add granular synthesis window shape control for TTS playback
 - [x] Implement per-phoneme granular synthesis grain size control
-- [ ] Could we create a visually interactive overlay on the sequencer for modifying TTS granular envelope shapes directly per note?
+- [x] Could we create a visually interactive overlay on the sequencer for modifying TTS granular envelope shapes directly per note?
+- [ ] Add granular random jitter per phoneme
 
 ## Innovation Lab
 - [x] What if we could link voice affinity directly to WebGPU/WASM buffers, preventing redundant host-to-device memory copies on voice steal?
 - [x] Implement reverse TTS sample per step
 - [x] Implement Phoneme Envelope shaping per step
 - [x] Implement Expressive Note Transitions for Vowels
+- [ ] What if we could modulate the grain size with an LFO or envelope to create "breathing" textures?
+- [ ] Explore spectral panning per grain to create a wide stereo field for TTS voices.
 
 - [x] Optimize TTS memory footprint
 - [x] Implement Lyric Track parsing
@@ -21,7 +24,6 @@
 - [x] Implement per-phoneme pitch drift/vibrato
 - [x] Add Formant Modulation LFO
 - [x] Add Formant Glide per phoneme
-- [ ] Add granular random jitter per phoneme
 - [x] Optimize Voice Manager state syncing
 - [x] Add granular synthesis window shape control for TTS playback
 - [x] What if we could apply an LFO to the TTS formant shift directly from the step sequencer?
@@ -35,7 +37,8 @@
 - Completed the "Optimize Voice Manager state syncing" task by removing the redundant `activeVoices` map in `SingingVoiceManager` and relying entirely on the base `VoicePool` class implementation (`activeIndices`, `startTimes`). This reduces memory allocations and aligns with the generic pool structure constraint.
 - Velocity Check: Refactoring went smoothly. The architecture is much cleaner without duplicate voice maps. Also completed linking voice affinity directly to WebGPU/WASM buffers to prevent redundant host-to-device memory copies by correctly providing a bankId to `acquireVoiceForBank`.
 - Completed the "Implement per-phoneme granular synthesis grain size control" task from the Innovation Lab backlog by adding `grainSize` and `formantShift` fully to `PhonemeData`, updating the `PhonemeAligner` SharedArrayBuffer stride to 10, and modifying the `RubberBandProcessor` AudioWorklet to natively read and apply the `grainSize` parameter during FREEZE stream synthesis.
-- Moved two ideas from the Innovation Lab into the Active Backlog to ensure the pipeline stays full.
-- Velocity Check: Adding new per-phoneme parameters is well-documented and straightforward due to the clean separation between main thread Web Audio API (formants) and AudioWorklet (grain/pitch).
+- Completed "Could we create a visually interactive overlay on the sequencer for modifying TTS granular envelope shapes directly per note?" Added `DrawableLFO` to `SynthGranularEffects` and wired `customWindowShape` through `playSamplerVoice`, `EffectsControlMixin`, and `RubberBandProcessor`.
+- Moved one idea from the Innovation Lab into the Active Backlog and added two new ideas to the Innovation Lab to ensure the pipeline stays full.
+- Velocity Check: Implementing the custom drawable window shape went quickly by reusing `DrawableLFO` and the message passing infrastructure. The AudioWorklet handles the Float32Array gracefully with linear interpolation.
 
 ## Roadmap

--- a/src/audio-worklets/rubberband-processor.ts
+++ b/src/audio-worklets/rubberband-processor.ts
@@ -46,6 +46,7 @@ class RubberBandProcessor extends AudioWorkletProcessor {
   private isPlaying = false;
   private isReverse = false;
   private freezePhase: number = 0;
+  private customWindowShape: Float32Array | null = null;
   private freezeLfoPhase: number = 0;
   private gatePhase: number = 0;
   private currentGateLfo: number = 1.0;
@@ -161,6 +162,14 @@ class RubberBandProcessor extends AudioWorkletProcessor {
       case 'loadBuffer':
         if (data && data.buffer) {
           this.fullSampleBuffer = new Float32Array(data.buffer);
+        }
+        break;
+
+      case 'setCustomWindowShape':
+        if (data.shape && data.shape.length > 0) {
+          this.customWindowShape = new Float32Array(data.shape);
+        } else {
+          this.customWindowShape = null;
         }
         break;
 
@@ -499,19 +508,27 @@ class RubberBandProcessor extends AudioWorkletProcessor {
                 const phase = this.freezePhase / (actualGrainSize - 1);
                 let windowVal = 1.0;
 
-                // 0: Hann, 1: Hamming, 2: Blackman, 3: Rectangular (None)
-                if (windowShape < 0.5) {
-                    // Hann
-                    windowVal = 0.5 * (1 - Math.cos(2 * Math.PI * phase));
-                } else if (windowShape < 1.5) {
-                    // Hamming
-                    windowVal = 0.54 - 0.46 * Math.cos(2 * Math.PI * phase);
-                } else if (windowShape < 2.5) {
-                    // Blackman
-                    windowVal = 0.42 - 0.5 * Math.cos(2 * Math.PI * phase) + 0.08 * Math.cos(4 * Math.PI * phase);
+                if (this.customWindowShape && this.customWindowShape.length > 0) {
+                    const index = phase * (this.customWindowShape.length - 1);
+                    const lower = Math.floor(index);
+                    const upper = Math.ceil(index);
+                    const weight = index - lower;
+                    windowVal = this.customWindowShape[lower] * (1 - weight) + this.customWindowShape[upper] * weight;
                 } else {
-                    // Rectangular / None
-                    windowVal = 1.0;
+                    // 0: Hann, 1: Hamming, 2: Blackman, 3: Rectangular (None)
+                    if (windowShape < 0.5) {
+                        // Hann
+                        windowVal = 0.5 * (1 - Math.cos(2 * Math.PI * phase));
+                    } else if (windowShape < 1.5) {
+                        // Hamming
+                        windowVal = 0.54 - 0.46 * Math.cos(2 * Math.PI * phase);
+                    } else if (windowShape < 2.5) {
+                        // Blackman
+                        windowVal = 0.42 - 0.5 * Math.cos(2 * Math.PI * phase) + 0.08 * Math.cos(4 * Math.PI * phase);
+                    } else {
+                        // Rectangular / None
+                        windowVal = 1.0;
+                    }
                 }
 
                 heap[ptr + i] = buf[grainStart + this.freezePhase] * windowVal;

--- a/src/components/NoteSelector.tsx
+++ b/src/components/NoteSelector.tsx
@@ -40,6 +40,7 @@ export const NoteSelector: React.FC<NoteSelectorProps> = memo(
     currentFilterCutoff,
     currentFilterResonance,
     currentEnvMod,
+    currentCustomWindowShape,
     currentFormantLfoSync,
     currentFormantLfoRate = 0,
     currentFormantLfoDepth = 0,
@@ -193,6 +194,7 @@ export const NoteSelector: React.FC<NoteSelectorProps> = memo(
                 currentPitchAmount={currentPitchAmount}
                 currentPitchAttack={currentPitchAttack}
                 currentPitchDecay={currentPitchDecay}
+                currentCustomWindowShape={currentCustomWindowShape}
                 currentFormantEnvSync={currentFormantEnvSync}
                 currentFormantEnvAttack={currentFormantEnvAttack}
                 currentFormantEnvDecay={currentFormantEnvDecay}

--- a/src/components/note-selector/SynthGranularEffects.tsx
+++ b/src/components/note-selector/SynthGranularEffects.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { PropertySlider } from "./PropertySlider";
 import { VocoderProperties } from "./VocoderProperties";
+import { DrawableLFO } from "../DrawableLFO";
 import type { SynthEffectPropertiesProps } from "./synthEffectTypes";
 
 export const SynthGranularEffects: React.FC<SynthEffectPropertiesProps> = React.memo((props) => {
@@ -41,6 +42,7 @@ export const SynthGranularEffects: React.FC<SynthEffectPropertiesProps> = React.
     currentFormantEnvFollower = 0,
     currentDrive,
     currentVibratoDepth = 0,
+    currentCustomWindowShape,
     currentVowel = 0,
     currentPortamento = 0,
     currentCharacterMorph = 0,
@@ -379,6 +381,14 @@ export const SynthGranularEffects: React.FC<SynthEffectPropertiesProps> = React.
           aria-label="Trance Gate"
         />
       </div>
+
+      {(trackType === "synth" || trackType === "voice") && onPropertyChange && (
+          <DrawableLFO
+              value={currentCustomWindowShape}
+              onChange={(shape) => onPropertyChange("customWindowShape", shape)}
+              label="Custom Window Shape"
+          />
+      )}
     </>
   );
 });

--- a/src/components/note-selector/synthEffectTypes.ts
+++ b/src/components/note-selector/synthEffectTypes.ts
@@ -2,7 +2,7 @@ import type { PropertyChangeKey } from "./types";
 
 export interface SynthEffectPropertiesProps {
   trackType: "synth" | "drum" | "voice";
-  onPropertyChange: (key: PropertyChangeKey, value: number | boolean | string) => void;
+  onPropertyChange: (key: PropertyChangeKey, value: number | boolean | string | number[]) => void;
   isProphecy?: boolean;
   currentFreeze?: number;
   currentFreezeLfoSync?: boolean;
@@ -50,4 +50,5 @@ export interface SynthEffectPropertiesProps {
   currentSpectralPanRate?: number;
   currentSpectralPanDepth?: number;
   currentReverse?: boolean;
+  currentCustomWindowShape?: number[];
 }

--- a/src/components/note-selector/types.ts
+++ b/src/components/note-selector/types.ts
@@ -41,6 +41,7 @@ export type PropertyChangeKey =
   | "formantEnvSync"
   | "vibratoDepth"
   | "tremoloDepth"
+  | "customWindowShape"
   | "tremoloRate"
   | "gateDepth"
   | "gateRate"
@@ -143,5 +144,6 @@ export interface NoteSelectorProps {
   isProphecy?: boolean;
   currentVowel?: number;
   currentPortamento?: number;
-  onPropertyChange?: (key: PropertyChangeKey, value: number | boolean | string) => void;
+  currentCustomWindowShape?: number[];
+  onPropertyChange?: (key: PropertyChangeKey, value: number | boolean | string | number[]) => void;
 }

--- a/src/engines/singing-voice/effectsControl.ts
+++ b/src/engines/singing-voice/effectsControl.ts
@@ -284,4 +284,22 @@ export const EffectsControlMixin = {
   setDownsample(this: SingingVoiceHost, factor: number, time?: number): void {
     setWorkletParam(this, "downsample", factor, time);
   },
+
+  /**
+   * Set custom shape for granular synthesis windowing.
+   * @param shape Array of normalized values (0.0 to 1.0)
+   * @param time Optional time to apply the change (default: now)
+   */
+  setCustomWindowShape(
+    this: SingingVoiceHost,
+    shape: number[] | undefined,
+    time?: number,
+  ): void {
+    if (this.workletNode) {
+      this.workletNode.port.postMessage({
+        type: "setCustomWindowShape",
+        data: { shape }
+      });
+    }
+  },
 };

--- a/src/hooks/audioEngine/samplerPlayback/playSamplerVoice.ts
+++ b/src/hooks/audioEngine/samplerPlayback/playSamplerVoice.ts
@@ -135,6 +135,7 @@ export function createPlaySamplerVoice(
     if (pFormantLfoShape === undefined) {
       pFormantLfoShape = noteParams?.customLfoShape !== undefined ? noteParams.customLfoShape : params.customLfoShape;
     }
+    const pCustomWindowShape = noteParams?.customWindowShape !== undefined ? noteParams.customWindowShape : params.customWindowShape;
 
     // Formant Envelope
     const envSync = noteParams?.formantEnvSync ?? params.formantEnvSync ?? false;
@@ -334,6 +335,8 @@ export function createPlaySamplerVoice(
         if (pBitcrush !== undefined) voice.setBitcrush(pBitcrush, triggerTime);
         if (pDownsample !== undefined) voice.setDownsample(pDownsample, triggerTime);
         if (pTranceGate !== undefined) voice.setTranceGate(pTranceGate, triggerTime);
+
+        voice.setCustomWindowShape(pCustomWindowShape, triggerTime);
 
         if (pFormantLfoRateHz !== undefined) voice.setFormantLfoRate(pFormantLfoRateHz, triggerTime);
         if (pFormantLfoDepth !== undefined) voice.setFormantLfoDepth(pFormantLfoDepth, triggerTime);

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,7 @@ export interface SamplerBankParams {
   formantLfoRate?: number;
   formantLfoDepth?: number;
   customLfoShape?: number[];
+  customWindowShape?: number[];
   reverbLfoRate?: number;
   reverbLfoDepth?: number;
   bitcrush?: number;
@@ -462,6 +463,7 @@ export interface Note {
   grainPitchQuantize?: number;
   grainEnvDepth?: number;
   vibratoDepth?: number;
+  customWindowShape?: number[];
   reverbSend?: number;
   reverbType?: ReverbType;
   reverbLfoRate?: number;
@@ -639,6 +641,7 @@ export interface AudioEngine {
 export interface AutomationPoint {
   step: number;
   value: number;
+  customWindowShape?: number[];
 }
 
 export interface KnobAutomation {


### PR DESCRIPTION
This adds a `DrawableLFO` to the SynthGranularEffects UI, allowing users to draw custom granular windowing shapes. The custom shape array is piped down through sampler params to the WebAudio Worklet, where it linearly interpolates the custom envelope values for the granular playback. Fallbacks gracefully to predefined window shapes if no custom shape is drawn.

Addresses plan item: 'Could we create a visually interactive overlay on the sequencer for modifying TTS granular envelope shapes directly per note?'

---
*PR created automatically by Jules for task [12763152467928588582](https://jules.google.com/task/12763152467928588582) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive editor for designing custom granular window shapes.
  * Custom window shapes can now be applied to individual notes, sampler settings, and automation points.
  * Audio grains use the custom shape when provided, with existing envelope and built-in shape options available as fallbacks.
  * Added planned support for LFO/envelope grain-size modulation and spectral panning ideas in the innovation backlog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->