### PR TITLE
feat(tts): Add Grain Size LFO modulation

### DIFF
--- a/.Jules/agent_plan.md
+++ b/.Jules/agent_plan.md
@@ -8,6 +8,7 @@
 - [x] Add granular synthesis window shape control for TTS playback
 - [x] Implement per-phoneme granular synthesis grain size control
 - [x] Could we create a visually interactive overlay on the sequencer for modifying TTS granular envelope shapes directly per note?
+- [x] What if we could modulate the grain size with an LFO or envelope to create "breathing" textures?
 
 
 ## Innovation Lab
@@ -15,8 +16,8 @@
 - [x] Implement reverse TTS sample per step
 - [x] Implement Phoneme Envelope shaping per step
 - [x] Implement Expressive Note Transitions for Vowels
-- [ ] What if we could modulate the grain size with an LFO or envelope to create "breathing" textures?
 - [ ] Explore spectral panning per grain to create a wide stereo field for TTS voices.
+- [ ] Explore multi-band spectral compression for the TTS output
 
 - [x] Optimize TTS memory footprint
 - [x] Implement Lyric Track parsing
@@ -40,5 +41,8 @@
 - Completed "Could we create a visually interactive overlay on the sequencer for modifying TTS granular envelope shapes directly per note?" by adding both a `DrawableLFO` to `SynthGranularEffects` and a `<select>` menu for predefined window shapes. Wired `customWindowShape` and `windowShape` through `playSamplerVoice`, `EffectsControlMixin`, and `RubberBandProcessor`. The custom drawable shape allows per-note granular windowing control while predefined shapes provide quick presets. The AudioWorklet handles both Float32Array shapes and numeric shape indices gracefully.
 - Moved ideas from the Innovation Lab into the Active Backlog and added new ideas to ensure the pipeline stays full.
 - Velocity Check: Working with `DrawableLFO` and the message passing infrastructure proved robust for exposing complex array modulations. Per-note granular control is now directly accessible from the sequencer UI overlays.
+- Completed "What if we could modulate the grain size with an LFO or envelope to create breathing textures?" by adding a `grainLfoPhase` calculation right after the existing `freezeLfoPhase` logic in the `RubberBandProcessor` AudioWorklet. This feeds an LFO modulation scalar directly into the `baseGrainSize` calculation.
+- Added a new idea to the Innovation Lab: "Explore multi-band spectral compression for the TTS output".
+- Velocity Check: Wiring up LFO parameters is becoming increasingly streamlined as the boilerplate (params -> types -> UI hooks) is well-established. Performance is well-preserved by calculating the LFO per-block (`framesInBlock`) rather than per-sample in the hot loop.
 
 ## Roadmap

--- a/src/audio-worklets/rubberband-processor.ts
+++ b/src/audio-worklets/rubberband-processor.ts
@@ -51,6 +51,7 @@ class RubberBandProcessor extends AudioWorkletProcessor {
   private freezePhase: number = 0;
   private customWindowShape: Float32Array | null = null;
   private freezeLfoPhase: number = 0;
+  private grainLfoPhase: number = 0;
   private gatePhase: number = 0;
   private currentGateLfo: number = 1.0;
 
@@ -86,6 +87,8 @@ class RubberBandProcessor extends AudioWorkletProcessor {
       { name: 'freezeEnvDepth', defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },
       { name: 'timeStretchEnvDepth', defaultValue: 0.0, minValue: -1.0, maxValue: 1.0 },
       { name: 'grainEnvDepth', defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },
+      { name: 'grainLfoRate', defaultValue: 0.0, minValue: 0.0, maxValue: 20.0 },
+      { name: 'grainLfoDepth', defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },
       { name: 'grainJitter', defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },
       { name: 'grainPitchEnvDepth', defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },
       { name: 'grainPitchQuantize', defaultValue: 0.0, minValue: 0.0, maxValue: 12.0 },
@@ -447,6 +450,8 @@ class RubberBandProcessor extends AudioWorkletProcessor {
         const freezeEnvDepth = parameters.freezeEnvDepth ? parameters.freezeEnvDepth[0] : 0.0;
         const grainEnvDepth = parameters.grainEnvDepth ? parameters.grainEnvDepth[0] : 0.0;
         const windowShape = parameters.windowShape ? parameters.windowShape[0] : 0.0;
+        const grainLfoRate = parameters.grainLfoRate ? parameters.grainLfoRate[0] : 0.0;
+        const grainLfoDepth = parameters.grainLfoDepth ? parameters.grainLfoDepth[0] : 0.0;
 
         // Advance LFO phase (we can do this per block/process call rather than per sample since block is 128 samples (~2.9ms at 44.1kHz),
         // which is fast enough for low-frequency LFOs up to 20Hz. We'll add the increment based on the block size).
@@ -459,6 +464,11 @@ class RubberBandProcessor extends AudioWorkletProcessor {
         this.freezeLfoPhase += (2 * Math.PI * freezeLfoRate * framesInBlock) / sRate;
         if (this.freezeLfoPhase > 2 * Math.PI) {
             this.freezeLfoPhase -= 2 * Math.PI;
+        }
+
+        this.grainLfoPhase += (2 * Math.PI * grainLfoRate * framesInBlock) / sRate;
+        if (this.grainLfoPhase > 2 * Math.PI) {
+            this.grainLfoPhase -= 2 * Math.PI;
         }
 
         const lfoValue = Math.sin(this.freezeLfoPhase);
@@ -501,8 +511,12 @@ class RubberBandProcessor extends AudioWorkletProcessor {
                 }
             }
 
+            const grainLfoValue = Math.sin(this.grainLfoPhase);
+            // Apply unipolar LFO modulation to grain size (reduces size)
+            const lfoMod = 1.0 - (grainLfoDepth * ((grainLfoValue + 1) * 0.5));
+
             // Modulate grain size with envelope: louder = smaller grains for more texture
-            const grainSizeSamples = Math.max(100, Math.floor(baseGrainSize * (1.0 - grainEnvDepth * envelopeValue)));
+            const grainSizeSamples = Math.max(100, Math.floor(baseGrainSize * lfoMod * (1.0 - grainEnvDepth * envelopeValue)));
 
             // Jitter adds a random offset to the grain center up to +/- 50ms based on jitter amount
             const maxJitterSamples = Math.floor(0.05 * sRate * grainJitter);

--- a/src/components/NoteSelector.tsx
+++ b/src/components/NoteSelector.tsx
@@ -66,6 +66,8 @@ export const NoteSelector: React.FC<NoteSelectorProps> = memo(
     currentDelayLfoDepth,
     currentDelaySend,
     currentFreezeEnvDepth = 0,
+    currentGrainLfoRate = 0,
+    currentGrainLfoDepth = 0,
     currentGrainEnvDepth = 0,
     currentGrainPitchEnvDepth = 0,
     currentGrainJitter = 0,
@@ -151,6 +153,8 @@ export const NoteSelector: React.FC<NoteSelectorProps> = memo(
                 currentFreezeLfoRate={currentFreezeLfoRate}
                 currentFreezeLfoDepth={currentFreezeLfoDepth}
                 currentFreezeEnvDepth={currentFreezeEnvDepth}
+                currentGrainLfoRate={currentGrainLfoRate}
+                currentGrainLfoDepth={currentGrainLfoDepth}
                 currentGrainEnvDepth={currentGrainEnvDepth}
                 currentGrainPitchEnvDepth={currentGrainPitchEnvDepth}
                 currentGrainJitter={currentGrainJitter}

--- a/src/components/appParts/ContextMenuNode.tsx
+++ b/src/components/appParts/ContextMenuNode.tsx
@@ -66,6 +66,8 @@ export const ContextMenuNode = React.memo(() => {
           currentTranceGate={stepData?.tranceGate}
           currentTimeStretchEnvDepth={stepData?.timeStretchEnvDepth}
           currentFreezeEnvDepth={stepData?.freezeEnvDepth}
+          currentGrainLfoRate={stepData?.grainLfoRate}
+          currentGrainLfoDepth={stepData?.grainLfoDepth}
           currentGrainEnvDepth={stepData?.grainEnvDepth}
           currentGrainPitchEnvDepth={stepData?.grainPitchEnvDepth}
           currentGrainPitchQuantize={stepData?.grainPitchQuantize}

--- a/src/components/note-selector/SynthGranularEffects.tsx
+++ b/src/components/note-selector/SynthGranularEffects.tsx
@@ -14,6 +14,8 @@ export const SynthGranularEffects: React.FC<SynthEffectPropertiesProps> = React.
     currentFreezeLfoRate = 0,
     currentFreezeLfoDepth = 0,
     currentFreezeEnvDepth = 0,
+    currentGrainLfoRate = 0,
+    currentGrainLfoDepth = 0,
     currentGrainEnvDepth = 0,
     currentGrainPitchEnvDepth = 0,
     currentGrainJitter = 0,
@@ -222,6 +224,56 @@ export const SynthGranularEffects: React.FC<SynthEffectPropertiesProps> = React.
           className="w-full h-2 bg-gray-800 rounded-lg appearance-none cursor-pointer accent-cyan-400 border border-cyan-900/30 hover:accent-cyan-300 transition-all"
           aria-valuetext={`\${Math.round((currentGrainEnvDepth + 0.0001) * 100)}%`}
           aria-label="Envelope to Grain Size Depth"
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <div className="flex justify-between text-[10px] text-cyan-200/70 font-bold uppercase">
+          <label htmlFor="note-grain-lfo-rate">Grain LFO Rate</label>
+          <span className="text-cyan-400 font-mono text-[10px] drop-shadow-[0_0_5px_rgba(34,211,238,0.5)]">
+            {currentGrainLfoRate.toFixed(1)} Hz
+          </span>
+        </div>
+        <input
+          id="note-grain-lfo-rate"
+          type="range"
+          min="0"
+          max="20"
+          step="0.1"
+          value={currentGrainLfoRate}
+          onChange={(e) =>
+            onPropertyChange?.(
+              "grainLfoRate",
+              parseFloat(e.target.value)
+            )
+          }
+          className="w-full h-2 bg-gray-800 rounded-lg appearance-none cursor-pointer accent-cyan-400 border border-cyan-900/30 hover:accent-cyan-300 transition-all"
+          aria-valuetext={`${currentGrainLfoRate.toFixed(1)} Hz`}
+          aria-label="Grain Size LFO Rate"
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <div className="flex justify-between text-[10px] text-cyan-200/70 font-bold uppercase">
+          <label htmlFor="note-grain-lfo-depth">Grain LFO Depth</label>
+          <span className="text-cyan-400 font-mono text-[10px] drop-shadow-[0_0_5px_rgba(34,211,238,0.5)]">
+            {Math.round((currentGrainLfoDepth + 0.0001) * 100)}%
+          </span>
+        </div>
+        <input
+          id="note-grain-lfo-depth"
+          type="range"
+          min="0"
+          max="1"
+          step="0.01"
+          value={currentGrainLfoDepth}
+          onChange={(e) =>
+            onPropertyChange?.(
+              "grainLfoDepth",
+              parseFloat(e.target.value)
+            )
+          }
+          className="w-full h-2 bg-gray-800 rounded-lg appearance-none cursor-pointer accent-cyan-400 border border-cyan-900/30 hover:accent-cyan-300 transition-all"
+          aria-valuetext={`${Math.round((currentGrainLfoDepth + 0.0001) * 100)}%`}
+          aria-label="Grain Size LFO Depth"
         />
       </div>
        <div className="flex flex-col gap-1">

--- a/src/components/note-selector/synthEffectTypes.ts
+++ b/src/components/note-selector/synthEffectTypes.ts
@@ -11,6 +11,8 @@ export interface SynthEffectPropertiesProps {
   currentFreezeEnvDepth?: number;
   currentGrainEnvDepth?: number;
   currentGrainPitchEnvDepth?: number;
+  currentGrainLfoRate?: number;
+  currentGrainLfoDepth?: number;
   currentGrainJitter?: number;
   currentGrainPitchQuantize?: number;
   currentGranularPitchShift?: number;

--- a/src/components/note-selector/types.ts
+++ b/src/components/note-selector/types.ts
@@ -12,6 +12,8 @@ export type PropertyChangeKey =
   | "freezeEnvDepth"
   | "grainEnvDepth"
   | "grainPitchEnvDepth"
+  | "grainLfoRate"
+  | "grainLfoDepth"
   | "grainJitter"
   | "grainPitchQuantize"
   | "windowShape"
@@ -127,6 +129,8 @@ export interface NoteSelectorProps {
   currentFreezeEnvDepth?: number;
   currentGrainEnvDepth?: number;
   currentGrainPitchEnvDepth?: number;
+  currentGrainLfoRate?: number;
+  currentGrainLfoDepth?: number;
   currentGrainJitter?: number;
   currentGrainPitchQuantize?: number;
   currentGranularPitchShift?: number;

--- a/src/components/sampler-panel/SamplerKnobControls.tsx
+++ b/src/components/sampler-panel/SamplerKnobControls.tsx
@@ -23,6 +23,8 @@ interface SamplerKnobHandlers {
   formantLfoRate: (v: number) => void;
   freezeEnvDepth: (v: number) => void;
   timeStretchEnvDepth: (v: number) => void;
+  grainLfoRate: (v: number) => void;
+  grainLfoDepth: (v: number) => void;
   grainEnvDepth: (v: number) => void;
   grainPitchEnvDepth: (v: number) => void;
   grainJitter: (v: number) => void;
@@ -171,6 +173,8 @@ export const SamplerKnobControls = React.memo(function SamplerKnobControls({
 
           <Knob label="Env → Freeze" value={currentParams.freezeEnvDepth || 0} onChange={handlers.freezeEnvDepth} min={0} max={1.0} step={0.01} color="indigo" unit="%" />
           <Knob label="Env → Time" value={currentParams.timeStretchEnvDepth || 0} onChange={handlers.timeStretchEnvDepth} min={-1.0} max={1.0} step={0.01} color="indigo" unit="%" />
+          <Knob label="Grain LFO Rate" value={currentParams.grainLfoRate || 0} onChange={handlers.grainLfoRate} min={0} max={20.0} step={0.1} color="indigo" unit="Hz" />
+          <Knob label="Grain LFO Depth" value={currentParams.grainLfoDepth || 0} onChange={handlers.grainLfoDepth} min={0} max={1.0} step={0.01} color="indigo" unit="%" />
           <Knob label="Env → Grain" value={currentParams.grainEnvDepth || 0} onChange={handlers.grainEnvDepth} min={0} max={1.0} step={0.01} color="indigo" unit="%" />
           <Knob label="Env → Grn Pitch" value={currentParams.grainPitchEnvDepth || 0} onChange={handlers.grainPitchEnvDepth} min={0} max={1.0} step={0.01} color="indigo" unit="%" />
           <Knob label="Jitter" value={currentParams.grainJitter || 0} onChange={handlers.grainJitter} min={0} max={1.0} step={0.01} color="indigo" unit="%" />

--- a/src/components/sampler-panel/types.ts
+++ b/src/components/sampler-panel/types.ts
@@ -57,6 +57,8 @@ export const DEFAULT_BANK_PARAMS: SamplerBankParams = {
   freeze: 0,
   grainPitchEnvDepth: 0,
   grainJitter: 0,
+  grainLfoRate: 0,
+  grainLfoDepth: 0,
   grainPitchQuantize: 0,
   granularPitchShift: 0,
   windowShape: 0,

--- a/src/components/sampler-panel/useSamplerPanelState.ts
+++ b/src/components/sampler-panel/useSamplerPanelState.ts
@@ -65,7 +65,7 @@ export function useSamplerPanelState({
       'playbackSpeed', 'volume', 'filterCutoff', 'drive',
       'timeRatio', 'pitchScale', 'formantShift', 'vibratoDepth',
       'tremoloRate', 'tremoloDepth', 'breathIntensity', 'freeze',
-      'freezeLfoSync', 'formantLfoSync', 'formantEnvSync', 'freezeLfoRate', 'freezeLfoDepth', 'freezeEnvDepth', 'timeStretchEnvDepth', 'grainEnvDepth', 'grainPitchEnvDepth', 'grainJitter', 'grainPitchQuantize', 'granularPitchShift', 'windowShape', 'customGrainEnvelope', 'formantEnvFollower', 'formantSidechainDepth',
+      'freezeLfoSync', 'formantLfoSync', 'formantEnvSync', 'freezeLfoRate', 'freezeLfoDepth', 'freezeEnvDepth', 'timeStretchEnvDepth', 'grainLfoRate', 'grainLfoDepth', 'grainEnvDepth', 'grainPitchEnvDepth', 'grainJitter', 'grainPitchQuantize', 'granularPitchShift', 'windowShape', 'customGrainEnvelope', 'formantEnvFollower', 'formantSidechainDepth',
       'vocoderMix', 'vocoderFormantShift', 'vocoderPreservation', 'vocoderAttack', 'vocoderRelease',
       'formantLfoRate', 'formantLfoDepth', 'customLfoShape', 'characterMorph', 'attack', 'decay',
       'pitchAmount', 'pitchAttack', 'pitchDecay',

--- a/src/engines/singing-voice/effectsControl.ts
+++ b/src/engines/singing-voice/effectsControl.ts
@@ -121,6 +121,28 @@ export const EffectsControlMixin = {
   },
 
   /**
+   * Set grain LFO rate.
+   * @param rate LFO rate in Hz
+   * @param time Optional time to apply the change (default: now)
+   */
+  setGrainLfoRate(this: SingingVoiceHost, rate: number, time?: number): void {
+    setWorkletParam(this, "grainLfoRate", rate, time);
+  },
+
+  /**
+   * Set grain LFO depth.
+   * @param depth LFO depth (0-1)
+   * @param time Optional time to apply the change (default: now)
+   */
+  setGrainLfoDepth(
+    this: SingingVoiceHost,
+    depth: number,
+    time?: number,
+  ): void {
+    setWorkletParam(this, "grainLfoDepth", depth, time);
+  },
+
+  /**
    * Set envelope follower depth for time stretch modulation.
    * @param depth Depth (-1 to 1)
    * @param time Optional time to apply the change (default: now)

--- a/src/hooks/appState/usePatternHandlers.ts
+++ b/src/hooks/appState/usePatternHandlers.ts
@@ -199,7 +199,7 @@ export function usePatternHandlers(deps: {
              'reverbSend' | 'reverbType' | 'reverbLfoRate' | 'reverbLfoDepth' |
              'delayLfoRate' | 'delayLfoDepth' | 'delaySend' |
              'freezeEnvDepth' | 'timeStretchEnvDepth' | 'spectralPanRate' | 'spectralPanDepth' | 'slideFormant' | 'tremoloRate' | 'tremoloDepth' | 'pan' | 'glitchChance' |
-             'grainEnvDepth' | 'grainPitchEnvDepth' | 'grainJitter' | 'grainPitchQuantize' | 'granularPitchShift' | 'windowShape' | 'customGrainEnvelope' |
+             'grainLfoRate' | 'grainLfoDepth' | 'grainEnvDepth' | 'grainPitchEnvDepth' | 'grainJitter' | 'grainPitchQuantize' | 'granularPitchShift' | 'windowShape' | 'customGrainEnvelope' |
              'choir' | 'gateDepth' | 'gateRate' | 'tranceGate' | 'bitcrush' | 'downsample' | 'vocoderMix' | 'vocoderFormantShift' | 'vocoderPreservation' | 'vocoderAttack' | 'vocoderRelease' | 'pitchAmount' |
              'spectralPanRate' | 'spectralPanDepth' | 'slideFormant' | 'tremoloRate' | 'tremoloDepth' |
              'vowel' | 'portamento' | 'slideFormant' | 'pitchAttack' | 'pitchDecay' | 'pitchAmount',

--- a/src/hooks/audioEngine/samplerPlayback.ts
+++ b/src/hooks/audioEngine/samplerPlayback.ts
@@ -38,6 +38,8 @@ export interface SamplerVoiceContext {
     pFreeze: number | undefined;
     pFreezeLfoRate: number | undefined;
     pFreezeLfoDepth: number | undefined;
+    pGrainLfoRate: number | undefined;
+    pGrainLfoDepth: number | undefined;
     pFreezeEnvDepth: number | undefined;
     pTimeStretchEnvDepth: number | undefined;
     pGrainEnvDepth: number | undefined;
@@ -442,6 +444,8 @@ export function createSamplerPlayback(
         if (ctx.pFreeze !== undefined) voice.setFreeze(ctx.pFreeze, triggerTime);
         if (ctx.pFreezeLfoRate !== undefined) voice.setFreezeLfoRate(ctx.pFreezeLfoRate, triggerTime);
         if (ctx.pFreezeLfoDepth !== undefined) voice.setFreezeLfoDepth(ctx.pFreezeLfoDepth, triggerTime);
+        if (ctx.pGrainLfoRate !== undefined) voice.setGrainLfoRate(ctx.pGrainLfoRate, triggerTime);
+        if (ctx.pGrainLfoDepth !== undefined) voice.setGrainLfoDepth(ctx.pGrainLfoDepth, triggerTime);
 
         if (ctx.pFreezeEnvDepth !== undefined) voice.setFreezeEnvDepth(ctx.pFreezeEnvDepth, triggerTime);
         if (ctx.pTimeStretchEnvDepth !== undefined) voice.setTimeStretchEnvDepth(ctx.pTimeStretchEnvDepth, triggerTime);
@@ -699,6 +703,8 @@ const playSamplerVoice = (
         pFreezeLfoRate = freezeRateSync ? getSyncedLfoHz(params.freezeLfoRate, tempo) : params.freezeLfoRate;
     }
     const pFreezeLfoDepth = noteParams?.freezeLfoDepth !== undefined ? noteParams.freezeLfoDepth : params.freezeLfoDepth;
+    const pGrainLfoRate = noteParams?.grainLfoRate !== undefined ? noteParams.grainLfoRate : params.grainLfoRate;
+    const pGrainLfoDepth = noteParams?.grainLfoDepth !== undefined ? noteParams.grainLfoDepth : params.grainLfoDepth;
 
     // Envelopes
     const pFreezeEnvDepth = noteParams?.freezeEnvDepth !== undefined ? noteParams.freezeEnvDepth : params.freezeEnvDepth;
@@ -782,6 +788,8 @@ const playSamplerVoice = (
                 pFreeze,
                 pFreezeLfoRate,
                 pFreezeLfoDepth,
+                pGrainLfoRate,
+                pGrainLfoDepth,
                 pFreezeEnvDepth,
                 pTimeStretchEnvDepth,
                 pGrainEnvDepth,

--- a/src/hooks/audioEngine/samplerPlayback/playSamplerVoice.ts
+++ b/src/hooks/audioEngine/samplerPlayback/playSamplerVoice.ts
@@ -111,6 +111,8 @@ export function createPlaySamplerVoice(
       pFreezeLfoRate = freezeRateSync ? getSyncedLfoHz(params.freezeLfoRate, tempo) : params.freezeLfoRate;
     }
     const pFreezeLfoDepth = noteParams?.freezeLfoDepth !== undefined ? noteParams.freezeLfoDepth : params.freezeLfoDepth;
+    const pGrainLfoRate = noteParams?.grainLfoRate !== undefined ? noteParams.grainLfoRate : params.grainLfoRate;
+    const pGrainLfoDepth = noteParams?.grainLfoDepth !== undefined ? noteParams.grainLfoDepth : params.grainLfoDepth;
 
     // Envelopes
     const pFreezeEnvDepth = noteParams?.freezeEnvDepth !== undefined ? noteParams.freezeEnvDepth : params.freezeEnvDepth;
@@ -323,6 +325,8 @@ export function createPlaySamplerVoice(
         if (pFreeze !== undefined) voice.setFreeze(pFreeze, triggerTime);
         if (pFreezeLfoRate !== undefined) voice.setFreezeLfoRate(pFreezeLfoRate, triggerTime);
         if (pFreezeLfoDepth !== undefined) voice.setFreezeLfoDepth(pFreezeLfoDepth, triggerTime);
+        if (pGrainLfoRate !== undefined) voice.setGrainLfoRate(pGrainLfoRate, triggerTime);
+        if (pGrainLfoDepth !== undefined) voice.setGrainLfoDepth(pGrainLfoDepth, triggerTime);
 
         if (pFreezeEnvDepth !== undefined) voice.setFreezeEnvDepth(pFreezeEnvDepth, triggerTime);
         if (pTimeStretchEnvDepth !== undefined) voice.setTimeStretchEnvDepth(pTimeStretchEnvDepth, triggerTime);

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,6 +120,8 @@ export interface SamplerBankParams {
   timeStretchEnvDepth?: number;
   grainPitchEnvDepth?: number;
   grainEnvDepth?: number;
+  grainLfoRate?: number;
+  grainLfoDepth?: number;
   grainPitchQuantize?: number;
   granularPitchShift?: number;
   windowShape?: number;
@@ -464,6 +466,8 @@ export interface Note {
   grainJitter?: number;
   grainPitchQuantize?: number;
   grainEnvDepth?: number;
+  grainLfoRate?: number;
+  grainLfoDepth?: number;
   vibratoDepth?: number;
   customWindowShape?: number[];
   reverbSend?: number;

--- a/verification_notes.txt
+++ b/verification_notes.txt
@@ -1,0 +1,1 @@
+Blocked by out-of-scope syntax error in src/components/WaveformDisplay.tsx on base branch


### PR DESCRIPTION
Added per-note and global LFO modulation to granular synthesis grain sizes for expressive, breathing textures in the TTS engine.

- **Audio DSP**: Implemented `grainLfoPhase` calculation in `rubberband-processor.ts` to modulate base grain size smoothly at block-rate.
- **Engine Logic**: Added host methods `setGrainLfoRate` and `setGrainLfoDepth` in `effectsControl.ts` and tied parameter passthrough in `playSamplerVoice.ts` and `samplerPlayback.ts`.
- **UI & State**: Exposed sliders and knobs in `SynthGranularEffects.tsx` and `SamplerKnobControls.tsx`, and updated TS typings, `usePatternHandlers.ts`, and `useSamplerPanelState.ts` to manage the new settings.

---
*PR created automatically by Jules for task [10307971476177457027](https://jules.google.com/task/10307971476177457027) started by @ford442*