### PR TITLE
feat: Phase A WAM2 host compatibility spike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### WAM2 host compatibility spike (Phase A)
+- Local-first Web Audio Modules 2.0 host on the existing declarative graph (`wam2` ids — distinct from AssemblyScript `wam-*` oscillators).
+- Bundled MIT fixtures: `hyphon.tone` (instrument) and `hyphon.gain` (track/master insert).
+- Sequencer notes, one automatable parameter, song save/load, missing-plugin bypass, Engine HUD telemetry.
+- Official SDK pin `@webaudiomodules/sdk@0.0.12` (MIT, lazy-load only). ADR: [0001-wam2-host.md](docs/adr/0001-wam2-host.md).
+
 ### High-fidelity TB-303 offline path (epic #972 / Phase-6 #979)
 - **Multi-core offline rendering**: OpenMP oversampling (`1` / `2` / `4`) and a worker pool for freeze / export / multisample — real-time AudioWorklet latency unchanged ([OFFLINE_303_OVERSAMPLE.md](docs/audio-engine/OFFLINE_303_OVERSAMPLE.md)).
 - **High-Fidelity CPU** (`highfid-cpu`): diode-ladder offline reference with PolyBLEP oscillators and coupled accent ([HIGHFID_CPU_303.md](docs/audio-engine/HIGHFID_CPU_303.md)).

--- a/DOCS.md
+++ b/DOCS.md
@@ -41,6 +41,7 @@ Only these markdown files may live at the repository root. `pnpm run check:root`
 | [docs/plan.md](docs/plan.md) | High-level project planning notes |
 | [docs/automation.md](docs/automation.md) | Automation scheduler + RBS import architecture |
 | [docs/PERFORMANCE_BUDGET.md](docs/PERFORMANCE_BUDGET.md) | Audio-thread budget, auto-degrade order, offline 303 metrics |
+| [docs/adr/0001-wam2-host.md](docs/adr/0001-wam2-host.md) | WAM2 host Phase A: SDK pin, allowlist, CSP, integrity, lifecycle |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ For a quick-start overview see the root [README.md](../README.md).
 |------|---------|
 | [automation.md](automation.md) | Current automation scheduler + RBS import architecture and testing touchpoints |
 | [PERFORMANCE_BUDGET.md](PERFORMANCE_BUDGET.md) | Audio-thread budget, auto-degrade order, offline 303 metrics |
+| [adr/0001-wam2-host.md](adr/0001-wam2-host.md) | WAM2 host Phase A loading/security model (SDK 0.0.12, allowlist, CSP) |
 
 ---
 

--- a/docs/adr/0001-wam2-host.md
+++ b/docs/adr/0001-wam2-host.md
@@ -1,0 +1,76 @@
+# ADR 0001: WAM2 host loading and security model (Phase A)
+
+**Status:** Accepted for Phase A  
+**Date:** 2026-08-17  
+**Supersedes (executable slice):** closed roadmap #882 (unrestricted remote URL host)  
+**Builds on:** #1038 declarative audio graph / compiler
+
+## Context
+
+Hyphon already labels AssemblyScript oscillators as `wam` (`wam-saw`, engine id `wam`). This ADR is about **Web Audio Modules 2.0**. The host uses `wam2` identifiers so the two systems never collide.
+
+The long-term studio goal is first-party AssemblyScript / Rust / Emscripten / WebGPU engines coexisting with standardized community instruments and effects — on **one** declarative graph, not a parallel router.
+
+## Decision
+
+### SDK pin
+
+| Item | Choice |
+|------|--------|
+| Package | `@webaudiomodules/sdk` |
+| Version | **0.0.12** (published 2024-07-26) |
+| License | **MIT** (WebAudioModules Working Group) |
+| Unpacked size | **375.5 KB** (49 files, 0 dependencies) |
+| Load | **Lazy only** via `src/audio/wam/sdk/loadOfficialSdk.ts` (`import(/* @vite-ignore */)`) |
+
+Phase A does **not** add the SDK to `package.json`. First-party fixtures implement the WAM2 *contract* (descriptor, initialize with abort/timeout, `audioNode`, MIDI notes, one automatable param, getState/setState, dispose) using native `OscillatorNode` / `GainNode`. Community plugins stay behind the lazy loader until Phase B’s allowlisted installer exists.
+
+### Loading model
+
+- **Local-first and allowlisted.** v1 loads bundled packages `hyphon.tone` and `hyphon.gain` only. There is no remote JavaScript URL field.
+- Packages are identified by `{ id, version, integrity }`. Integrity is SHA-256 of a canonical fingerprint when `crypto.subtle` is available, otherwise FNV-1a 32-bit in tests.
+- Initialization is bounded (`WAM2_INIT_TIMEOUT_MS = 2000`) and cancellable (`AbortSignal`). Failure/timeout/missing identity leaves a **bypass placeholder**; transport and master output continue.
+- **Never silently substitute** another plugin or first-party engine when a saved plugin is missing or the hash/version does not match.
+
+### Graph integration
+
+WAM nodes are factories on the existing compiler (`wamInstrumentSlot`, `wamTrackInsert`, `wamMasterInsert`, `wamSendReturn`) with dual ports (`input` / `output`). Cycles are rejected unless a `delay` node sits on the cycle (classic Electribe feedback remains legal).
+
+Notes and automation use current paths: sequencer `useStepHandler` + `AutomationScheduler` (`target: 'wam'`, `parameter: 'slotId/paramId'`).
+
+### Security / CSP / isolation
+
+| Surface | Phase A policy |
+|---------|----------------|
+| Network | Denied (`permissions.network: false`). No plugin `fetch`. |
+| Cloud tokens / filesystem | Denied. Plugins never receive `CloudStorage` or project FS abstractions. |
+| CSP | Same-origin scripts/worklets only. Do not add `unsafe-eval` or remote `script-src` for plugins. |
+| COOP/COEP | Unchanged Vite headers (`same-origin` / `require-corp`). Required for threaded WASM; WAM2 fixtures do not need `SharedArrayBuffer`. Runtime probe: `crossOriginIsolated` + `BASE_URL` in Engine HUD. |
+| Worklet / Worker | Fixtures do not spawn extra worklets/workers. Community SDK plugins that do must remain same-origin. |
+| Subdirectory deploy | Descriptors live under `public/wam/` and are resolved with `resolvePublicAsset` / Vite `base: './'`. |
+| Package integrity | Fingerprint hash stored on the song; mismatch → missing placeholder, not a substitute. |
+
+### Lifecycle
+
+Mount → integrity check → initialize (timeout) → attach to slot ports → restore state → telemetry. Dispose disconnects AudioNodes deterministically. A crash in one slot sets bypass gain; other slots and the master chain stay connected.
+
+### Offline render / freeze
+
+| Fixture | Position |
+|---------|----------|
+| `hyphon.tone` / `hyphon.gain` | `offline: 'native'` (same Web Audio nodes work in `OfflineAudioContext`) |
+| Official SDK / community WAMs | **Unsupported** in Phase A — show an explicit unsupported badge. Do not fake freeze with a different engine. |
+
+### Bundle impact
+
+| Chunk | Cost |
+|-------|------|
+| Main entry (`main.tsx` / `App.tsx`) | **0 bytes** of `@webaudiomodules/sdk` (static import forbidden; unit-tested) |
+| Official SDK if lazy-loaded | 375.5 KB unpacked (~gzip well under that; measure again when added to lockfile) |
+| First-party host + fixtures | TypeScript in `src/audio/wam/**` compiled into the app chunk that already owns the audio engine (~small; no extra WASM) |
+
+## Consequences
+
+- Phase B can install the pinned SDK as a dependency and lazy-import it for allowlisted community packages without changing song schema.
+- Product work (browser/install/update, generic editor, CPU meters from worklets) stays out of Phase A.
+- Naming: UI copy for Web Audio Modules must say **WAM2**, not **WAM**, until the AssemblyScript oscillator family is renamed.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -13,6 +13,7 @@ This document summarizes the current automation architecture and how `.rbs` data
   - `scheduleFromLanes()` handles step-indexed lanes from app state/import.
   - `scheduleFromTrakEvents()` handles RBS TRAK tick events.
   - Open303 parameters are applied through `Open303Manager.scheduleParamAtTime()` per voice (`lead303`, `bass1`, `bass2`).
+- WAM2 parameters use `target: 'wam'` and `parameter: '<slotId>/<paramId>'` via `AutomationScheduler.setWamHost()`.
 
 ## Practical importer behavior
 

--- a/public/wam/catalog.json
+++ b/public/wam/catalog.json
@@ -1,0 +1,24 @@
+{
+  "sdk": {
+    "package": "@webaudiomodules/sdk",
+    "version": "0.0.12",
+    "license": "MIT",
+    "load": "lazy"
+  },
+  "packages": [
+    {
+      "id": "hyphon.tone",
+      "version": "1.0.0",
+      "kind": "instrument",
+      "license": "MIT",
+      "origin": "bundled"
+    },
+    {
+      "id": "hyphon.gain",
+      "version": "1.0.0",
+      "kind": "effect",
+      "license": "MIT",
+      "origin": "bundled"
+    }
+  ]
+}

--- a/src/audio/automation/AutomationScheduler.ts
+++ b/src/audio/automation/AutomationScheduler.ts
@@ -36,6 +36,7 @@ import { automationStore } from '../../stores/automationStore';
 import type { Open303Manager } from '../../engines/Open303Manager';
 import type { ProphecyManager } from '../../engines/ProphecyManager';
 import type { PcfEffect } from '../../engines/PcfEffect';
+import type { WamHost } from '../wam/WamHost';
 import {
   playbackHealthMonitor,
   PLAYBACK_THRESHOLDS,
@@ -138,6 +139,7 @@ export class AutomationScheduler {
   private open303Manager: Open303Manager | null;
   private prophecyManager: ProphecyManager | null = null;
   private pcfEffect: PcfEffect | null = null;
+  private wamHost: WamHost | null = null;
 
   private readonly lookaheadSeconds: number;
   private readonly rampDuration: number;
@@ -178,6 +180,11 @@ export class AutomationScheduler {
    */
   setPcfEffect(effect: PcfEffect | null): void {
     this.pcfEffect = effect;
+  }
+
+  /** Route `target: 'wam'` lanes to a mounted WAM2 slot (`parameter` = `slotId/paramId`). */
+  setWamHost(host: WamHost | null): void {
+    this.wamHost = host;
   }
 
   /** Update ProphecyManager for audio-clock vowel/portamento automation. */
@@ -388,6 +395,16 @@ export class AutomationScheduler {
           }, delayMs);
           this.pendingTimeouts.push(id);
         }
+        break;
+      }
+      case 'wam': {
+        if (!this.wamHost) return;
+        const slash = parameter.indexOf('/');
+        if (slash <= 0) return;
+        const slotId = parameter.slice(0, slash);
+        const paramId = parameter.slice(slash + 1);
+        const effectiveTime = this._effectiveAudioTime(audioTime, target, parameter);
+        this.wamHost.setParam(slotId, paramId, clamp01(value), effectiveTime);
         break;
       }
       default:

--- a/src/audio/graph/__tests__/compileGraph.test.ts
+++ b/src/audio/graph/__tests__/compileGraph.test.ts
@@ -44,6 +44,7 @@ function createTrackingContext(): {
             const node = makeNode('gain');
             return Object.assign(node, {
                 gain: { value: 1, setValueAtTime: () => {} },
+                disconnect: () => {},
             });
         },
         createWaveShaper: () => makeNode('waveShaper'),

--- a/src/audio/graph/__tests__/cycleCheck.test.ts
+++ b/src/audio/graph/__tests__/cycleCheck.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { CLASSIC_ELECTRIBE_GRAPH } from '../defaultElectribeGraph';
+import { assertSafeGraphCycles, GraphCycleError } from '../cycleCheck';
+import type { AudioGraphConfig } from '../types';
+
+describe('assertSafeGraphCycles', () => {
+  it('allows the classic delay feedback loop', () => {
+    expect(() => assertSafeGraphCycles(CLASSIC_ELECTRIBE_GRAPH)).not.toThrow();
+  });
+
+  it('rejects a gain-only cycle', () => {
+    const cyclic: AudioGraphConfig = {
+      id: 'bad',
+      name: 'bad',
+      nodes: [
+        { id: 'a', factory: 'gain' },
+        { id: 'b', factory: 'gain' },
+      ],
+      edges: [
+        { from: 'a', to: 'b' },
+        { from: 'b', to: 'a' },
+      ],
+    };
+    expect(() => assertSafeGraphCycles(cyclic)).toThrow(GraphCycleError);
+  });
+});

--- a/src/audio/graph/compileGraph.ts
+++ b/src/audio/graph/compileGraph.ts
@@ -1,5 +1,7 @@
 import { makeDistortionCurve } from '../../hooks/audioEngine/distortion';
 import { createReverbImpulseResponse } from '../impulseResponses';
+import { WamSlotPorts } from '../wam/WamSlotPorts';
+import { assertSafeGraphCycles } from './cycleCheck';
 import type {
     AnalyserConfig,
     AudioGraphConfig,
@@ -15,6 +17,7 @@ import type {
     GraphNodeId,
     GraphNodeRole,
     GraphNodeSpec,
+    GraphPortPair,
     StereoPannerConfig,
     TrackMonitorConfig,
     WaveShaperConfig,
@@ -59,6 +62,7 @@ function createNode(
     spec: GraphNodeSpec,
     options: Required<CompileGraphOptions>,
     analysers: Map<GraphNodeId, AnalyserNode>,
+    ports: Map<GraphNodeId, GraphPortPair>,
 ): AudioNode | null {
     const { factory, id, config } = spec;
 
@@ -150,6 +154,14 @@ function createNode(
             return options.createMasterLimiterNode(context);
         case 'destination':
             return context.destination;
+        case 'wamInstrumentSlot':
+        case 'wamTrackInsert':
+        case 'wamMasterInsert':
+        case 'wamSendReturn': {
+            const slot = new WamSlotPorts(context);
+            ports.set(id, { input: slot.input, output: slot.output, wamSlot: slot });
+            return slot.output;
+        }
         default:
             throw new Error(`Unknown graph node factory: ${factory}`);
     }
@@ -209,16 +221,21 @@ export function compileAudioGraph(
     config: AudioGraphConfig,
     options: CompileGraphOptions = {},
 ): CompiledAudioGraph {
+    assertSafeGraphCycles(config);
     const resolved = { ...DEFAULT_OPTIONS, ...options };
     const nodes = new Map<GraphNodeId, AudioNode>();
+    const ports = new Map<GraphNodeId, GraphPortPair>();
     const analysers = new Map<GraphNodeId, AnalyserNode>();
     const roles = new Map<GraphNodeRole, GraphNodeId | GraphNodeId[]>();
     const connectionLog: GraphConnectionRecord[] = [];
 
     for (const spec of config.nodes) {
-        const node = createNode(context, spec, resolved, analysers);
+        const node = createNode(context, spec, resolved, analysers, ports);
         if (node) {
             nodes.set(spec.id, node);
+            if (!ports.has(spec.id)) {
+                ports.set(spec.id, { input: node, output: node });
+            }
             if (spec.role) {
                 registerRole(roles, spec.role, spec.id);
             }
@@ -250,8 +267,13 @@ export function compileAudioGraph(
     }
 
     for (const edge of edges) {
-        const fromNode = nodes.get(edge.from);
-        const toNode = nodes.get(edge.to) ?? (edge.to === 'destination' ? context.destination : undefined);
+        const fromPort = ports.get(edge.from);
+        const toPort = ports.get(edge.to);
+        const fromNode = fromPort?.output ?? nodes.get(edge.from);
+        const toNode =
+            toPort?.input ??
+            nodes.get(edge.to) ??
+            (edge.to === 'destination' ? context.destination : undefined);
         if (!fromNode || !toNode) {
             if (!hasStereoPanner && (edge.to === 'masterPanner' || edge.from === 'masterPanner')) {
                 continue;
@@ -272,6 +294,7 @@ export function compileAudioGraph(
         configId: config.id,
         configName: config.name,
         nodes,
+        ports,
         analysers,
         roles,
         connectionLog,
@@ -281,6 +304,13 @@ export function compileAudioGraph(
                 throw new Error(`AudioGraph node not found: ${id}`);
             }
             return node as T;
+        },
+        getPort(id: GraphNodeId): GraphPortPair {
+            const pair = ports.get(id);
+            if (!pair) {
+                throw new Error(`AudioGraph port not found: ${id}`);
+            }
+            return pair;
         },
         getRoleNode(role: GraphNodeRole): AudioNode | undefined {
             const entry = roles.get(role);

--- a/src/audio/graph/cycleCheck.ts
+++ b/src/audio/graph/cycleCheck.ts
@@ -1,0 +1,115 @@
+import type { AudioGraphConfig, GraphNodeFactory, GraphNodeId } from './types';
+
+/**
+ * Delay-class factories that make a feedback loop audio-safe (a time offset
+ * exists in the cycle). All other cycles are rejected.
+ */
+const DELAY_FACTORIES = new Set<GraphNodeFactory>(['delay']);
+
+export class GraphCycleError extends Error {
+  readonly cycle: readonly GraphNodeId[];
+
+  constructor(cycle: readonly GraphNodeId[]) {
+    super(
+      `AudioGraph compile failed: unsafe cycle ${cycle.join(' → ')} (feedback requires a delay node)`,
+    );
+    this.name = 'GraphCycleError';
+    this.cycle = cycle;
+  }
+}
+
+function factoryById(config: AudioGraphConfig): Map<GraphNodeId, GraphNodeFactory> {
+  const map = new Map<GraphNodeId, GraphNodeFactory>();
+  for (const node of config.nodes) {
+    map.set(node.id, node.factory);
+  }
+  return map;
+}
+
+function adjacency(config: AudioGraphConfig): Map<GraphNodeId, GraphNodeId[]> {
+  const adj = new Map<GraphNodeId, GraphNodeId[]>();
+  for (const node of config.nodes) {
+    adj.set(node.id, []);
+  }
+  for (const edge of config.edges) {
+    const list = adj.get(edge.from);
+    if (list) {
+      list.push(edge.to);
+    } else {
+      adj.set(edge.from, [edge.to]);
+    }
+  }
+  return adj;
+}
+
+/**
+ * DFS that records one simple cycle if present. Returns node ids in cycle
+ * order including the repeated start node at the end.
+ */
+function findCycle(adj: Map<GraphNodeId, GraphNodeId[]>): GraphNodeId[] | null {
+  const WHITE = 0;
+  const GRAY = 1;
+  const BLACK = 2;
+  const color = new Map<GraphNodeId, number>();
+  const parent = new Map<GraphNodeId, GraphNodeId | null>();
+  for (const id of adj.keys()) {
+    color.set(id, WHITE);
+    parent.set(id, null);
+  }
+
+  let found: GraphNodeId[] | null = null;
+
+  const visit = (u: GraphNodeId): void => {
+    if (found) return;
+    color.set(u, GRAY);
+    for (const v of adj.get(u) ?? []) {
+      if (found) return;
+      const c = color.get(v) ?? WHITE;
+      if (c === WHITE) {
+        parent.set(v, u);
+        visit(v);
+      } else if (c === GRAY) {
+        const cycle: GraphNodeId[] = [v];
+        let cur: GraphNodeId | null = u;
+        while (cur && cur !== v) {
+          cycle.push(cur);
+          cur = parent.get(cur) ?? null;
+        }
+        cycle.push(v);
+        cycle.reverse();
+        found = cycle;
+        return;
+      }
+    }
+    color.set(u, BLACK);
+  };
+
+  for (const id of adj.keys()) {
+    if ((color.get(id) ?? WHITE) === WHITE) {
+      visit(id);
+    }
+  }
+  return found;
+}
+
+function cycleHasDelay(
+  cycle: readonly GraphNodeId[],
+  factories: Map<GraphNodeId, GraphNodeFactory>,
+): boolean {
+  // Last id repeats the start; skip it.
+  const unique = cycle.slice(0, -1);
+  return unique.some((id) => DELAY_FACTORIES.has(factories.get(id) ?? 'gain'));
+}
+
+/**
+ * Reject graph cycles unless at least one delay node sits on the cycle.
+ * The classic Electribe delay feedback loop is the allowed example.
+ */
+export function assertSafeGraphCycles(config: AudioGraphConfig): void {
+  const adj = adjacency(config);
+  const cycle = findCycle(adj);
+  if (!cycle) return;
+  const factories = factoryById(config);
+  if (cycleHasDelay(cycle, factories)) return;
+  throw new GraphCycleError(cycle);
+}

--- a/src/audio/graph/index.ts
+++ b/src/audio/graph/index.ts
@@ -128,4 +128,6 @@ export type {
     GraphConnectionRecord,
     GraphNodeId,
     GraphNodeRole,
+    GraphPortPair,
 } from './types';
+export { assertSafeGraphCycles, GraphCycleError } from './cycleCheck';

--- a/src/audio/graph/types.ts
+++ b/src/audio/graph/types.ts
@@ -15,7 +15,11 @@ export type GraphNodeRole =
     | 'trackAnalyser'
     | 'auxReturn'
     | 'choirBus'
-    | 'internal';
+    | 'internal'
+    | 'instrumentSource'
+    | 'trackInsert'
+    | 'masterInsert'
+    | 'auxSend';
 
 export type GraphNodeFactory =
     | 'waveShaper'
@@ -28,7 +32,11 @@ export type GraphNodeFactory =
     | 'delay'
     | 'trackMonitor'
     | 'masterLimiter'
-    | 'destination';
+    | 'destination'
+    | 'wamInstrumentSlot'
+    | 'wamTrackInsert'
+    | 'wamMasterInsert'
+    | 'wamSendReturn';
 
 export interface BiquadFilterConfig {
     type: BiquadFilterType;
@@ -116,15 +124,25 @@ export interface GraphConnectionRecord {
     order: number;
 }
 
+/** Dual-port pair so inserts have a distinct input and output. */
+export interface GraphPortPair {
+    input: AudioNode;
+    output: AudioNode;
+    wamSlot?: import('../wam/WamSlotPorts').WamSlotPorts;
+}
+
 export interface CompiledAudioGraph {
     configId: string;
     configName: string;
     nodes: ReadonlyMap<GraphNodeId, AudioNode>;
+    /** Incoming/outgoing ports. Simple nodes have input === output. */
+    ports: ReadonlyMap<GraphNodeId, GraphPortPair>;
     /** Passive analyser taps keyed by graph node id (trackMonitor nodes). */
     analysers: ReadonlyMap<GraphNodeId, AnalyserNode>;
     roles: ReadonlyMap<GraphNodeRole, GraphNodeId | GraphNodeId[]>;
     connectionLog: readonly GraphConnectionRecord[];
     getNode<T extends AudioNode = AudioNode>(id: GraphNodeId): T;
+    getPort(id: GraphNodeId): GraphPortPair;
     getRoleNode(role: GraphNodeRole): AudioNode | undefined;
     getRoleNodes(role: GraphNodeRole): AudioNode[];
 }

--- a/src/audio/wam/WamHost.ts
+++ b/src/audio/wam/WamHost.ts
@@ -1,0 +1,358 @@
+import { engineDegradationStore } from '../../stores/engineDegradationStore';
+import { engineTelemetry } from '../../utils/engineTelemetry';
+import { noteToMidi } from '../../utils/musicTheory';
+import type { CompiledAudioGraph, GraphNodeId } from '../graph/types';
+import { applyWamSlotsToGraph } from './applySlots';
+import { getBundledPackage, isAllowlistedPackageId } from './catalog';
+import { createBundledPlugin } from './fixtures';
+import { hashCanonicalJson, integrityMatches } from './integrity';
+import { planWam2Restore, serializeWam2SongState, type Wam2SongPayload } from './persist';
+import { collectWam2RuntimeConstraints } from './runtimeConstraints';
+import type {
+  Wam2NoteEvent,
+  Wam2Plugin,
+  Wam2PluginInstanceState,
+  Wam2SlotStatus,
+  Wam2SlotTelemetry,
+} from './types';
+import { WAM2_DEFAULT_PERMISSIONS, WAM2_INIT_TIMEOUT_MS } from './types';
+import { WamSlotPorts } from './WamSlotPorts';
+
+interface LiveSlot {
+  instance: Wam2PluginInstanceState;
+  ports: WamSlotPorts;
+  plugin: Wam2Plugin | null;
+  status: Wam2SlotStatus;
+  lastError?: string;
+  cpuPercent: number;
+  latencyMs: number;
+  integrityOk: boolean;
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, signal: AbortSignal): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`WAM2 init timed out after ${ms}ms`));
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException('The operation was aborted.', 'AbortError'));
+    };
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (err: unknown) => {
+        clearTimeout(timer);
+        signal.removeEventListener('abort', onAbort);
+        reject(err);
+      },
+    );
+  });
+}
+
+export class WamHost {
+  private readonly slots = new Map<string, LiveSlot>();
+  private graph: CompiledAudioGraph | null = null;
+  private disposed = false;
+  private readonly context: AudioContext;
+
+  constructor(context: AudioContext) {
+    this.context = context;
+  }
+
+  attachCompiledGraph(graph: CompiledAudioGraph): void {
+    this.graph = graph;
+  }
+
+  getSlotPorts(slotId: string): WamSlotPorts | undefined {
+    return this.slots.get(slotId)?.ports;
+  }
+
+  takesOverTrack(trackKey: 'partA' | 'partB' | 'bass2'): boolean {
+    for (const slot of this.slots.values()) {
+      if (
+        slot.instance.placement === 'instrument' &&
+        slot.instance.trackKey === trackKey &&
+        slot.status === 'ready' &&
+        slot.plugin
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  scheduleTrackNotes(
+    trackKey: 'partA' | 'partB' | 'bass2',
+    notes: string | string[],
+    time: number,
+    durationSeconds: number,
+    velocity: number,
+  ): void {
+    const list = Array.isArray(notes) ? notes : [notes];
+    for (const slot of this.slots.values()) {
+      if (slot.instance.trackKey !== trackKey || slot.status !== 'ready' || !slot.plugin?.noteOn) {
+        continue;
+      }
+      for (const note of list) {
+        const event: Wam2NoteEvent = {
+          midi: noteToMidi(note),
+          velocity,
+          time,
+          durationSeconds,
+        };
+        slot.plugin.noteOn(event);
+      }
+    }
+  }
+
+  setParam(slotId: string, paramId: string, value: number, time?: number): void {
+    const slot = this.slots.get(slotId);
+    if (!slot?.plugin || slot.status !== 'ready') return;
+    slot.plugin.setParam(paramId, value, time);
+    slot.instance.paramState[paramId] = value;
+  }
+
+  exportSongState(): Wam2SongPayload {
+    const plugins: Wam2PluginInstanceState[] = [];
+    for (const slot of this.slots.values()) {
+      plugins.push({
+        ...slot.instance,
+        paramState: slot.plugin ? { ...slot.instance.paramState, gain: slot.plugin.getParam('gain') } : slot.instance.paramState,
+        pluginState: slot.plugin?.getState() ?? slot.instance.pluginState,
+      });
+    }
+    return serializeWam2SongState(plugins);
+  }
+
+  telemetry(): Wam2SlotTelemetry[] {
+    return [...this.slots.values()].map((slot) => ({
+      slotId: slot.instance.slotId,
+      packageId: slot.instance.packageId,
+      version: slot.instance.version,
+      origin: 'bundled',
+      placement: slot.instance.placement,
+      status: slot.status,
+      cpuPercent: slot.cpuPercent,
+      latencyMs: slot.latencyMs,
+      lastError: slot.lastError,
+      isolation: 'audio-graph-slot',
+      permissions: WAM2_DEFAULT_PERMISSIONS,
+      offline: slot.plugin?.descriptor.offline ?? 'unsupported',
+      integrityOk: slot.integrityOk,
+    }));
+  }
+
+  publishTelemetry(): void {
+    const slots = this.telemetry();
+    engineTelemetry.recordWam2Slots(slots);
+    engineTelemetry.recordWam2Constraints(collectWam2RuntimeConstraints());
+    for (const slot of slots) {
+      engineTelemetry.registerResolution(
+        `wam2:${slot.slotId}`,
+        slot.status,
+        slot.lastError ?? slot.packageId,
+      );
+      engineTelemetry.recordLatency(`wam2:${slot.slotId}`, slot.latencyMs);
+      if (slot.lastError) {
+        engineTelemetry.recordError(`wam2:${slot.slotId}`, slot.lastError);
+      }
+    }
+  }
+
+  async restore(payload: Wam2SongPayload | undefined, portsById?: Map<GraphNodeId, WamSlotPorts>): Promise<void> {
+    const plan = await planWam2Restore(payload);
+    const ports = portsById ?? (this.graph ? collectSlotPorts(this.graph) : new Map());
+
+    for (const missing of plan.missing) {
+      const slotPorts = ports.get(missing.slotId) ?? this.ensureLiveSlotPorts(missing);
+      this.slots.set(missing.slotId, {
+        instance: missing,
+        ports: slotPorts,
+        plugin: null,
+        status: isAllowlistedPackageId(missing.packageId) ? 'failed' : 'missing',
+        lastError: isAllowlistedPackageId(missing.packageId)
+          ? 'integrity or version mismatch — not substituted'
+          : `missing plugin ${missing.packageId}@${missing.version}`,
+        cpuPercent: 0,
+        latencyMs: 0,
+        integrityOk: false,
+      });
+      slotPorts.failSafeBypass();
+      this.reportPlaceholder(missing.slotId, 'missing plugin — slot bypassed');
+    }
+    for (const instance of plan.load) {
+      const slotPorts = ports.get(instance.slotId) ?? this.ensureLiveSlotPorts(instance);
+      await this.mountInstance(instance, slotPorts);
+    }
+    this.publishTelemetry();
+  }
+
+  private ensureLiveSlotPorts(instance: Wam2PluginInstanceState): WamSlotPorts {
+    const existing = this.slots.get(instance.slotId)?.ports;
+    if (existing) return existing;
+    const ports = new WamSlotPorts(this.context);
+    if (this.graph) {
+      try {
+        this.spliceLive(instance, ports);
+      } catch {
+        /* graph may already include the slot from compile-time apply */
+      }
+    }
+    return ports;
+  }
+
+  private spliceLive(instance: Wam2PluginInstanceState, ports: WamSlotPorts): void {
+    if (!this.graph) return;
+    if (instance.placement === 'instrument') {
+      const dest = this.graph.getPort(instance.attachToNodeId).input;
+      ports.output.connect(dest);
+      return;
+    }
+    if (instance.placement === 'sendReturn') {
+      const src = this.graph.getPort(instance.attachToNodeId).output;
+      const fx = this.graph.getPort('masterSaturation').input;
+      src.connect(ports.input);
+      ports.output.connect(fx);
+      return;
+    }
+    const fromId = instance.interceptFromNodeId;
+    if (!fromId) return;
+    const from = this.graph.getPort(fromId).output;
+    const to = this.graph.getPort(instance.attachToNodeId).input;
+    try {
+      from.disconnect(to);
+    } catch {
+      /* mock / already disconnected */
+    }
+    from.connect(ports.input);
+    ports.output.connect(to);
+  }
+
+  async mountInstance(instance: Wam2PluginInstanceState, ports: WamSlotPorts): Promise<void> {
+    const started = typeof performance !== 'undefined' ? performance.now() : 0;
+    const controller = new AbortController();
+    const live: LiveSlot = {
+      instance,
+      ports,
+      plugin: null,
+      status: 'loading',
+      cpuPercent: 0,
+      latencyMs: 0,
+      integrityOk: false,
+    };
+    this.slots.set(instance.slotId, live);
+
+    try {
+      const bundled = await getBundledPackage(instance.packageId);
+      if (!bundled) {
+        throw new Error(`not allowlisted: ${instance.packageId}`);
+      }
+      const fingerprint = {
+        id: bundled.id,
+        kind: bundled.kind,
+        license: bundled.license,
+        params: bundled.params.map((p) => p.id),
+        title: bundled.title,
+        vendor: bundled.vendor,
+        version: bundled.version,
+      };
+      const hash = await hashCanonicalJson(fingerprint);
+      live.integrityOk = integrityMatches(bundled.integrity, hash);
+      if (!live.integrityOk) {
+        throw new Error('package integrity check failed');
+      }
+
+      const plugin = await createBundledPlugin(instance.packageId);
+      await withTimeout(plugin.initialize(this.context, controller.signal), WAM2_INIT_TIMEOUT_MS, controller.signal);
+
+      if (instance.pluginState !== undefined) {
+        plugin.setState(instance.pluginState);
+      }
+      for (const [paramId, value] of Object.entries(instance.paramState)) {
+        plugin.setParam(paramId, value);
+      }
+      if (instance.bypass) {
+        ports.failSafeBypass();
+        live.status = 'bypassed';
+      } else if (instance.placement === 'instrument') {
+        ports.attachInstrument(plugin.audioNode);
+        live.status = 'ready';
+      } else {
+        ports.attachPlugin(plugin.audioNode);
+        live.status = 'ready';
+      }
+      live.plugin = plugin;
+      live.latencyMs = (typeof performance !== 'undefined' ? performance.now() : started) - started;
+      live.cpuPercent = 0;
+      engineDegradationStore.resolve(`wam2:${instance.slotId}`);
+    } catch (err) {
+      controller.abort();
+      const message = err instanceof Error ? err.message : String(err);
+      const timedOut = message.includes('timed out');
+      live.status = timedOut ? 'timeout' : 'failed';
+      live.lastError = message;
+      live.plugin = null;
+      ports.failSafeBypass();
+      this.reportPlaceholder(instance.slotId, message);
+    }
+  }
+
+  private reportPlaceholder(slotId: string, reason: string): void {
+    engineDegradationStore.report({
+      id: `wam2:${slotId}`,
+      subsystem: 'wam2',
+      category: 'audio',
+      message: 'WAM2 slot bypassed',
+      reason,
+      status: 'active',
+      activeBackend: 'bypass-placeholder',
+      requestedBackend: 'wam2-plugin',
+      retryable: false,
+    });
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    for (const slot of this.slots.values()) {
+      slot.plugin?.dispose();
+      slot.ports.dispose();
+    }
+    this.slots.clear();
+    this.graph = null;
+  }
+}
+
+let activeHost: WamHost | null = null;
+
+export function getWamHost(): WamHost | null {
+  return activeHost;
+}
+
+export function setWamHost(host: WamHost | null): void {
+  if (activeHost && activeHost !== host) {
+    activeHost.dispose();
+  }
+  activeHost = host;
+}
+
+export function collectSlotPorts(graph: CompiledAudioGraph): Map<GraphNodeId, WamSlotPorts> {
+  const out = new Map<GraphNodeId, WamSlotPorts>();
+  for (const [id, port] of graph.ports) {
+    if (port.wamSlot) {
+      out.set(id, port.wamSlot);
+    }
+  }
+  return out;
+}
+
+export { applyWamSlotsToGraph };

--- a/src/audio/wam/WamSlotPorts.ts
+++ b/src/audio/wam/WamSlotPorts.ts
@@ -1,0 +1,84 @@
+/**
+ * Dual-port bypass wrapper used as a graph node factory result.
+ *
+ * Incoming edges connect to `input`; outgoing edges connect from `output`.
+ * A plugin crash or timeout leaves the dry bypass path open so transport
+ * and master output keep running.
+ */
+
+export class WamSlotPorts {
+  readonly input: GainNode;
+  readonly output: GainNode;
+  readonly bypass: GainNode;
+  readonly wet: GainNode;
+  private plugin: AudioNode | null = null;
+
+  constructor(context: AudioContext) {
+    this.input = context.createGain();
+    this.output = context.createGain();
+    this.bypass = context.createGain();
+    this.wet = context.createGain();
+    this.input.gain.value = 1;
+    this.output.gain.value = 1;
+    this.bypass.gain.value = 1;
+    this.wet.gain.value = 0;
+    this.input.connect(this.bypass);
+    this.bypass.connect(this.output);
+    this.input.connect(this.wet);
+    this.wet.connect(this.output);
+  }
+
+  attachPlugin(node: AudioNode): void {
+    this.detachPlugin();
+    this.wet.disconnect();
+    this.wet.connect(node);
+    node.connect(this.output);
+    this.plugin = node;
+    this.bypass.gain.value = 0;
+    this.wet.gain.value = 1;
+  }
+
+  /** Instrument sources have no audio input — plugin output feeds the slot. */
+  attachInstrument(node: AudioNode): void {
+    this.detachPlugin();
+    node.connect(this.output);
+    this.plugin = node;
+    this.bypass.gain.value = 0;
+    this.wet.gain.value = 0;
+  }
+
+  failSafeBypass(): void {
+    this.bypass.gain.value = 1;
+    this.wet.gain.value = 0;
+  }
+
+  detachPlugin(): void {
+    if (this.plugin) {
+      try {
+        this.plugin.disconnect();
+      } catch {
+        /* already disconnected */
+      }
+      this.plugin = null;
+    }
+    try {
+      this.wet.disconnect();
+    } catch {
+      /* already disconnected */
+    }
+    this.wet.connect(this.output);
+    this.failSafeBypass();
+  }
+
+  dispose(): void {
+    this.detachPlugin();
+    try {
+      this.input.disconnect();
+      this.bypass.disconnect();
+      this.wet.disconnect();
+      this.output.disconnect();
+    } catch {
+      /* AudioContext closed */
+    }
+  }
+}

--- a/src/audio/wam/__tests__/WamHost.test.ts
+++ b/src/audio/wam/__tests__/WamHost.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import { applyWamSlotsToGraph } from '../applySlots';
+import { CLASSIC_ELECTRIBE_GRAPH, compileAudioGraph } from '../../graph';
+import { finalizeBundledCatalog, HYPHON_GAIN_PACKAGE_ID, HYPHON_TONE_PACKAGE_ID } from '../catalog';
+import { collectSlotPorts, WamHost } from '../WamHost';
+import { serializeWam2SongState, planWam2Restore } from '../persist';
+import { OFFICIAL_WAM_SDK_PACKAGE, OFFICIAL_WAM_SDK_VERSION } from '../types';
+import type { Wam2PluginInstanceState } from '../types';
+import { engineTelemetry } from '../../../utils/engineTelemetry';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { makeWamTestAudioContext } from './audioContextMock';
+
+function makeToneInstance(overrides?: Partial<Wam2PluginInstanceState>): Wam2PluginInstanceState {
+  return {
+    slotId: 'wam-tone-1',
+    packageId: HYPHON_TONE_PACKAGE_ID,
+    version: '1.0.0',
+    integrity: { alg: 'fnv1a32', value: 'pending' },
+    placement: 'instrument',
+    attachToNodeId: 'synthABus',
+    trackKey: 'partA',
+    paramState: { gain: 0.5 },
+    pluginState: { gain: 0.5, extra: { preset: 'spike' } },
+    ...overrides,
+  };
+}
+
+function makeGainInstance(overrides?: Partial<Wam2PluginInstanceState>): Wam2PluginInstanceState {
+  return {
+    slotId: 'wam-gain-1',
+    packageId: HYPHON_GAIN_PACKAGE_ID,
+    version: '1.0.0',
+    integrity: { alg: 'fnv1a32', value: 'pending' },
+    placement: 'trackInsert',
+    attachToNodeId: 'masterSaturation',
+    interceptFromNodeId: 'synthABus',
+    paramState: { gain: 0.7 },
+    ...overrides,
+  };
+}
+
+async function withIntegrity<T extends Wam2PluginInstanceState>(instance: T): Promise<T> {
+  const catalog = await finalizeBundledCatalog();
+  const pkg = catalog.find((p) => p.id === instance.packageId);
+  if (!pkg) throw new Error('missing catalog');
+  return { ...instance, version: pkg.version, integrity: { ...pkg.integrity } };
+}
+
+describe('WAM2 Phase A host', () => {
+  it('compiles instrument + insert ports into the existing graph', async () => {
+    const tone = await withIntegrity(makeToneInstance());
+    const fx = await withIntegrity(makeGainInstance());
+    const config = applyWamSlotsToGraph(CLASSIC_ELECTRIBE_GRAPH, [tone, fx]);
+    const graph = compileAudioGraph(makeWamTestAudioContext(), config);
+    expect(graph.getPort('wam-tone-1').wamSlot).toBeDefined();
+    expect(graph.getPort('wam-gain-1').input).not.toBe(graph.getPort('wam-gain-1').output);
+    const pairs = graph.connectionLog.map((c) => `${c.from}->${c.to}`);
+    expect(pairs).toContain('wam-tone-1->synthABus');
+    expect(pairs).toContain('synthABus->wam-gain-1');
+    expect(pairs).toContain('wam-gain-1->masterSaturation');
+    expect(pairs).not.toContain('synthABus->masterSaturation');
+  });
+
+  it('plays sequencer notes through the instrument source port', async () => {
+    const tone = await withIntegrity(makeToneInstance());
+    const config = applyWamSlotsToGraph(CLASSIC_ELECTRIBE_GRAPH, [tone]);
+    const ctx = makeWamTestAudioContext();
+    const graph = compileAudioGraph(ctx, config);
+    const host = new WamHost(ctx);
+    host.attachCompiledGraph(graph);
+    await host.restore(serializeWam2SongState([tone]), collectSlotPorts(graph));
+    expect(host.takesOverTrack('partA')).toBe(true);
+    host.scheduleTrackNotes('partA', 'A4', 0, 0.25, 0.9);
+    expect(ctx.createOscillator).toHaveBeenCalled();
+    expect(host.telemetry()[0]?.status).toBe('ready');
+  });
+
+  it('runs the bundled effect in a track insert and automates gain', async () => {
+    const fx = await withIntegrity(makeGainInstance({ paramState: { gain: 0.2 } }));
+    const config = applyWamSlotsToGraph(CLASSIC_ELECTRIBE_GRAPH, [fx]);
+    const ctx = makeWamTestAudioContext();
+    const graph = compileAudioGraph(ctx, config);
+    const host = new WamHost(ctx);
+    host.attachCompiledGraph(graph);
+    await host.restore(serializeWam2SongState([fx]), collectSlotPorts(graph));
+    host.setParam('wam-gain-1', 'gain', 0.9, 0);
+    const exported = host.exportSongState();
+    expect(exported.plugins[0]?.paramState.gain).toBe(0.9);
+  });
+
+  it('round-trips plugin state and keeps missing plugins as bypass placeholders', async () => {
+    const tone = await withIntegrity(makeToneInstance());
+    const missing: Wam2PluginInstanceState = {
+      slotId: 'wam-gone',
+      packageId: 'community.unknown',
+      version: '9.9.9',
+      integrity: { alg: 'sha256', value: 'deadbeef' },
+      placement: 'masterInsert',
+      attachToNodeId: 'masterLimiter',
+      interceptFromNodeId: 'masterPanner',
+      paramState: {},
+    };
+    const payload = serializeWam2SongState([tone, missing]);
+    const plan = await planWam2Restore(payload);
+    expect(plan.load).toHaveLength(1);
+    expect(plan.missing).toHaveLength(1);
+    expect(plan.missing[0]?.packageId).toBe('community.unknown');
+
+    const config = applyWamSlotsToGraph(CLASSIC_ELECTRIBE_GRAPH, [tone, missing]);
+    const ctx = makeWamTestAudioContext();
+    const graph = compileAudioGraph(ctx, config);
+    const host = new WamHost(ctx);
+    host.attachCompiledGraph(graph);
+    await host.restore(payload, collectSlotPorts(graph));
+    const tel = host.telemetry();
+    expect(tel.find((s) => s.slotId === 'wam-tone-1')?.status).toBe('ready');
+    expect(tel.find((s) => s.slotId === 'wam-gone')?.status).toBe('missing');
+    host.publishTelemetry();
+    const snap = engineTelemetry.getRuntimeSnapshot();
+    expect(snap.wam2Slots.some((s) => s.status === 'missing')).toBe(true);
+    expect(snap.wam2Constraints?.baseUrl).toBeDefined();
+  });
+
+  it('does not substitute another engine when integrity fails', async () => {
+    const tone = await withIntegrity(makeToneInstance());
+    tone.integrity = { alg: 'sha256', value: '0000000000000000000000000000000000000000000000000000000000000000' };
+    const plan = await planWam2Restore(serializeWam2SongState([tone]));
+    expect(plan.load).toHaveLength(0);
+    expect(plan.missing[0]?.packageId).toBe(HYPHON_TONE_PACKAGE_ID);
+  });
+});
+
+describe('WAM2 bundle boundary', () => {
+  it('pins the official SDK version and keeps it out of eager entries', () => {
+    expect(OFFICIAL_WAM_SDK_PACKAGE).toBe('@webaudiomodules/sdk');
+    expect(OFFICIAL_WAM_SDK_VERSION).toBe('0.0.12');
+    const main = readFileSync(resolve(process.cwd(), 'src/main.tsx'), 'utf8');
+    const app = readFileSync(resolve(process.cwd(), 'src/App.tsx'), 'utf8');
+    expect(main).not.toContain('@webaudiomodules/sdk');
+    expect(app).not.toContain('@webaudiomodules/sdk');
+    const loader = readFileSync(resolve(process.cwd(), 'src/audio/wam/sdk/loadOfficialSdk.ts'), 'utf8');
+    expect(loader).toContain('@vite-ignore');
+    expect(loader).toContain('OFFICIAL_WAM_SDK_PACKAGE');
+  });
+});

--- a/src/audio/wam/__tests__/audioContextMock.ts
+++ b/src/audio/wam/__tests__/audioContextMock.ts
@@ -1,0 +1,65 @@
+import { vi } from 'vitest';
+
+/** Unique-node AudioContext mock so WAM slot ports are distinct GainNodes. */
+export function makeWamTestAudioContext(): AudioContext {
+  const makeGain = () => ({
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    gain: { value: 1, setValueAtTime: vi.fn() },
+  });
+  const makeOsc = () => ({
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+    frequency: { value: 440, setValueAtTime: vi.fn() },
+  });
+  return {
+    currentTime: 0,
+    sampleRate: 48000,
+    destination: { connect: vi.fn(), disconnect: vi.fn() },
+    createGain: vi.fn(makeGain),
+    createOscillator: vi.fn(makeOsc),
+    createWaveShaper: vi.fn(() => ({ connect: vi.fn(), disconnect: vi.fn(), curve: null, oversample: 'none' })),
+    createBiquadFilter: vi.fn(() => ({
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      type: 'lowpass',
+      frequency: { setValueAtTime: vi.fn() },
+      Q: { setValueAtTime: vi.fn() },
+      gain: { setValueAtTime: vi.fn(), value: 0 },
+    })),
+    createDynamicsCompressor: vi.fn(() => ({
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      threshold: { setValueAtTime: vi.fn() },
+      knee: { setValueAtTime: vi.fn() },
+      ratio: { setValueAtTime: vi.fn() },
+      attack: { setValueAtTime: vi.fn() },
+      release: { setValueAtTime: vi.fn() },
+    })),
+    createStereoPanner: vi.fn(() => ({
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      pan: { setValueAtTime: vi.fn() },
+    })),
+    createAnalyser: vi.fn(() => ({
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      fftSize: 256,
+      smoothingTimeConstant: 0.5,
+    })),
+    createConvolver: vi.fn(() => ({ connect: vi.fn(), disconnect: vi.fn(), buffer: null })),
+    createDelay: vi.fn(() => ({
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      delayTime: { value: 0 },
+    })),
+    createBuffer: (channels: number, length: number, sampleRate: number) => ({
+      numberOfChannels: channels,
+      length,
+      sampleRate,
+      getChannelData: () => new Float32Array(length),
+    }),
+  } as unknown as AudioContext;
+}

--- a/src/audio/wam/__tests__/automationBridge.test.ts
+++ b/src/audio/wam/__tests__/automationBridge.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AutomationScheduler } from '../../automation/AutomationScheduler';
+import { WamHost } from '../WamHost';
+import { applyWamSlotsToGraph } from '../applySlots';
+import { CLASSIC_ELECTRIBE_GRAPH, compileAudioGraph } from '../../graph';
+import { finalizeBundledCatalog, HYPHON_GAIN_PACKAGE_ID } from '../catalog';
+import { collectSlotPorts } from '../WamHost';
+import { serializeWam2SongState } from '../persist';
+import { automationStore, generateLaneId, resetLaneIdCounter } from '../../../stores/automationStore';
+import type { UnifiedAutomationLane } from '../../../types';
+import { makeWamTestAudioContext } from './audioContextMock';
+
+function makeLane(overrides?: Partial<UnifiedAutomationLane>): UnifiedAutomationLane {
+  return {
+    id: generateLaneId(),
+    target: 'wam',
+    parameter: 'wam-gain-1/gain',
+    name: 'WAM2 Gain',
+    points: [{ step: 0, value: 0.25 }],
+    interpolation: 'linear',
+    source: 'recorded',
+    scope: 'pattern',
+    patternIndex: 0,
+    enabled: true,
+    ...overrides,
+  };
+}
+
+describe('AutomationScheduler WAM2 bridge', () => {
+  it('records and replays one WAM parameter through existing lanes', async () => {
+    resetLaneIdCounter();
+    automationStore.importLanes([]);
+    const catalog = await finalizeBundledCatalog();
+    const pkg = catalog.find((p) => p.id === HYPHON_GAIN_PACKAGE_ID)!;
+    const instance = {
+      slotId: 'wam-gain-1',
+      packageId: pkg.id,
+      version: pkg.version,
+      integrity: pkg.integrity,
+      placement: 'trackInsert' as const,
+      attachToNodeId: 'masterSaturation',
+      interceptFromNodeId: 'synthABus',
+      paramState: { gain: 0.8 },
+    };
+    const ctx = makeWamTestAudioContext();
+    const graph = compileAudioGraph(ctx, applyWamSlotsToGraph(CLASSIC_ELECTRIBE_GRAPH, [instance]));
+    const host = new WamHost(ctx);
+    host.attachCompiledGraph(graph);
+    await host.restore(serializeWam2SongState([instance]), collectSlotPorts(graph));
+    const setParam = vi.spyOn(host, 'setParam');
+    const scheduler = new AutomationScheduler(ctx, null);
+    scheduler.setWamHost(host);
+    const lane = makeLane();
+    automationStore.importLanes([lane]);
+    scheduler.scheduleFromLanes([lane], 0, 1, 0.5, 0);
+    expect(setParam).toHaveBeenCalledWith('wam-gain-1', 'gain', 0.25, expect.any(Number));
+  });
+});

--- a/src/audio/wam/applySlots.ts
+++ b/src/audio/wam/applySlots.ts
@@ -1,0 +1,79 @@
+import type { AudioGraphConfig, GraphEdgeSpec, GraphNodeSpec } from '../graph/types';
+import type { Wam2Placement, Wam2PluginInstanceState } from './types';
+
+const FACTORY_BY_PLACEMENT: Record<Wam2Placement, GraphNodeSpec['factory']> = {
+  instrument: 'wamInstrumentSlot',
+  trackInsert: 'wamTrackInsert',
+  masterInsert: 'wamMasterInsert',
+  sendReturn: 'wamSendReturn',
+};
+
+const ROLE_BY_PLACEMENT: Record<Wam2Placement, GraphNodeSpec['role']> = {
+  instrument: 'instrumentSource',
+  trackInsert: 'trackInsert',
+  masterInsert: 'masterInsert',
+  sendReturn: 'auxSend',
+};
+
+function incomingTo(edges: readonly GraphEdgeSpec[], nodeId: string): GraphEdgeSpec[] {
+  return edges.filter((e) => e.to === nodeId);
+}
+
+/**
+ * Splice WAM2 slots into a declarative graph. Does not compile audio —
+ * {@link compileAudioGraph} still owns connections.
+ */
+export function applyWamSlotsToGraph(
+  base: AudioGraphConfig,
+  instances: readonly Wam2PluginInstanceState[],
+): AudioGraphConfig {
+  const nodes = [...base.nodes];
+  let edges = [...base.edges];
+
+  for (const instance of instances) {
+    const slotId = instance.slotId;
+    if (nodes.some((n) => n.id === slotId)) {
+      continue;
+    }
+    nodes.push({
+      id: slotId,
+      factory: FACTORY_BY_PLACEMENT[instance.placement],
+      role: ROLE_BY_PLACEMENT[instance.placement],
+    });
+
+    const attach = instance.attachToNodeId;
+    if (instance.placement === 'instrument') {
+      edges.push({ from: slotId, to: attach });
+      continue;
+    }
+
+    if (instance.placement === 'sendReturn') {
+      edges.push({ from: attach, to: slotId });
+      edges.push({ from: slotId, to: 'masterSaturation' });
+      continue;
+    }
+
+    const fromId = instance.interceptFromNodeId;
+    if (fromId) {
+      edges = edges.filter((e) => !(e.from === fromId && e.to === attach));
+      edges.push({ from: fromId, to: slotId });
+      edges.push({ from: slotId, to: attach });
+      continue;
+    }
+
+    const incoming = incomingTo(edges, attach);
+    edges = edges.filter((e) => e.to !== attach);
+    for (const edge of incoming) {
+      edges.push({ from: edge.from, to: slotId });
+    }
+    edges.push({ from: slotId, to: attach });
+  }
+
+  return {
+    ...base,
+    id: `${base.id}+wam2`,
+    name: `${base.name} + WAM2 slots`,
+    nodes,
+    edges,
+  };
+}

--- a/src/audio/wam/catalog.ts
+++ b/src/audio/wam/catalog.ts
@@ -1,0 +1,99 @@
+import { hashCanonicalJson } from './integrity';
+import type { Wam2PackageDescriptor, Wam2ParamDesc } from './types';
+import { WAM2_DEFAULT_PERMISSIONS } from './types';
+
+const GAIN_PARAM: Wam2ParamDesc = {
+  id: 'gain',
+  label: 'Gain',
+  min: 0,
+  max: 1,
+  defaultValue: 0.8,
+};
+
+function fingerprint(partial: {
+  id: string;
+  version: string;
+  kind: Wam2PackageDescriptor['kind'];
+  title: string;
+  vendor: string;
+  license: string;
+  params: Wam2ParamDesc[];
+}): unknown {
+  return {
+    id: partial.id,
+    kind: partial.kind,
+    license: partial.license,
+    params: partial.params.map((p) => p.id),
+    title: partial.title,
+    vendor: partial.vendor,
+    version: partial.version,
+  };
+}
+
+const TONE_PARTIAL = {
+  id: 'hyphon.tone',
+  version: '1.0.0',
+  kind: 'instrument' as const,
+  title: 'Hyphon Tone',
+  vendor: 'Hyphon',
+  license: 'MIT',
+  params: [GAIN_PARAM],
+};
+
+const GAIN_FX_PARTIAL = {
+  id: 'hyphon.gain',
+  version: '1.0.0',
+  kind: 'effect' as const,
+  title: 'Hyphon Gain',
+  vendor: 'Hyphon',
+  license: 'MIT',
+  params: [GAIN_PARAM],
+};
+
+/**
+ * Bundled allowlist. v1 loads only these ids — no remote JavaScript URL field.
+ * Integrity values are filled by {@link finalizeBundledCatalog}.
+ */
+export const BUNDLED_WAM2_FINGERPRINTS = {
+  tone: fingerprint(TONE_PARTIAL),
+  gain: fingerprint(GAIN_FX_PARTIAL),
+} as const;
+
+let catalogCache: readonly Wam2PackageDescriptor[] | null = null;
+
+export async function finalizeBundledCatalog(): Promise<readonly Wam2PackageDescriptor[]> {
+  if (catalogCache) return catalogCache;
+  const toneHash = await hashCanonicalJson(BUNDLED_WAM2_FINGERPRINTS.tone);
+  const gainHash = await hashCanonicalJson(BUNDLED_WAM2_FINGERPRINTS.gain);
+  catalogCache = [
+    {
+      ...TONE_PARTIAL,
+      origin: 'bundled',
+      integrity: toneHash,
+      offline: 'native',
+      isolation: 'audio-graph-slot',
+      permissions: WAM2_DEFAULT_PERMISSIONS,
+    },
+    {
+      ...GAIN_FX_PARTIAL,
+      origin: 'bundled',
+      integrity: gainHash,
+      offline: 'native',
+      isolation: 'audio-graph-slot',
+      permissions: WAM2_DEFAULT_PERMISSIONS,
+    },
+  ];
+  return catalogCache;
+}
+
+export async function getBundledPackage(packageId: string): Promise<Wam2PackageDescriptor | undefined> {
+  const catalog = await finalizeBundledCatalog();
+  return catalog.find((pkg) => pkg.id === packageId);
+}
+
+export function isAllowlistedPackageId(packageId: string): boolean {
+  return packageId === TONE_PARTIAL.id || packageId === GAIN_FX_PARTIAL.id;
+}
+
+export const HYPHON_TONE_PACKAGE_ID = TONE_PARTIAL.id;
+export const HYPHON_GAIN_PACKAGE_ID = GAIN_FX_PARTIAL.id;

--- a/src/audio/wam/fixtures/hyphonGain.ts
+++ b/src/audio/wam/fixtures/hyphonGain.ts
@@ -1,0 +1,67 @@
+import type { Wam2PackageDescriptor, Wam2Plugin } from '../types';
+
+/**
+ * First-party WAM2 effect fixture: unity-through GainNode with automatable `gain`.
+ */
+export class HyphonGainPlugin implements Wam2Plugin {
+  readonly descriptor: Wam2PackageDescriptor;
+  private node: GainNode | null = null;
+  private gainValue: number;
+  private context: AudioContext | null = null;
+  private pluginState: unknown = {};
+
+  constructor(descriptor: Wam2PackageDescriptor) {
+    this.descriptor = descriptor;
+    this.gainValue = descriptor.params[0]?.defaultValue ?? 0.8;
+  }
+
+  get audioNode(): AudioNode {
+    if (!this.node) {
+      throw new Error('HyphonGainPlugin is not initialized');
+    }
+    return this.node;
+  }
+
+  async initialize(context: AudioContext, signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) {
+      throw new DOMException('The operation was aborted.', 'AbortError');
+    }
+    this.context = context;
+    this.node = context.createGain();
+    this.node.gain.value = this.gainValue;
+  }
+
+  setParam(id: string, value: number, time?: number): void {
+    if (id !== 'gain' || !this.node) return;
+    this.gainValue = Math.max(0, Math.min(1, value));
+    const t = time ?? this.context?.currentTime ?? 0;
+    this.node.gain.setValueAtTime(this.gainValue, t);
+  }
+
+  getParam(id: string): number {
+    return id === 'gain' ? this.gainValue : 0;
+  }
+
+  getState(): unknown {
+    return { gain: this.gainValue, extra: this.pluginState };
+  }
+
+  setState(state: unknown): void {
+    this.pluginState = state;
+    if (state && typeof state === 'object' && 'gain' in state) {
+      const gain = (state as { gain: unknown }).gain;
+      if (typeof gain === 'number') {
+        this.setParam('gain', gain);
+      }
+    }
+  }
+
+  dispose(): void {
+    try {
+      this.node?.disconnect();
+    } catch {
+      /* already disconnected */
+    }
+    this.node = null;
+  }
+}

--- a/src/audio/wam/fixtures/hyphonTone.ts
+++ b/src/audio/wam/fixtures/hyphonTone.ts
@@ -1,0 +1,108 @@
+import type { Wam2NoteEvent, Wam2PackageDescriptor, Wam2Plugin } from '../types';
+
+function midiToHz(midi: number): number {
+  return 440 * Math.pow(2, (midi - 69) / 12);
+}
+
+interface Voice {
+  osc: OscillatorNode;
+  gain: GainNode;
+}
+
+/**
+ * First-party WAM2 instrument fixture: one automatable `gain` param and MIDI notes.
+ * Uses native OscillatorNode so unit tests work without AudioWorklet / the official SDK.
+ */
+export class HyphonTonePlugin implements Wam2Plugin {
+  readonly descriptor: Wam2PackageDescriptor;
+  private node: GainNode | null = null;
+  private readonly voices = new Map<number, Voice>();
+  private gainValue: number;
+  private context: AudioContext | null = null;
+  private pluginState: unknown = {};
+
+  constructor(descriptor: Wam2PackageDescriptor) {
+    this.descriptor = descriptor;
+    this.gainValue = descriptor.params[0]?.defaultValue ?? 0.8;
+  }
+
+  get audioNode(): AudioNode {
+    if (!this.node) {
+      throw new Error('HyphonTonePlugin is not initialized');
+    }
+    return this.node;
+  }
+
+  async initialize(context: AudioContext, signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) {
+      throw new DOMException('The operation was aborted.', 'AbortError');
+    }
+    this.context = context;
+    this.node = context.createGain();
+    this.node.gain.value = this.gainValue;
+  }
+
+  setParam(id: string, value: number, time?: number): void {
+    if (id !== 'gain' || !this.node) return;
+    this.gainValue = Math.max(0, Math.min(1, value));
+    const t = time ?? this.context?.currentTime ?? 0;
+    this.node.gain.setValueAtTime(this.gainValue, t);
+  }
+
+  getParam(id: string): number {
+    return id === 'gain' ? this.gainValue : 0;
+  }
+
+  getState(): unknown {
+    return { gain: this.gainValue, extra: this.pluginState };
+  }
+
+  setState(state: unknown): void {
+    this.pluginState = state;
+    if (state && typeof state === 'object' && 'gain' in state) {
+      const gain = (state as { gain: unknown }).gain;
+      if (typeof gain === 'number') {
+        this.setParam('gain', gain);
+      }
+    }
+  }
+
+  noteOn(event: Wam2NoteEvent): void {
+    if (!this.context || !this.node) return;
+    this.noteOff(event.midi, event.time);
+    const osc = this.context.createOscillator();
+    const gain = this.context.createGain();
+    osc.frequency.setValueAtTime(midiToHz(event.midi), event.time);
+    const amp = Math.max(0, Math.min(1, event.velocity)) * this.gainValue;
+    gain.gain.setValueAtTime(amp, event.time);
+    osc.connect(gain);
+    gain.connect(this.node);
+    osc.start(event.time);
+    const stopAt = event.time + Math.max(0.01, event.durationSeconds);
+    osc.stop(stopAt);
+    this.voices.set(event.midi, { osc, gain });
+  }
+
+  noteOff(midi: number, time: number): void {
+    const voice = this.voices.get(midi);
+    if (!voice) return;
+    try {
+      voice.osc.stop(time);
+    } catch {
+      /* already stopped */
+    }
+    this.voices.delete(midi);
+  }
+
+  dispose(): void {
+    for (const midi of [...this.voices.keys()]) {
+      this.noteOff(midi, this.context?.currentTime ?? 0);
+    }
+    try {
+      this.node?.disconnect();
+    } catch {
+      /* already disconnected */
+    }
+    this.node = null;
+  }
+}

--- a/src/audio/wam/fixtures/index.ts
+++ b/src/audio/wam/fixtures/index.ts
@@ -1,0 +1,20 @@
+import { getBundledPackage, HYPHON_GAIN_PACKAGE_ID, HYPHON_TONE_PACKAGE_ID } from '../catalog';
+import type { Wam2Plugin } from '../types';
+import { HyphonGainPlugin } from './hyphonGain';
+import { HyphonTonePlugin } from './hyphonTone';
+
+export async function createBundledPlugin(packageId: string): Promise<Wam2Plugin> {
+  const descriptor = await getBundledPackage(packageId);
+  if (!descriptor) {
+    throw new Error(`Unknown bundled WAM2 package: ${packageId}`);
+  }
+  if (packageId === HYPHON_TONE_PACKAGE_ID) {
+    return new HyphonTonePlugin(descriptor);
+  }
+  if (packageId === HYPHON_GAIN_PACKAGE_ID) {
+    return new HyphonGainPlugin(descriptor);
+  }
+  throw new Error(`No fixture constructor for ${packageId}`);
+}
+
+export { HyphonGainPlugin, HyphonTonePlugin };

--- a/src/audio/wam/index.ts
+++ b/src/audio/wam/index.ts
@@ -1,0 +1,27 @@
+export type {
+  Wam2PackageDescriptor,
+  Wam2PluginInstanceState,
+  Wam2SlotTelemetry,
+  Wam2RuntimeConstraints,
+  Wam2Placement,
+  Wam2SlotStatus,
+} from './types';
+export {
+  OFFICIAL_WAM_SDK_PACKAGE,
+  OFFICIAL_WAM_SDK_VERSION,
+  OFFICIAL_WAM_SDK_LICENSE,
+  WAM2_DEFAULT_PERMISSIONS,
+  WAM2_INIT_TIMEOUT_MS,
+} from './types';
+export { applyWamSlotsToGraph } from './applySlots';
+export { serializeWam2SongState, planWam2Restore, WAM2_SONG_SCHEMA } from './persist';
+export type { Wam2SongPayload } from './persist';
+export { collectWam2RuntimeConstraints } from './runtimeConstraints';
+export { WamHost, getWamHost, setWamHost, collectSlotPorts } from './WamHost';
+export { WamSlotPorts } from './WamSlotPorts';
+export {
+  finalizeBundledCatalog,
+  HYPHON_TONE_PACKAGE_ID,
+  HYPHON_GAIN_PACKAGE_ID,
+} from './catalog';
+export { loadOfficialWamSdk } from './sdk/loadOfficialSdk';

--- a/src/audio/wam/integrity.ts
+++ b/src/audio/wam/integrity.ts
@@ -1,0 +1,61 @@
+/** Canonical JSON (sorted keys) so integrity hashes are stable. */
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortValue(value));
+}
+
+function sortValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortValue);
+  }
+  if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(obj).sort()) {
+      out[key] = sortValue(obj[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+function toHex(bytes: ArrayBuffer | Uint8Array): string {
+  const view = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  let hex = '';
+  for (let i = 0; i < view.length; i++) {
+    hex += view[i].toString(16).padStart(2, '0');
+  }
+  return hex;
+}
+
+/** FNV-1a 32-bit — used in unit tests when SubtleCrypto is unavailable. */
+export function fnv1a32Hex(bytes: Uint8Array): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < bytes.length; i++) {
+    h ^= bytes[i];
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, '0');
+}
+
+export async function hashBytes(bytes: Uint8Array): Promise<{ alg: 'sha256' | 'fnv1a32'; value: string }> {
+  const subtle = globalThis.crypto?.subtle;
+  if (subtle) {
+    const ab = new ArrayBuffer(bytes.byteLength);
+    new Uint8Array(ab).set(bytes);
+    const digest = await subtle.digest('SHA-256', ab);
+    return { alg: 'sha256', value: toHex(digest) };
+  }
+  return { alg: 'fnv1a32', value: fnv1a32Hex(bytes) };
+}
+
+export async function hashCanonicalJson(value: unknown): Promise<{ alg: 'sha256' | 'fnv1a32'; value: string }> {
+  const encoded = new TextEncoder().encode(canonicalJson(value));
+  return hashBytes(encoded);
+}
+
+export function integrityMatches(
+  expected: { alg: string; value: string },
+  actual: { alg: string; value: string },
+): boolean {
+  return expected.alg === actual.alg && expected.value === actual.value;
+}

--- a/src/audio/wam/persist.ts
+++ b/src/audio/wam/persist.ts
@@ -1,0 +1,65 @@
+import type { Wam2PluginInstanceState } from './types';
+import { isAllowlistedPackageId } from './catalog';
+import { integrityMatches } from './integrity';
+import { getBundledPackage } from './catalog';
+
+export const WAM2_SONG_SCHEMA = 1 as const;
+
+export interface Wam2SongPayload {
+  schema: typeof WAM2_SONG_SCHEMA;
+  plugins: Wam2PluginInstanceState[];
+}
+
+export function serializeWam2SongState(plugins: readonly Wam2PluginInstanceState[]): Wam2SongPayload {
+  return {
+    schema: WAM2_SONG_SCHEMA,
+    plugins: plugins.map((p) => ({
+      slotId: p.slotId,
+      packageId: p.packageId,
+      version: p.version,
+      integrity: { ...p.integrity },
+      placement: p.placement,
+      attachToNodeId: p.attachToNodeId,
+      interceptFromNodeId: p.interceptFromNodeId,
+      trackKey: p.trackKey,
+      paramState: { ...p.paramState },
+      pluginState: p.pluginState,
+      bypass: p.bypass,
+    })),
+  };
+}
+
+export interface Wam2RestorePlan {
+  load: Wam2PluginInstanceState[];
+  missing: Wam2PluginInstanceState[];
+}
+
+/**
+ * Plan restore without substituting a different plugin when identity/version
+ * cannot be honoured. Missing entries stay in the song as placeholders.
+ */
+export async function planWam2Restore(payload: Wam2SongPayload | undefined | null): Promise<Wam2RestorePlan> {
+  if (!payload || !Array.isArray(payload.plugins)) {
+    return { load: [], missing: [] };
+  }
+  const load: Wam2PluginInstanceState[] = [];
+  const missing: Wam2PluginInstanceState[] = [];
+
+  for (const plugin of payload.plugins) {
+    if (!isAllowlistedPackageId(plugin.packageId)) {
+      missing.push(plugin);
+      continue;
+    }
+    const bundled = await getBundledPackage(plugin.packageId);
+    if (!bundled || bundled.version !== plugin.version) {
+      missing.push(plugin);
+      continue;
+    }
+    if (!integrityMatches(plugin.integrity, bundled.integrity)) {
+      missing.push(plugin);
+      continue;
+    }
+    load.push(plugin);
+  }
+  return { load, missing };
+}

--- a/src/audio/wam/runtimeConstraints.ts
+++ b/src/audio/wam/runtimeConstraints.ts
@@ -1,0 +1,42 @@
+import { resolvePublicAsset } from '../../utils/engineTelemetry';
+import type { Wam2RuntimeConstraints } from './types';
+
+/**
+ * Probe COOP/COEP, worklet, worker, and relative-base deployment.
+ * Does not fetch remote plugin URLs.
+ */
+export function collectWam2RuntimeConstraints(): Wam2RuntimeConstraints {
+  const crossOriginIsolated =
+    typeof globalThis.crossOriginIsolated === 'boolean' ? globalThis.crossOriginIsolated : false;
+
+  let coopHint: string | null = null;
+  if (typeof document !== 'undefined') {
+    const meta = document.querySelector('meta[http-equiv="Cross-Origin-Opener-Policy"]');
+    coopHint = meta?.getAttribute('content') ?? null;
+  }
+
+  const audioWorklet = typeof AudioWorkletNode !== 'undefined';
+  const worker = typeof Worker !== 'undefined';
+
+  const baseUrl =
+    typeof import.meta !== 'undefined' && import.meta.env?.BASE_URL
+      ? String(import.meta.env.BASE_URL)
+      : './';
+
+  let subdirectoryDeploy = baseUrl !== '/' && baseUrl !== '';
+  try {
+    const sample = resolvePublicAsset('wam/catalog.json');
+    subdirectoryDeploy = subdirectoryDeploy || /\/.+\/wam\//.test(new URL(sample, 'https://example.invalid').pathname);
+  } catch {
+    /* keep baseUrl heuristic */
+  }
+
+  return {
+    crossOriginIsolated,
+    coopHint,
+    audioWorklet,
+    worker,
+    baseUrl,
+    subdirectoryDeploy,
+  };
+}

--- a/src/audio/wam/sdk/loadOfficialSdk.ts
+++ b/src/audio/wam/sdk/loadOfficialSdk.ts
@@ -1,0 +1,40 @@
+import {
+  OFFICIAL_WAM_SDK_LICENSE,
+  OFFICIAL_WAM_SDK_PACKAGE,
+  OFFICIAL_WAM_SDK_VERSION,
+} from '../types';
+
+export interface OfficialWamSdkLoad {
+  packageName: typeof OFFICIAL_WAM_SDK_PACKAGE;
+  version: typeof OFFICIAL_WAM_SDK_VERSION;
+  license: typeof OFFICIAL_WAM_SDK_LICENSE;
+  /** Present only when the optional npm package is installed and imported. */
+  module: unknown | null;
+  unavailableReason?: string;
+}
+
+/**
+ * Lazy-load `@webaudiomodules/sdk@0.0.12`. Must never be imported from
+ * `main.tsx` or other eager entry modules — Phase A fixtures do not need it.
+ */
+export async function loadOfficialWamSdk(): Promise<OfficialWamSdkLoad> {
+  try {
+    const specifier: string = OFFICIAL_WAM_SDK_PACKAGE;
+    const mod: unknown = await import(/* @vite-ignore */ specifier);
+    return {
+      packageName: OFFICIAL_WAM_SDK_PACKAGE,
+      version: OFFICIAL_WAM_SDK_VERSION,
+      license: OFFICIAL_WAM_SDK_LICENSE,
+      module: mod,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      packageName: OFFICIAL_WAM_SDK_PACKAGE,
+      version: OFFICIAL_WAM_SDK_VERSION,
+      license: OFFICIAL_WAM_SDK_LICENSE,
+      module: null,
+      unavailableReason: message,
+    };
+  }
+}

--- a/src/audio/wam/types.ts
+++ b/src/audio/wam/types.ts
@@ -1,0 +1,135 @@
+/**
+ * WAM2 host contract (Phase A).
+ *
+ * Hyphon already uses the label "WAM" for AssemblyScript oscillators
+ * (`wam-saw`, engine `wam`). This module is **Web Audio Modules 2.0** and
+ * uses `wam2` identifiers everywhere to avoid colliding with that family.
+ *
+ * Official SDK pin: `@webaudiomodules/sdk@0.0.12` (MIT). Phase A speaks the
+ * WAM2 descriptor/lifecycle/state/param/MIDI contract via first-party
+ * fixtures; the official SDK is lazy-loaded only when a community package
+ * is allowlisted (see ADR).
+ */
+
+export const OFFICIAL_WAM_SDK_PACKAGE = '@webaudiomodules/sdk' as const;
+export const OFFICIAL_WAM_SDK_VERSION = '0.0.12' as const;
+export const OFFICIAL_WAM_SDK_LICENSE = 'MIT' as const;
+
+export type Wam2PackageKind = 'instrument' | 'effect';
+
+export type Wam2Placement = 'instrument' | 'trackInsert' | 'masterInsert' | 'sendReturn';
+
+export type Wam2SlotStatus =
+  | 'empty'
+  | 'loading'
+  | 'ready'
+  | 'bypassed'
+  | 'missing'
+  | 'failed'
+  | 'timeout';
+
+export type Wam2OfflineSupport = 'native' | 'unsupported';
+
+export interface Wam2Permissions {
+  audio: true;
+  network: false;
+  filesystem: false;
+  cloudTokens: false;
+}
+
+export const WAM2_DEFAULT_PERMISSIONS: Wam2Permissions = {
+  audio: true,
+  network: false,
+  filesystem: false,
+  cloudTokens: false,
+};
+
+export interface Wam2ParamDesc {
+  id: string;
+  label: string;
+  min: number;
+  max: number;
+  defaultValue: number;
+}
+
+export interface Wam2PackageDescriptor {
+  /** Allowlisted package id — never a remote URL. */
+  id: string;
+  version: string;
+  kind: Wam2PackageKind;
+  title: string;
+  vendor: string;
+  license: string;
+  origin: 'bundled';
+  params: Wam2ParamDesc[];
+  /** SHA-256 (or test-only fnv1a32) of the canonical fingerprint. */
+  integrity: { alg: 'sha256' | 'fnv1a32'; value: string };
+  offline: Wam2OfflineSupport;
+  isolation: 'audio-graph-slot';
+  permissions: Wam2Permissions;
+}
+
+export interface Wam2PluginInstanceState {
+  slotId: string;
+  packageId: string;
+  version: string;
+  integrity: { alg: 'sha256' | 'fnv1a32'; value: string };
+  placement: Wam2Placement;
+  /** Graph node the slot feeds (instrument) or sits in front of (insert). */
+  attachToNodeId: string;
+  /** When set, only this predecessor→attach edge is intercepted (track insert). */
+  interceptFromNodeId?: string;
+  trackKey?: 'partA' | 'partB' | 'bass2';
+  /** Normalized 0–1 param values keyed by param id. */
+  paramState: Record<string, number>;
+  /** Opaque plugin getState() payload. */
+  pluginState?: unknown;
+  bypass?: boolean;
+}
+
+export interface Wam2NoteEvent {
+  midi: number;
+  velocity: number;
+  time: number;
+  durationSeconds: number;
+}
+
+export interface Wam2Plugin {
+  readonly descriptor: Wam2PackageDescriptor;
+  readonly audioNode: AudioNode;
+  initialize(context: AudioContext, signal?: AbortSignal): Promise<void>;
+  setParam(id: string, value: number, time?: number): void;
+  getParam(id: string): number;
+  getState(): unknown;
+  setState(state: unknown): void;
+  noteOn?(event: Wam2NoteEvent): void;
+  noteOff?(midi: number, time: number): void;
+  dispose(): void;
+}
+
+export interface Wam2SlotTelemetry {
+  slotId: string;
+  packageId: string;
+  version: string;
+  origin: 'bundled';
+  placement: Wam2Placement;
+  status: Wam2SlotStatus;
+  cpuPercent: number;
+  latencyMs: number;
+  lastError?: string;
+  isolation: 'audio-graph-slot';
+  permissions: Wam2Permissions;
+  offline: Wam2OfflineSupport;
+  integrityOk: boolean;
+}
+
+export interface Wam2RuntimeConstraints {
+  crossOriginIsolated: boolean;
+  coopHint: string | null;
+  audioWorklet: boolean;
+  worker: boolean;
+  baseUrl: string;
+  subdirectoryDeploy: boolean;
+}
+
+export const WAM2_INIT_TIMEOUT_MS = 2000;

--- a/src/components/EngineHUD.tsx
+++ b/src/components/EngineHUD.tsx
@@ -179,7 +179,19 @@ if (typeof window !== 'undefined' && !document.getElementById(CONTAINER_ID)) {
       ? `<div class="subheader">Degradations</div><div style="font-size:11px;opacity:0.85">${runtime.degradations.slice(-3).map(d => `${d.step}: ${d.active ? 'ON' : 'off'}`).join(' · ')}</div>`
       : '';
 
-    container.innerHTML = `<div class="header">Engine HUD</div>${summary}${syncSection}${latencySection}${offlineSection}${backendSection}<div class="subheader">Worklets</div>${workletRows}${degradeNote}<div class="subheader">Subsystems</div>${rows}<div class="hud-actions"><button type="button" id="hud-export-btn">Download Report</button><button type="button" id="hud-copy-btn">Copy JSON</button></div>`;
+    const wamRows = (runtime.wam2Slots ?? []).map((slot) => {
+      const cls = slot.status === 'ready' ? 'cpu-ok' : slot.status === 'bypassed' ? 'cpu-warn' : 'cpu-hot';
+      const err = slot.lastError ? ` title="${slot.lastError.replace(/"/g, '&quot;')}"` : '';
+      return `<div class="row"${err}><div class="badge backend-wam">wam2</div><div style="flex:1">${slot.slotId}<div style="font-size:10px;opacity:0.7">${slot.packageId}@${slot.version} · ${slot.origin} · ${slot.isolation}</div></div><div class="${cls}" style="min-width:72px;text-align:right">${slot.status}</div><div style="width:48px;text-align:right">${slot.cpuPercent.toFixed(0)}%</div><div style="width:56px;text-align:right">${slot.latencyMs.toFixed(1)}ms</div></div>`;
+    }).join('');
+    const coop = runtime.wam2Constraints
+      ? `<div class="row"><div style="flex:1">COOP isolated</div><div style="min-width:72px;text-align:right">${runtime.wam2Constraints.crossOriginIsolated ? 'yes' : 'no'}</div></div>
+         <div class="row"><div style="flex:1">Worklet / Worker</div><div style="min-width:72px;text-align:right">${runtime.wam2Constraints.audioWorklet ? 'AW' : '—'} / ${runtime.wam2Constraints.worker ? 'W' : '—'}</div></div>
+         <div class="row"><div style="flex:1">BASE_URL</div><div style="min-width:72px;text-align:right;font-size:10px">${runtime.wam2Constraints.baseUrl}</div></div>`
+      : '';
+    const wamSection = `<div class="subheader">WAM2 slots</div>${wamRows || '<div class="row"><div style="flex:1;opacity:0.7">none mounted</div></div>'}${coop}`;
+
+    container.innerHTML = `<div class="header">Engine HUD</div>${summary}${syncSection}${latencySection}${offlineSection}${backendSection}<div class="subheader">Worklets</div>${workletRows}${degradeNote}${wamSection}<div class="subheader">Subsystems</div>${rows}<div class="hud-actions"><button type="button" id="hud-export-btn">Download Report</button><button type="button" id="hud-copy-btn">Copy JSON</button></div>`;
   }
 
   // Event delegation: render() replaces innerHTML every 500ms, so per-render

--- a/src/hooks/audioEngine/engineLifecycle.ts
+++ b/src/hooks/audioEngine/engineLifecycle.ts
@@ -22,6 +22,7 @@ import { engineTelemetry } from '../../utils/engineTelemetry';
 import { loadingProgressStore } from '../../stores/loadingProgressStore';
 import { startGlitchMonitor } from '../../utils/workletPerfBridge';
 import { buildClassicElectribeGraph } from '../../audio/graph';
+import { WamHost, setWamHost } from '../../audio/wam';
 import {
     createMasterLoudnessStage,
     setMasterLoudnessStage,
@@ -116,9 +117,13 @@ export async function initializeAudioContextAndEngines(
     // load the graph is compiled without it and playback continues unmetered.
     const loudnessStage = await createMasterLoudnessStage(context);
     setMasterLoudnessStage(loudnessStage);
-    const { masterBusInput } = buildClassicElectribeGraph(context, refs, {
+    const { masterBusInput, graph } = buildClassicElectribeGraph(context, refs, {
         masterLimiterNode: loudnessStage?.node ?? null,
     });
+    const wamHost = new WamHost(context);
+    wamHost.attachCompiledGraph(graph);
+    setWamHost(wamHost);
+    wamHost.publishTelemetry();
     loadingProgressStore.completeStep('masterChain');
 
     // Initialize oscillator backends through the shared registry. Every engine

--- a/src/hooks/useAppState.tsx
+++ b/src/hooks/useAppState.tsx
@@ -14,6 +14,7 @@ import { SupertonicService } from '../services/Supertonic'
 import { loadingProgressStore } from '../stores/loadingProgressStore'
 import { automationStore } from '../stores/automationStore';
 import { AutomationScheduler } from '../audio/automation/AutomationScheduler';
+import { getWamHost } from '../audio/wam';
 import type { PcfEffect } from '../engines/PcfEffect';
 import { resolveRealtimeTB303Model } from '../engines/TB303Models';
 import type { MainSequencerHandle } from '../components/MainSequencer'
@@ -231,6 +232,7 @@ export function useAppState() {
             if (prophecyManagerRef) {
                 automationSchedulerRef.current.setProphecyManager(prophecyManagerRef.current ?? null);
             }
+            automationSchedulerRef.current.setWamHost(getWamHost());
         }
     }, [audioEngine, prophecyManagerRef]);
 

--- a/src/hooks/useSongStorage.ts
+++ b/src/hooks/useSongStorage.ts
@@ -18,6 +18,7 @@ import { automationStore, convertHyphonLanes } from '../stores/automationStore';
 import { midiMapStore } from '../stores/midiMapStore';
 import { e2eTransportSnapshot, isE2eMode, setE2eLaneCount } from '../e2e/probe';
 import { RbsExporter, hyphonSongFromSavedData } from '../importers/rbs';
+import { getWamHost } from '../audio/wam';
 
 // ---- Types for the hook parameters ----
 
@@ -185,6 +186,12 @@ export function useSongStorage(deps: SongStorageDeps): SongStorageReturn {
             ttsPhrases,
             ...(exportedLanes.length > 0 ? { automationLanes: exportedLanes } : {}),
             ...(exportedMidi.length > 0 ? { midiMappings: exportedMidi } : {}),
+            ...(() => {
+                const host = getWamHost();
+                if (!host) return {};
+                const payload = host.exportSongState();
+                return payload.plugins.length > 0 ? { wam2: payload } : {};
+            })(),
         } as SavedSongData;
     }, [ambianceUrl, backgroundImage, sampleBuffers, ttsPhrases]);
 
@@ -276,6 +283,10 @@ export function useSongStorage(deps: SongStorageDeps): SongStorageReturn {
             // Restore automation lanes — importLanes replaces all existing lanes (including clearing when empty).
             automationStore.importLanes(songData.automationLanes ?? []);
             midiMapStore.importSongMappings(songData.midiMappings);
+            const wamHost = getWamHost();
+            if (wamHost) {
+                await wamHost.restore(songData.wam2);
+            }
             if (isE2eMode()) {
                 setE2eLaneCount(automationStore.getState().lanes.length);
             }

--- a/src/hooks/useStepHandler.ts
+++ b/src/hooks/useStepHandler.ts
@@ -44,6 +44,7 @@ import {
     playbackHealthMonitor,
     PLAYBACK_THRESHOLDS,
 } from '../audio/playback/PlaybackHealthMonitor';
+import { getWamHost } from '../audio/wam';
 
 // Module-level scratch buffers for single-threaded main-thread use to avoid GC on hot path
 const _midiScratch: number[] = [];
@@ -317,7 +318,14 @@ export const useStepHandler = ({
             const driveVal = getAutomationValue(targetForLane, 'drive', step);
             if (driveVal !== undefined) noteParams.drive = driveVal;
 
-            audioEngine.playSynth(params, notes, time, stepData.length, stepTime, slideFrom, trackKey, currentScale, noteParams);
+            const durationSeconds = (stepData.length ?? 1) * stepTime;
+            const wamHost = getWamHost();
+            if (wamHost?.takesOverTrack(trackKey)) {
+                const velocity = stepData.velocity ?? 1;
+                wamHost.scheduleTrackNotes(trackKey, notes, time, durationSeconds, velocity);
+            } else {
+                audioEngine.playSynth(params, notes, time, stepData.length, stepTime, slideFrom, trackKey, currentScale, noteParams);
+            }
 
             // Update last frequency for future slides
             lastFreqRef.current[trackKey] = tunedNoteToFrequency(stepData.note, currentScale);
@@ -373,7 +381,13 @@ export const useStepHandler = ({
             const b2Drive = getAutomationValue('bass2', 'drive', step);
             if (b2Drive !== undefined) bass2NoteParams.drive = b2Drive;
 
-            audioEngine.playSynth(bass2Params, notes, time, stepData.length, stepTime, undefined, 'bass2' as any, currentScale, bass2NoteParams.drive !== undefined || bass2NoteParams.filterCutoff !== undefined || bass2NoteParams.filterResonance !== undefined ? bass2NoteParams : undefined);
+            const wamBass = getWamHost();
+            if (wamBass?.takesOverTrack('bass2')) {
+                const durationSeconds = (stepData.length ?? 1) * stepTime;
+                wamBass.scheduleTrackNotes('bass2', notes, time, durationSeconds, stepData.velocity ?? 1);
+            } else {
+                audioEngine.playSynth(bass2Params, notes, time, stepData.length, stepTime, undefined, 'bass2' as any, currentScale, bass2NoteParams.drive !== undefined || bass2NoteParams.filterCutoff !== undefined || bass2NoteParams.filterResonance !== undefined ? bass2NoteParams : undefined);
+            }
         };
 
         // Trigger synths

--- a/src/types.ts
+++ b/src/types.ts
@@ -665,7 +665,8 @@ export type AutomationTarget =
   | 'kick' | 'snare' | 'closedHat' | 'openHat'
   | 'sampler' | 'master'
   | 'sampler0' | 'sampler1' | 'sampler2' | 'sampler3'
-  | 'sampler4' | 'sampler5' | 'sampler6' | 'sampler7';
+  | 'sampler4' | 'sampler5' | 'sampler6' | 'sampler7'
+  | 'wam';
 
 /** Where the automation data originated */
 export type AutomationSource = 'rbs' | 'recorded' | 'ai' | 'manual';
@@ -827,6 +828,8 @@ export interface SavedSongData {
   automationLanes?: UnifiedAutomationLane[];
   /** Per-song MIDI CC / note → control mappings */
   midiMappings?: import('./types/midi').MidiBinding[];
+  /** WAM2 plugin slots (identity, version, param/plugin state). */
+  wam2?: import('./audio/wam').Wam2SongPayload;
 }
 export interface AmbianceTrack {
   id: string;

--- a/src/utils/__tests__/engineTelemetry.test.ts
+++ b/src/utils/__tests__/engineTelemetry.test.ts
@@ -59,6 +59,8 @@ const fakeRuntime = {
   baseLatencyMs: null as number | null,
   latencyHint: null as string | null,
   transportSync: null,
+  wam2Slots: [] as [],
+  wam2Constraints: null,
 };
 
 describe('serializeEngineReport', () => {

--- a/src/utils/engineTelemetry.ts
+++ b/src/utils/engineTelemetry.ts
@@ -2,6 +2,7 @@
 
 import { engineDegradationStore } from '../stores/engineDegradationStore';
 import type { TransportSyncTelemetry } from '../midi/clock/types';
+import type { Wam2RuntimeConstraints, Wam2SlotTelemetry } from '../audio/wam/types';
 
 type Resolution = { backend: string; reason?: string; ts: number };
 
@@ -71,6 +72,8 @@ type RuntimeTelemetry = {
   /** P0 audio foundation — latencyHint requested when the context was created. */
   latencyHint: string | null;
   transportSync: TransportSyncTelemetry | null;
+  wam2Slots: Wam2SlotTelemetry[];
+  wam2Constraints: Wam2RuntimeConstraints | null;
 };
 
 function emptyData(): TelemetryData {
@@ -200,6 +203,9 @@ export interface RuntimeSnapshot {
   latencyHint: string | null;
   /** MIDI transport sync telemetry (master/slave/internal). */
   transportSync: TransportSyncTelemetry | null;
+  /** WAM2 host slots (Phase A compatibility spike). */
+  wam2Slots: Wam2SlotTelemetry[];
+  wam2Constraints: Wam2RuntimeConstraints | null;
 }
 
 export interface EngineReport {
@@ -287,6 +293,8 @@ export class EngineTelemetry {
     baseLatencyMs: null,
     latencyHint: null,
     transportSync: null,
+    wam2Slots: [],
+    wam2Constraints: null,
   };
   private lastUnderrunByWorklet = new Map<string, number>();
 
@@ -463,11 +471,21 @@ export class EngineTelemetry {
       baseLatencyMs: this.runtime.baseLatencyMs,
       latencyHint: this.runtime.latencyHint,
       transportSync: this.runtime.transportSync,
+      wam2Slots: this.runtime.wam2Slots.slice(),
+      wam2Constraints: this.runtime.wam2Constraints,
     };
   }
 
   recordTransportSync(telemetry: TransportSyncTelemetry): void {
     this.runtime.transportSync = telemetry;
+  }
+
+  recordWam2Slots(slots: Wam2SlotTelemetry[]): void {
+    this.runtime.wam2Slots = slots.slice();
+  }
+
+  recordWam2Constraints(constraints: Wam2RuntimeConstraints): void {
+    this.runtime.wam2Constraints = constraints;
   }
 
   registerResolution(subsystem: string, backend: string, reason?: string) {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -26,6 +26,7 @@ if (typeof window !== 'undefined') {
   window.AudioContext = vi.fn().mockImplementation(function () { return ({
     createGain: vi.fn().mockReturnValue({
       connect: vi.fn(),
+      disconnect: vi.fn(),
       gain: {
         value: 0,
         setTargetAtTime: vi.fn(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase A Web Audio Modules 2.0 host on the existing declarative graph (supersedes the executable slice of closed #882 without a remote JS URL field). Hyphon’s AssemblyScript oscillators stay named `wam-*`; this host uses `wam2`.

- Bundled MIT fixtures: `hyphon.tone` (instrument source) and `hyphon.gain` (track/master insert).
- Graph factories/ports: `wamInstrumentSlot`, `wamTrackInsert`, `wamMasterInsert`, `wamSendReturn`, with cycle rejection unless a delay is on the loop.
- Sequencer notes take over a track when a WAM2 instrument is ready; one param (`gain`) records/replays via `AutomationScheduler` (`target: 'wam'`, `parameter: slotId/paramId`).
- Plugin identity/version/integrity/state round-trips on `SavedSongData.wam2`. Missing or hash-mismatched plugins become bypass placeholders — no silent substitute.
- Engine HUD shows slot status, CPU/latency, origin, isolation, and COOP/worklet/`BASE_URL` probes.
- Official SDK pin: `@webaudiomodules/sdk@0.0.12` (MIT, 375.5 KB unpacked), lazy-load only. ADR: `docs/adr/0001-wam2-host.md`.

## Testing

- `tsc -b` clean
- `check:root` OK
- Unit: `src/audio/wam`, graph compile/cycle, AutomationScheduler, engineTelemetry (74 tests)

## Phase A acceptance

- [x] Bundled instrument plays notes through a graph source port
- [x] Bundled effect in a track insert
- [x] One WAM param through existing automation
- [x] State round-trip + missing placeholder
- [x] HUD telemetry (CPU/latency/failure)
- [x] COOP/COEP headers unchanged; relative `BASE_URL` via `resolvePublicAsset`
- [x] ADR (SDK/version/license/security/CSP/integrity/lifecycle/offline)
- [x] SDK kept out of `main.tsx` / `App.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1154632-8b8b-4ffd-a47e-9ef60a19fd9e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1154632-8b8b-4ffd-a47e-9ef60a19fd9e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WAM2 audio-plugin hosting with bundled Tone and Gain instruments/effects.
  * Added plugin note scheduling, parameter automation, state saving, and restoration.
  * Added safe plugin loading with integrity checks, timeouts, bypass handling, and offline support.
  * Added WAM2 slot telemetry and runtime compatibility details to the Engine HUD.
  * Added support for plugin slots in audio graph routing and track playback.

* **Bug Fixes**
  * Unsafe audio-graph cycles are now detected and rejected.

* **Documentation**
  * Added WAM2 architecture, automation, compatibility, and release documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->