### PR TITLE
Session / clip launcher (audio-clock quantized)

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -40,6 +40,7 @@ Only these markdown files may live at the repository root. `pnpm run check:root`
 | [docs/features-implementation.md](docs/features-implementation.md) | Feature implementation tracking notes |
 | [docs/plan.md](docs/plan.md) | High-level project planning notes |
 | [docs/automation.md](docs/automation.md) | Automation scheduler + RBS import architecture |
+| [docs/session-launcher.md](docs/session-launcher.md) | Session / clip launcher: quantization, capture, MIDI/gamepad |
 | [docs/PERFORMANCE_BUDGET.md](docs/PERFORMANCE_BUDGET.md) | Audio-thread budget, auto-degrade order, offline 303 metrics |
 | [docs/adr/0001-wam2-host.md](docs/adr/0001-wam2-host.md) | WAM2 host Phase A: SDK pin, allowlist, CSP, integrity, lifecycle |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ For a quick-start overview see the root [README.md](../README.md).
 | File | Summary |
 |------|---------|
 | [automation.md](automation.md) | Current automation scheduler + RBS import architecture and testing touchpoints |
+| [session-launcher.md](session-launcher.md) | Session / clip launcher: schema, quantization, capture, MIDI/gamepad |
 | [PERFORMANCE_BUDGET.md](PERFORMANCE_BUDGET.md) | Audio-thread budget, auto-degrade order, offline 303 metrics |
 | [adr/0001-wam2-host.md](adr/0001-wam2-host.md) | WAM2 host Phase A loading/security model (SDK 0.0.12, allowlist, CSP) |
 

--- a/docs/session-launcher.md
+++ b/docs/session-launcher.md
@@ -1,0 +1,69 @@
+# Session / Clip Launcher
+
+Hyphon’s session view is a **non-linear clip launcher**. It does not start a second transport. Clip and scene launches compile into timestamped events consumed by the existing AudioWorklet clock (`TransportClockController` → `useStepHandler`).
+
+## Model (separated concerns)
+
+| Layer | Responsibility | Code |
+| --- | --- | --- |
+| Clip content | Pattern data stays in `trackStorage` slots; clips only *reference* `slotIndex` | `src/session/types.ts` |
+| Launch state machine | Queue, quantize, apply start/replace/stop | `src/session/SessionLaunchEngine.ts` |
+| UI focus | Grid keyboard / gamepad navigation | `src/session/gridKeyboard.ts`, `SessionLauncher.tsx` |
+| Arrangement capture | Live events → Song Mode measures | `src/session/capture.ts` |
+
+Stable clip ids: `c:{track}:{slot}` (migration). Scene ids: `s:{row}`.
+
+Persisted as `SavedSongData.session` (song schema **v3**). v1/v2 songs load unchanged; a default session is adapted from occupied pattern slots.
+
+## Quantization
+
+`immediate | step | beat | bar | 2bars | 4bars`
+
+Boundaries are computed from the **last worklet step timestamp**, never from React render time. 1 step = 16th note; 1 beat = 4 steps; 1 bar = 16 steps.
+
+## Launch modes
+
+- **trigger** — loop until another clip or stop
+- **toggle** — start if stopped, stop if this clip is playing
+- **gate** — play while MIDI/gamepad is held
+- **one-shot** — one pattern loop, then stop
+
+Follow actions (at loop end): `next`, `previous`, `random`, `stop`, `repeat` (N loops then stop).
+
+## Conflict rules
+
+1. **Song Mode vs Session** — Enabling Song Mode playback stops session clips. A live clip/scene/MIDI/gamepad launch preempts Song Mode at the quantized boundary.
+2. **Scene vs manual** — Later `requestSeq` wins. Equal seq: manual/MIDI/gamepad beats scene. Stop beats start.
+3. **Tracks are independent** — Scene atomicity is a shared boundary, not a lock.
+
+Clip transitions call `audioEngine.stopTrackNotes(track)` so hanging synth/sampler notes are flushed (no stuck or doubled notes).
+
+## MIDI Learn & gamepad
+
+Right-click a clip or scene cell (with MIDI Learn) to bind:
+
+| Control id | Action |
+| --- | --- |
+| `session:clip:{track}:{row}` | Launch clip (gate uses note velocity / CC > 0) |
+| `session:scene:{index}` | Launch scene |
+| `session:stop:{track}` | Stop one track |
+| `session:stopAll` | Stop all clips |
+
+Gamepad (when Session is focused): D-pad moves the grid (same as arrows). Attack (`ControlLeft`) launches the focused clip; Jump (`AltLeft`) launches the scene. See `useGamepad.ts` mappings.
+
+## Capture → Song Mode
+
+**CAPTURE** records applied launches. Stopping capture compiles them into the linear arrangement (`captureEventsToSongStructure`) and opens Song Mode. Replay uses the existing song-mode scheduler.
+
+Undo/redo: session document edits use a dedicated history; capture writes go through song-structure undo.
+
+## Starter packs
+
+Acid Live Set, Vocal Chop Performance, Dual-303 Jam, Minimal Drum Lab (`src/session/packs`).
+
+## Tests
+
+- Unit / property: `src/session/__tests__/sessionLauncher.test.ts`
+- Packs: `src/session/__tests__/sessionPacks.test.ts`
+- A11y: `src/components/__tests__/SessionLauncherA11y.test.tsx`
+- E2E: `tests/session-launcher.spec.ts`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { StartOverlay } from './components/StartOverlay'
 import { LoadingOverlay } from './components/LoadingOverlay'
 import { SEQUENCER_STYLES } from './components/sequencer/constants'
 import { SongMode } from './components/SongMode'
+import { SessionLauncher } from './components/SessionLauncher'
 import { MobileTransportDock } from './components/MobileTransportDock'
 import { MasterLoudnessMeter } from './components/MasterLoudnessMeter'
 import { EngineDegradationBanner } from './components/EngineDegradationBanner'
@@ -54,6 +55,11 @@ export const App: React.FC = () => {
         handleSongStructureUpdate, handleEditSongStructure, handleAddMeasure, handleRemoveMeasure,
         handleExportXM, isSongModeActive, setIsSongModeActive,
         undoSongStructure, redoSongStructure, canUndoSong, canRedoSong,
+        isSessionOpen, setIsSessionOpen, sessionDocument, setSessionDocument,
+        sessionPlayingSlots, isSessionCapturing, launchSessionClip, launchSessionScene,
+        stopSessionTrack, stopSessionAll, setSessionQuantization,
+        beginSessionCapture, finishSessionCapture, undoSession, redoSession,
+        canUndoSession, canRedoSession, loadSessionPack,
         contextMenu, setContextMenu, handleNoteSelect, handleNoteLengthChange,
         handleNotePropertyChange, currentScale,
         handleKeyboardPlay, handleKeyboardStop, handleDrumPadPlay,
@@ -210,16 +216,45 @@ export const App: React.FC = () => {
 
             <SongMode isVisible={isSongModeOpen} songStructure={songStructure} currentSongStep={currentSongMeasure} backgroundImage={backgroundImage} onSetBackgroundImage={setBackgroundImage} onToggle={handleSongModeToggle} onUpdateStep={handleSongStructureUpdate} onEditStructure={handleEditSongStructure} onUndoSong={undoSongStructure} onRedoSong={redoSongStructure} canUndoSong={canUndoSong()} canRedoSong={canRedoSong()} onAddMeasure={handleAddMeasure} onRemoveMeasure={handleRemoveMeasure} onExportXM={handleExportXM} isSongModeActive={isSongModeActive} onSetIsSongModeActive={setIsSongModeActive} />
 
+            <SessionLauncher
+                isVisible={isSessionOpen}
+                document={sessionDocument}
+                playingSlots={sessionPlayingSlots}
+                currentStep={state.currentStepRef.current}
+                isCapturing={isSessionCapturing}
+                quantization={sessionDocument.quantization}
+                onClose={() => setIsSessionOpen(false)}
+                onLaunchClip={launchSessionClip}
+                onLaunchScene={launchSessionScene}
+                onStopTrack={stopSessionTrack}
+                onStopAll={stopSessionAll}
+                onSetQuantization={setSessionQuantization}
+                onBeginCapture={beginSessionCapture}
+                onFinishCapture={() => {
+                    const captured = finishSessionCapture();
+                    handleEditSongStructure(() => captured);
+                    setIsSongModeOpen(true);
+                }}
+                onUndo={undoSession}
+                onRedo={redoSession}
+                canUndo={canUndoSession()}
+                canRedo={canRedoSession()}
+                onLoadPack={loadSessionPack}
+                onUpdateDocument={(doc) => setSessionDocument(doc)}
+            />
+
             <MobileTransportDock
                 isPlaying={isPlaying}
                 isRecording={isRecording}
                 tempo={tempo}
                 isSongModeOpen={isSongModeOpen}
+                isSessionOpen={isSessionOpen}
                 onPlayToggle={handlePlayToggle}
                 onRecordToggle={() => setIsRecording(!isRecording)}
                 onTempoNudgeStart={handleTempoHoldStart}
                 onTempoNudgeEnd={handleTempoHoldEnd}
                 onSongModeToggle={() => setIsSongModeOpen(!isSongModeOpen)}
+                onSessionToggle={() => setIsSessionOpen(!isSessionOpen)}
                 onPanic={handlePanic}
             />
 

--- a/src/__tests__/trackStorageUtils.test.ts
+++ b/src/__tests__/trackStorageUtils.test.ts
@@ -38,8 +38,8 @@ describe('trackStorageUtils', () => {
     expect(slots.snare).toBe(0);
   });
 
-  it('exports schema version 2 for 32-slot songs', () => {
-    expect(SAVED_SONG_DATA_VERSION).toBe(2);
+  it('exports schema version 3 for songs with session launcher', () => {
+    expect(SAVED_SONG_DATA_VERSION).toBe(3);
     expect(MAX_TRACK_PATTERN_SLOTS).toBe(32);
   });
 });

--- a/src/components/MobileTransportDock.tsx
+++ b/src/components/MobileTransportDock.tsx
@@ -5,11 +5,13 @@ interface MobileTransportDockProps {
     isRecording: boolean;
     tempo: number;
     isSongModeOpen: boolean;
+    isSessionOpen?: boolean;
     onPlayToggle: () => void;
     onRecordToggle: () => void;
     onTempoNudgeStart: (direction: -1 | 1) => void;
     onTempoNudgeEnd: () => void;
     onSongModeToggle: () => void;
+    onSessionToggle?: () => void;
     onPanic: () => void;
 }
 
@@ -19,11 +21,13 @@ export const MobileTransportDock = memo(function MobileTransportDock({
     isRecording,
     tempo,
     isSongModeOpen,
+    isSessionOpen = false,
     onPlayToggle,
     onRecordToggle,
     onTempoNudgeStart,
     onTempoNudgeEnd,
     onSongModeToggle,
+    onSessionToggle,
     onPanic,
 }: MobileTransportDockProps) {
     return (
@@ -99,6 +103,22 @@ export const MobileTransportDock = memo(function MobileTransportDock({
             >
                 SONG
             </button>
+
+            {onSessionToggle && (
+            <button
+                type="button"
+                onClick={onSessionToggle}
+                aria-pressed={isSessionOpen}
+                aria-label="Toggle session launcher"
+                className={`mobile-tap-target h-11 px-3 rounded-lg font-orbitron text-xs font-bold touch-manipulation ${
+                    isSessionOpen
+                        ? 'bg-cyan-600 text-white border border-cyan-400'
+                        : 'bg-zinc-800 text-gray-300 border border-zinc-700'
+                }`}
+            >
+                CLIP
+            </button>
+            )}
 
             <button
                 type="button"

--- a/src/components/SessionLauncher.tsx
+++ b/src/components/SessionLauncher.tsx
@@ -1,0 +1,235 @@
+import React, { memo, useCallback, useMemo, useState } from 'react';
+import { TRACK_KEYS } from '../constants';
+import type { TrackKey } from '../constants/appDefaults';
+import { midiMapStore } from '../stores/midiMapStore';
+import { SESSION_PACKS } from '../session/packs';
+import { LAUNCH_QUANTIZATIONS, SESSION_TRACK_LABELS, type LaunchQuantization, type SessionDocument } from '../session/types';
+import { moveSessionFocus, type SessionGridFocus } from '../session/gridKeyboard';
+import { sessionClipControlId, sessionSceneControlId } from '../session/midiMap';
+import { startMidiLearnForControl } from '../hooks/useMidi';
+
+interface SessionLauncherProps {
+  isVisible: boolean;
+  document: SessionDocument;
+  playingSlots: Record<TrackKey, number | null>;
+  currentStep: number;
+  isCapturing: boolean;
+  quantization: LaunchQuantization;
+  onClose: () => void;
+  onLaunchClip: (track: TrackKey, row: number) => void;
+  onLaunchScene: (row: number) => void;
+  onStopTrack: (track: TrackKey) => void;
+  onStopAll: () => void;
+  onSetQuantization: (q: LaunchQuantization) => void;
+  onBeginCapture: () => void;
+  onFinishCapture: () => void;
+  onUndo: () => void;
+  onRedo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  onLoadPack: (id: string) => void;
+  onUpdateDocument: (next: SessionDocument) => void;
+}
+
+export const SessionLauncher = memo(function SessionLauncher({
+  isVisible,
+  document,
+  playingSlots,
+  currentStep,
+  isCapturing,
+  quantization,
+  onClose,
+  onLaunchClip,
+  onLaunchScene,
+  onStopTrack,
+  onStopAll,
+  onSetQuantization,
+  onBeginCapture,
+  onFinishCapture,
+  onUndo,
+  onRedo,
+  canUndo,
+  canRedo,
+  onLoadPack,
+  onUpdateDocument,
+}: SessionLauncherProps) {
+  const [focus, setFocus] = useState<SessionGridFocus>({ kind: 'scene', row: 0 });
+  const rowCount = document.columns.partA.clips.length;
+
+  const queuedHint = useMemo(() => `Step ${currentStep + 1}`, [currentStep]);
+
+  const onGridKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const next = moveSessionFocus(focus, e.key, rowCount);
+      if (next !== focus && (e.key.startsWith('Arrow'))) {
+        e.preventDefault();
+        setFocus(next);
+        return;
+      }
+      if (e.key === 'Enter' || e.key === ' ' || e.key === 'ControlLeft') {
+        e.preventDefault();
+        if (focus.kind === 'scene') onLaunchScene(focus.row);
+        else onLaunchClip(focus.track, focus.row);
+      }
+      if (e.key === 'AltLeft') {
+        e.preventDefault();
+        onLaunchScene(focus.kind === 'scene' ? focus.row : focus.row);
+      }
+      if (e.key === 'Backspace' || e.key === 'Delete') {
+        e.preventDefault();
+        if (focus.kind === 'clip') onStopTrack(focus.track);
+        else onStopAll();
+      }
+    },
+    [focus, rowCount, onLaunchClip, onLaunchScene, onStopTrack, onStopAll],
+  );
+
+  if (!isVisible) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-40 flex items-end sm:items-center justify-center bg-black/70 p-2 sm:p-4"
+      role="presentation"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-[1000px] max-h-[min(78vh,640px)] bg-[#0c1014] border border-cyan-900/50 rounded-xl shadow-[0_0_40px_rgba(6,182,212,0.15)] flex flex-col overflow-hidden"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="session-launcher-title"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={onGridKeyDown}
+      >
+        <header className="flex flex-wrap items-center gap-2 p-3 border-b border-gray-800 bg-gray-900/40">
+          <h2 id="session-launcher-title" className="font-orbitron text-cyan-400 tracking-widest text-sm font-bold mr-auto">
+            SESSION
+          </h2>
+          <label className="text-[10px] uppercase text-gray-500 flex items-center gap-1">
+            Quant
+            <select
+              className="bg-zinc-900 border border-zinc-700 text-cyan-200 text-[11px] rounded px-1 py-0.5"
+              value={quantization}
+              aria-label="Launch quantization"
+              onChange={(e) => onSetQuantization(e.target.value as LaunchQuantization)}
+            >
+              {LAUNCH_QUANTIZATIONS.map((q) => (
+                <option key={q} value={q}>{q}</option>
+              ))}
+            </select>
+          </label>
+          <span className="text-[10px] font-mono text-gray-500" aria-live="polite">{queuedHint}</span>
+          <button type="button" className="h-7 px-2 text-[10px] font-orbitron border border-zinc-700 rounded" onClick={onUndo} disabled={!canUndo} aria-label="Undo session edit">UNDO</button>
+          <button type="button" className="h-7 px-2 text-[10px] font-orbitron border border-zinc-700 rounded" onClick={onRedo} disabled={!canRedo} aria-label="Redo session edit">REDO</button>
+          <button
+            type="button"
+            className={`h-7 px-2 text-[10px] font-orbitron border rounded ${isCapturing ? 'bg-red-700 text-white border-red-400' : 'border-zinc-700 text-gray-300'}`}
+            aria-pressed={isCapturing}
+            aria-label={isCapturing ? 'Stop capturing launches into Song Mode' : 'Capture launches into Song Mode'}
+            onClick={() => (isCapturing ? onFinishCapture() : onBeginCapture())}
+          >
+            {isCapturing ? 'CAPTURING' : 'CAPTURE'}
+          </button>
+          <button type="button" className="h-7 px-2 text-[10px] font-orbitron border border-zinc-700 rounded" onClick={onStopAll} aria-label="Stop all clips">STOP</button>
+          <button type="button" className="h-7 w-7 text-gray-400" onClick={onClose} aria-label="Close Session Launcher">✕</button>
+        </header>
+
+        <div className="px-3 py-2 flex gap-2 overflow-x-auto border-b border-gray-800">
+          {SESSION_PACKS.map((pack) => (
+            <button
+              key={pack.id}
+              type="button"
+              className="shrink-0 h-7 px-2 text-[10px] font-orbitron border border-cyan-900/60 text-cyan-300 rounded"
+              onClick={() => onLoadPack(pack.id)}
+              aria-label={`Load starter pack ${pack.name}`}
+            >
+              {pack.name}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex-1 overflow-auto custom-scrollbar p-2" data-testid="session-grid">
+          <div
+            role="grid"
+            aria-label="Clip launcher"
+            className="min-w-[640px]"
+          >
+            <div role="row" className="flex text-[9px] uppercase tracking-wider text-gray-500 mb-1">
+              <div role="columnheader" className="w-16 shrink-0 px-1">Scene</div>
+              {TRACK_KEYS.map((track) => (
+                <div key={track} role="columnheader" className="flex-1 min-w-[72px] px-1 text-center">
+                  {SESSION_TRACK_LABELS[track]}
+                </div>
+              ))}
+            </div>
+            {Array.from({ length: rowCount }, (_, row) => (
+              <div key={row} role="row" className="flex gap-1 mb-1">
+                <button
+                  type="button"
+                  role="gridcell"
+                  data-testid={`session-scene-${row}`}
+                  tabIndex={focus.kind === 'scene' && focus.row === row ? 0 : -1}
+                  aria-label={`Launch ${document.scenes[row]?.name ?? `scene ${row + 1}`}`}
+                  className={`w-16 shrink-0 h-10 text-[10px] font-bold rounded border ${
+                    focus.kind === 'scene' && focus.row === row
+                      ? 'border-cyan-400 bg-cyan-950 text-cyan-200'
+                      : 'border-zinc-800 bg-zinc-900 text-gray-300'
+                  }`}
+                  onFocus={() => setFocus({ kind: 'scene', row })}
+                  onClick={() => onLaunchScene(row)}
+                  onContextMenu={(e) => {
+                    e.preventDefault();
+                    startMidiLearnForControl('session', `scene:${row}`);
+                    midiMapStore.touchControl(sessionSceneControlId(row));
+                  }}
+                >
+                  {document.scenes[row]?.name ?? row + 1}
+                </button>
+                {TRACK_KEYS.map((track) => {
+                  const clip = document.columns[track].clips[row];
+                  const playing = playingSlots[track] === clip?.slotIndex && clip && !clip.empty;
+                  const focused = focus.kind === 'clip' && focus.track === track && focus.row === row;
+                  return (
+                    <button
+                      key={track}
+                      type="button"
+                      role="gridcell"
+                      data-testid={`session-clip-${track}-${row}`}
+                      tabIndex={focused ? 0 : -1}
+                      disabled={!clip || clip.empty}
+                      aria-label={`${SESSION_TRACK_LABELS[track]} clip ${clip?.name ?? row + 1}${playing ? ', playing' : clip?.empty ? ', empty' : ''}`}
+                      aria-pressed={!!playing}
+                      className={`flex-1 min-w-[72px] h-10 text-[10px] rounded border truncate px-1 ${
+                        playing
+                          ? 'bg-cyan-600 text-black border-cyan-300'
+                          : clip?.empty
+                            ? 'bg-transparent border-zinc-800 text-zinc-600'
+                            : focused
+                              ? 'bg-zinc-800 border-cyan-400 text-white'
+                              : 'bg-zinc-900 border-zinc-700 text-gray-200'
+                      }`}
+                      onFocus={() => setFocus({ kind: 'clip', track, row })}
+                      onClick={() => onLaunchClip(track, row)}
+                      onContextMenu={(e) => {
+                        e.preventDefault();
+                        startMidiLearnForControl('session', `clip:${track}:${row}`);
+                        midiMapStore.touchControl(sessionClipControlId(track, row));
+                      }}
+                    >
+                      {clip?.empty ? '·' : clip?.name}
+                    </button>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <p className="sr-only">
+          Arrow keys move focus. Enter or Space launches the focused clip or scene.
+          Delete stops the focused track. Gamepad D-pad navigates; Attack launches the clip;
+          Jump launches the scene. Right-click a cell to MIDI-learn.
+        </p>
+      </div>
+    </div>
+  );
+});

--- a/src/components/TransportToolbar.tsx
+++ b/src/components/TransportToolbar.tsx
@@ -15,6 +15,7 @@ interface TransportToolbarProps {
     isRecording: boolean
     isPlaying: boolean
     isSongModeOpen: boolean
+    isSessionOpen?: boolean
     is3DMode: boolean
     loadSong: (slot: number) => void
     handleSaveSong: (slot: number) => Promise<void>
@@ -26,6 +27,7 @@ interface TransportToolbarProps {
     handlePlayToggle: () => void
     setIsRecording: React.Dispatch<React.SetStateAction<boolean>>
     setIsSongModeOpen: React.Dispatch<React.SetStateAction<boolean>>
+    setIsSessionOpen?: React.Dispatch<React.SetStateAction<boolean>>
     setIs3DMode: React.Dispatch<React.SetStateAction<boolean>>
     currentScale: ScaleDefinition | null
     setCurrentScale: (scale: ScaleDefinition | null) => void
@@ -47,6 +49,7 @@ export const TransportToolbar = memo(function TransportToolbar({
     isRecording,
     isPlaying,
     isSongModeOpen,
+    isSessionOpen = false,
     is3DMode,
     loadSong,
     handleSaveSong,
@@ -58,6 +61,7 @@ export const TransportToolbar = memo(function TransportToolbar({
     handlePlayToggle,
     setIsRecording,
     setIsSongModeOpen,
+    setIsSessionOpen,
     setIs3DMode,
     currentScale,
     setCurrentScale,
@@ -280,6 +284,20 @@ export const TransportToolbar = memo(function TransportToolbar({
                     SONG
                 </button>
                 </HelpTip>
+
+                {setIsSessionOpen && (
+                <HelpTip topicId="session-launcher" position="bottom">
+                <button type="button"
+                    onClick={() => setIsSessionOpen(!isSessionOpen)}
+                    aria-pressed={isSessionOpen}
+                    aria-label="Toggle Session Launcher"
+                    title={isSessionOpen ? "Close Session Launcher" : "Open Session Launcher"}
+                    className={`h-7 px-3 font-orbitron text-xs font-bold tracking-wide transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1014] rounded-md hover:scale-105 active:scale-95 ${isSessionOpen ? 'bg-cyan-600 text-white shadow-[0_0_10px_rgba(6,182,212,0.5)] border border-cyan-400' : 'bg-zinc-800 text-gray-400 border border-zinc-700 hover:bg-zinc-700 hover:text-gray-300'}`}
+                >
+                    CLIP
+                </button>
+                </HelpTip>
+                )}
 
                 {/* 3D Toggle */}
                 <button type="button"

--- a/src/components/__tests__/SessionLauncherA11y.test.tsx
+++ b/src/components/__tests__/SessionLauncherA11y.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { SessionLauncher } from '../SessionLauncher';
+import { createDefaultSessionDocument } from '../../session/defaults';
+import { TRACK_KEYS } from '../../constants';
+import type { TrackKey } from '../../constants/appDefaults';
+
+const emptyPlaying = () => {
+  const m = {} as Record<TrackKey, number | null>;
+  for (const t of TRACK_KEYS) m[t] = null;
+  return m;
+};
+
+describe('SessionLauncher accessibility', () => {
+  const doc = createDefaultSessionDocument();
+  doc.columns.kick.clips[0].empty = false;
+  doc.columns.kick.clips[0].name = 'Kick A';
+
+  const props = {
+    isVisible: true,
+    document: doc,
+    playingSlots: emptyPlaying(),
+    currentStep: 0,
+    isCapturing: false,
+    quantization: 'bar' as const,
+    onClose: vi.fn(),
+    onLaunchClip: vi.fn(),
+    onLaunchScene: vi.fn(),
+    onStopTrack: vi.fn(),
+    onStopAll: vi.fn(),
+    onSetQuantization: vi.fn(),
+    onBeginCapture: vi.fn(),
+    onFinishCapture: vi.fn(),
+    onUndo: vi.fn(),
+    onRedo: vi.fn(),
+    canUndo: false,
+    canRedo: false,
+    onLoadPack: vi.fn(),
+    onUpdateDocument: vi.fn(),
+  };
+
+  it('exposes a labeled grid and launches a scene with Enter', () => {
+    render(<SessionLauncher {...props} />);
+    expect(screen.getByRole('grid', { name: 'Clip launcher' })).toBeTruthy();
+    const scene = screen.getByTestId('session-scene-0');
+    scene.focus();
+    fireEvent.keyDown(scene, { key: 'Enter' });
+    expect(props.onLaunchScene).toHaveBeenCalledWith(0);
+  });
+
+  it('launches a clip from a grid cell', () => {
+    render(<SessionLauncher {...props} />);
+    fireEvent.click(screen.getByTestId('session-clip-kick-0'));
+    expect(props.onLaunchClip).toHaveBeenCalledWith('kick', 0);
+  });
+});

--- a/src/components/__tests__/SessionLauncherA11y.test.tsx
+++ b/src/components/__tests__/SessionLauncherA11y.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { SessionLauncher } from '../SessionLauncher';
 import { createDefaultSessionDocument } from '../../session/defaults';
@@ -43,8 +43,10 @@ describe('SessionLauncher accessibility', () => {
     render(<SessionLauncher {...props} />);
     expect(screen.getByRole('grid', { name: 'Clip launcher' })).toBeTruthy();
     const scene = screen.getByTestId('session-scene-0');
-    scene.focus();
-    fireEvent.keyDown(scene, { key: 'Enter' });
+    act(() => {
+      scene.focus();
+      fireEvent.keyDown(scene, { key: 'Enter' });
+    });
     expect(props.onLaunchScene).toHaveBeenCalledWith(0);
   });
 

--- a/src/components/appParts/TransportHeader.tsx
+++ b/src/components/appParts/TransportHeader.tsx
@@ -11,6 +11,7 @@ export const TransportHeader = React.memo(({ onToggleCompact, isCompactLayout }:
     isRecording,
     isPlaying,
     isSongModeOpen,
+    isSessionOpen,
     is3DMode,
     loadSong,
     handleSaveSong,
@@ -22,6 +23,7 @@ export const TransportHeader = React.memo(({ onToggleCompact, isCompactLayout }:
     handlePlayToggle,
     setIsRecording,
     setIsSongModeOpen,
+    setIsSessionOpen,
     setIs3DMode,
     currentScale,
     setCurrentScale,
@@ -48,6 +50,7 @@ export const TransportHeader = React.memo(({ onToggleCompact, isCompactLayout }:
       isRecording={isRecording}
       isPlaying={isPlaying}
       isSongModeOpen={isSongModeOpen}
+      isSessionOpen={isSessionOpen}
       is3DMode={is3DMode}
       loadSong={loadSong}
       handleSaveSong={handleSaveSong}
@@ -59,6 +62,7 @@ export const TransportHeader = React.memo(({ onToggleCompact, isCompactLayout }:
       handlePlayToggle={handlePlayToggle}
       setIsRecording={setIsRecording}
       setIsSongModeOpen={setIsSongModeOpen}
+      setIsSessionOpen={setIsSessionOpen}
       setIs3DMode={setIs3DMode}
       currentScale={currentScale}
       setCurrentScale={setCurrentScale}

--- a/src/components/help/helpShortcuts.ts
+++ b/src/components/help/helpShortcuts.ts
@@ -44,6 +44,7 @@ export const SHORTCUT_SECTIONS: ShortcutSection[] = [
       { key: 'Touch knob', desc: 'While learning: select target parameter' },
       { key: 'Long-press knob', desc: 'Start MIDI Learn for that parameter' },
       { key: 'Right-click master slider', desc: 'MIDI Learn for volume / pan / warmth' },
+      { key: 'Right-click session cell', desc: 'MIDI Learn for clip / scene launch' },
       { key: 'Move CC / note', desc: 'While learning: bind controller to last-touched control' },
     ],
   },
@@ -52,7 +53,11 @@ export const SHORTCUT_SECTIONS: ShortcutSection[] = [
     items: [
       { key: 'Tab', desc: 'Focus Next Element' },
       { key: 'Shift + Tab', desc: 'Focus Previous Element' },
-      { key: 'Esc', desc: 'Close Modals / Tape Stop' },
+      { key: 'CLIP (toolbar)', desc: 'Open Session / clip launcher' },
+      { key: 'Arrows (Session)', desc: 'Move clip/scene focus' },
+      { key: 'Enter / Space (Session)', desc: 'Launch focused clip or scene' },
+      { key: 'Delete (Session)', desc: 'Stop focused track (or all from a scene cell)' },
+      { key: 'Gamepad Attack / Jump', desc: 'Launch clip / scene when Session is focused' },
     ],
   },
 ];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,8 +11,8 @@ export const DEFAULT_TEMPO = 120;
 export const LEGACY_TRACK_PATTERN_SLOTS = 8;
 /** ReBirth-compatible pattern banks per track (DEVL supports 32). */
 export const MAX_TRACK_PATTERN_SLOTS = 32;
-/** SavedSongData schema: 1 = 8 slots, 2 = 32 slots. */
-export const SAVED_SONG_DATA_VERSION = 2;
+/** SavedSongData schema: 1 = 8 slots, 2 = 32 slots, 3 = 32 slots + session. */
+export const SAVED_SONG_DATA_VERSION = 3;
 
 export const TRACK_KEYS = [
   'partA',

--- a/src/content/helpTopics.ts
+++ b/src/content/helpTopics.ts
@@ -246,6 +246,24 @@ export const HELP_TOPICS: HelpTopic[] = [
     ],
   },
   {
+    id: 'session-launcher',
+    title: 'Session / clip launcher',
+    summary: 'CLIP opens a scene grid. Launch clips per track or whole scenes, quantized to the audio clock.',
+    body:
+      'Session is a live clip launcher. It uses the same transport as the sequencer — launches wait for the selected quantization (step, beat, bar, 2/4 bars) on the audio timeline.\n\n' +
+      'CAPTURE records your launches into Song Mode. Right-click a cell to MIDI-learn. Gamepad D-pad navigates; Attack launches a clip, Jump launches a scene.\n\n' +
+      'See docs/session-launcher.md for conflict rules and control ids.',
+    keywords: ['session', 'clip', 'launcher', 'scene', 'live', 'quantize', 'capture'],
+    category: 'song',
+    steps: [
+      'Click CLIP in the transport toolbar.',
+      'Load a starter pack or use clips mapped to pattern slots.',
+      'Press Play, then launch a scene or individual clips.',
+      'Optional: CAPTURE, then replay from Song Mode.',
+    ],
+    docLink: 'docs/session-launcher.md',
+  },
+  {
     id: 'midi-learn',
     title: 'MIDI learn & mapping',
     summary: 'Toolbar MIDI toggles learn mode; touch a knob then move a controller to bind.',

--- a/src/e2e/probe.ts
+++ b/src/e2e/probe.ts
@@ -4,6 +4,11 @@ declare global {
       step: number;
       laneCount: number;
     };
+    __HYPHON_E2E_SESSION__?: {
+      playingCount: number;
+      lastApplyStep: number;
+      captureCount: number;
+    };
   }
 }
 
@@ -26,4 +31,13 @@ export function setE2eTransportStep(step: number): void {
 export function setE2eLaneCount(count: number): void {
   if (!isE2eMode()) return;
   e2eTransportSnapshot().laneCount = count;
+}
+
+export function setE2eSessionState(state: {
+  playingCount: number;
+  lastApplyStep: number;
+  captureCount: number;
+}): void {
+  if (!isE2eMode() || typeof window === 'undefined') return;
+  window.__HYPHON_E2E_SESSION__ = state;
 }

--- a/src/engines/ProphecyManager.ts
+++ b/src/engines/ProphecyManager.ts
@@ -170,6 +170,14 @@ export class ProphecyManager {
         this.partB?.allNotesOff();
     }
 
+    allNotesOffPartA(): void {
+        this.partA?.allNotesOff();
+    }
+
+    allNotesOffPartB(): void {
+        this.partB?.allNotesOff();
+    }
+
     // ── Cleanup ───────────────────────────────────────────────────────────────
 
     cleanup(): void {

--- a/src/hooks/appState/useSessionState.ts
+++ b/src/hooks/appState/useSessionState.ts
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { TrackKey } from '../../constants/appDefaults';
+import { useUndoRedo } from '../useUndoRedo';
+import { SessionLaunchEngine } from '../../session/SessionLaunchEngine';
+import { createDefaultSessionDocument } from '../../session/defaults';
+import { captureEventsToSongStructure } from '../../session/capture';
+import { parseSessionMidiParam } from '../../session/midiMap';
+import type { LaunchQuantization, SessionDocument } from '../../session/types';
+import type { SongStructure } from '../../types/songMode';
+import { getSessionPack, mergePackStorage } from '../../session/packs';
+import type { TrackStorageMap } from '../../utils/trackStorageUtils';
+
+export function useSessionState() {
+  const [isSessionOpen, setIsSessionOpen] = useState(false);
+  const [sessionDocument, setSessionDocument] = useState<SessionDocument>(() => createDefaultSessionDocument());
+  const [playingSlots, setPlayingSlots] = useState<Record<TrackKey, number | null>>(() => {
+    const empty = {} as Record<TrackKey, number | null>;
+    empty.partA = null;
+    empty.partB = null;
+    empty.bass2 = null;
+    empty.kick = null;
+    empty.snare = null;
+    empty.closedHat = null;
+    empty.openHat = null;
+    empty.sampler = null;
+    return empty;
+  });
+  const [isCapturing, setIsCapturing] = useState(false);
+  const engineRef = useRef<SessionLaunchEngine | null>(null);
+  if (!engineRef.current) {
+    engineRef.current = new SessionLaunchEngine(sessionDocument);
+  }
+  const clockRef = useRef({ step: 0, audioTime: 0, tempo: 120 });
+  const undo = useUndoRedo<SessionDocument>(40);
+  const sessionDocumentRef = useRef(sessionDocument);
+  useEffect(() => {
+    sessionDocumentRef.current = sessionDocument;
+  }, [sessionDocument]);
+
+  useEffect(() => {
+    engineRef.current?.setDocument(sessionDocument);
+  }, [sessionDocument]);
+
+  const replaceSession = useCallback((next: SessionDocument, recordUndo = true) => {
+    if (recordUndo) undo.push(sessionDocument);
+    setSessionDocument(next);
+    engineRef.current?.setDocument(next);
+  }, [sessionDocument, undo]);
+
+  const launchClip = useCallback((track: TrackKey, row: number, source: 'manual' | 'midi' | 'gamepad' = 'manual', gateDown = true) => {
+    const engine = engineRef.current;
+    if (!engine) return;
+    const clip = engine.document.columns[track]?.clips[row];
+    if (!clip || clip.empty) return;
+    engine.enqueue({
+      kind: 'clip',
+      source,
+      requestAudioTime: clockRef.current.audioTime,
+      requestStep: clockRef.current.step,
+      track,
+      clipId: clip.id,
+      gateDown,
+    }, {
+      step: clockRef.current.step,
+      audioTime: clockRef.current.audioTime || 0,
+      tempo: clockRef.current.tempo,
+      patternSteps: 32,
+      stepsPerBeat: 4,
+      stepsPerBar: 16,
+      isPlaying: true,
+      songModeActive: false,
+    });
+  }, []);
+
+  const launchScene = useCallback((sceneIndex: number, source: 'manual' | 'midi' | 'gamepad' | 'scene' = 'scene') => {
+    const engine = engineRef.current;
+    if (!engine) return;
+    const scene = engine.document.scenes[sceneIndex];
+    if (!scene) return;
+    engine.enqueue({
+      kind: 'scene',
+      source,
+      requestAudioTime: clockRef.current.audioTime,
+      requestStep: clockRef.current.step,
+      sceneId: scene.id,
+    }, {
+      step: clockRef.current.step,
+      audioTime: clockRef.current.audioTime || 0,
+      tempo: clockRef.current.tempo,
+      patternSteps: 32,
+      stepsPerBeat: 4,
+      stepsPerBar: 16,
+      isPlaying: true,
+      songModeActive: false,
+    });
+  }, []);
+
+  const stopTrack = useCallback((track: TrackKey, source: 'manual' | 'midi' | 'gamepad' = 'manual') => {
+    engineRef.current?.enqueue({
+      kind: 'stop-track',
+      source,
+      requestAudioTime: clockRef.current.audioTime,
+      requestStep: clockRef.current.step,
+      track,
+    }, {
+      step: clockRef.current.step,
+      audioTime: clockRef.current.audioTime || 0,
+      tempo: clockRef.current.tempo,
+      patternSteps: 32,
+      stepsPerBeat: 4,
+      stepsPerBar: 16,
+      isPlaying: true,
+      songModeActive: false,
+    });
+  }, []);
+
+  const stopAll = useCallback(() => {
+    engineRef.current?.enqueue({
+      kind: 'stop-all',
+      source: 'manual',
+      requestAudioTime: clockRef.current.audioTime,
+      requestStep: clockRef.current.step,
+    }, {
+      step: clockRef.current.step,
+      audioTime: clockRef.current.audioTime || 0,
+      tempo: clockRef.current.tempo,
+      patternSteps: 32,
+      stepsPerBeat: 4,
+      stepsPerBar: 16,
+      isPlaying: true,
+      songModeActive: false,
+    });
+  }, []);
+
+  const setQuantization = useCallback((q: LaunchQuantization) => {
+    const engine = engineRef.current;
+    if (!engine) return;
+    undo.push(sessionDocument);
+    engine.setQuantization(q);
+    setSessionDocument({ ...engine.document });
+  }, [sessionDocument, undo]);
+
+  const handleSessionMidi = useCallback((param: string, normalized: number) => {
+    const action = parseSessionMidiParam(param, normalized);
+    if (!action) return;
+    if (action.type === 'clip') launchClip(action.track, action.row, 'midi', action.down);
+    else if (action.type === 'scene' && action.down) launchScene(action.sceneIndex, 'midi');
+    else if (action.type === 'stop-track') stopTrack(action.track, 'midi');
+    else if (action.type === 'stop-all') stopAll();
+  }, [launchClip, launchScene, stopTrack, stopAll]);
+
+  const beginCapture = useCallback(() => {
+    engineRef.current?.armCapture();
+    setIsCapturing(true);
+  }, []);
+
+  const finishCapture = useCallback((): SongStructure => {
+    const events = engineRef.current?.disarmCapture() ?? [];
+    setIsCapturing(false);
+    return captureEventsToSongStructure(events);
+  }, []);
+
+  const undoSession = useCallback(() => {
+    const prev = undo.undo();
+    if (prev) {
+      setSessionDocument(prev);
+      engineRef.current?.setDocument(prev);
+    }
+  }, [undo]);
+
+  const redoSession = useCallback(() => {
+    const next = undo.redo();
+    if (next) {
+      setSessionDocument(next);
+      engineRef.current?.setDocument(next);
+    }
+  }, [undo]);
+
+  const loadPack = useCallback((packId: string, setTrackStorage: (s: TrackStorageMap | ((p: TrackStorageMap) => TrackStorageMap)) => void) => {
+    const pack = getSessionPack(packId);
+    if (!pack) return;
+    undo.push(sessionDocument);
+    setSessionDocument(pack.session);
+    engineRef.current?.setDocument(pack.session);
+    setTrackStorage((prev) => mergePackStorage(prev, pack.trackStorage));
+  }, [sessionDocument, undo]);
+
+  return {
+    isSessionOpen,
+    setIsSessionOpen,
+    sessionDocument,
+    setSessionDocument: replaceSession,
+    playingSlots,
+    setPlayingSlots,
+    isCapturing,
+    sessionEngineRef: engineRef,
+    sessionClockRef: clockRef,
+    sessionDocumentRef,
+    launchClip,
+    launchScene,
+    stopTrack,
+    stopAll,
+    setQuantization,
+    handleSessionMidi,
+    beginCapture,
+    finishCapture,
+    undoSession,
+    redoSession,
+    canUndoSession: undo.canUndo,
+    canRedoSession: undo.canRedo,
+    loadPack,
+  };
+}

--- a/src/hooks/audioEngine/audioPlayback.ts
+++ b/src/hooks/audioEngine/audioPlayback.ts
@@ -13,6 +13,7 @@ export {
   createNoteOnSynth,
   noteOffSynth,
   createStopAllNotes,
+  createStopTrackNotes,
 } from "./audioPlayback/noteControls";
 export { createAmbianceControls } from "./audioPlayback/ambiance";
 export {

--- a/src/hooks/audioEngine/audioPlayback/noteControls.ts
+++ b/src/hooks/audioEngine/audioPlayback/noteControls.ts
@@ -194,6 +194,48 @@ export function noteOffSynth(
   activeSynthNotes.delete(id);
 }
 
+export function createStopTrackNotes(
+  refs: Pick<
+    PlaybackRefs,
+    | "activeSamplerNotes"
+    | "voiceManagerARef"
+    | "voiceManagerBRef"
+    | "singingVoiceManagerRef"
+    | "open303ManagerRef"
+    | "prophecyManagerRef"
+  >,
+): NonNullable<AudioEngine["stopTrackNotes"]> {
+  return (track) => {
+    if (track === "partA") {
+      refs.voiceManagerARef.current?.stopAll(0);
+      refs.open303ManagerRef.current?.noteOffLead303(0);
+      refs.prophecyManagerRef.current?.allNotesOffPartA();
+      return;
+    }
+    if (track === "partB") {
+      refs.voiceManagerBRef.current?.stopAll(0);
+      refs.open303ManagerRef.current?.noteOffBass1(0);
+      refs.prophecyManagerRef.current?.allNotesOffPartB();
+      return;
+    }
+    if (track === "bass2") {
+      refs.open303ManagerRef.current?.noteOffBass2(0);
+      return;
+    }
+    if (track === "sampler") {
+      refs.singingVoiceManagerRef.current?.stopAll();
+      for (const note of refs.activeSamplerNotes.current.values()) {
+        try {
+          note.source.stop();
+        } catch {
+          /* already stopped */
+        }
+      }
+      refs.activeSamplerNotes.current.clear();
+    }
+  };
+}
+
 export function createStopAllNotes(
   refs: Pick<
     PlaybackRefs,

--- a/src/hooks/audioEngine/engineApiBuilder.ts
+++ b/src/hooks/audioEngine/engineApiBuilder.ts
@@ -12,6 +12,7 @@ import {
     createPlayDrum,
     createPlaySynth,
     createStopAllNotes,
+    createStopTrackNotes,
     noteOffSynth,
     setGlobalPan as setMasterPan,
     setHarmonizerConfig as applyHarmonizerConfig,
@@ -57,6 +58,7 @@ export function buildAudioEngine(
     const noteOnSynth = createNoteOnSynth(context, refs);
     const noteOffSynthById = (id: number) => noteOffSynth(refs.activeSynthNotes.current, id);
     const stopAllNotes = createStopAllNotes(refs);
+    const stopTrackNotes = createStopTrackNotes(refs);
 
     const renderSynthPartToBuffer = (params: SynthParams, sequence: PartSequence, tempo: number): Promise<AudioBuffer> => {
         return renderSynthPattern(params, {
@@ -128,6 +130,7 @@ export function buildAudioEngine(
         noteOnSynth,
         noteOffSynth: noteOffSynthById,
         stopAllNotes,
+        stopTrackNotes,
         loadSampleToEngine: playbackFns.loadSampleToEngine,
         renderSynthPartToBuffer,
         playBufferedPart,

--- a/src/hooks/useAppState.tsx
+++ b/src/hooks/useAppState.tsx
@@ -47,6 +47,7 @@ import { useInstrumentState } from './appState/useInstrumentState'
 import { useSamplerVoiceState } from './appState/useSamplerVoiceState'
 import { useUIModalsState } from './appState/useUIModalsState'
 import { useSongModeState } from './appState/useSongModeState'
+import { useSessionState } from './appState/useSessionState'
 import { useSongStructureEditor } from './useSongStructureEditor'
 import { usePatternEditState } from './appState/usePatternEditState'
 import { useSamplerBanksState } from './appState/useSamplerBanksState'
@@ -173,6 +174,8 @@ export function useAppState() {
         songMeasureRef,
         isFirstStepRef,
     } = useSongModeState();
+
+    const session = useSessionState();
 
     const {
         editSongStructure: handleEditSongStructure,
@@ -327,9 +330,17 @@ export function useAppState() {
         setCurrentSongMeasure,
         automationSchedulerRef,
         trakEventsRef,
+        sessionEngineRef: session.sessionEngineRef,
+        sessionClockRef: session.sessionClockRef,
+        setIsSongModeActive,
+        onSessionTick: session.setPlayingSlots,
     })
 
     const { isPlaying: schedPlaying, setIsPlaying: setSchedPlaying } = useScheduler(tempo, NUM_STEPS, onStep, isEngineReady, audioEngine?.context ?? null, swing)
+
+    useEffect(() => {
+        session.sessionClockRef.current.tempo = tempo;
+    }, [tempo, session.sessionClockRef]);
     useEffect(() => setIsPlaying(schedPlaying), [schedPlaying])
 
     useEffect(() => {
@@ -339,6 +350,7 @@ export function useAppState() {
             isFirstStepRef.current = true;
             if (sequencerRef.current) sequencerRef.current.setHighlight(-1);
             currentStepRef.current = -1;
+            session.sessionEngineRef.current?.resetTransport();
             automationStore.clearLiveValues();
             automationSchedulerRef.current?.cancelAll();
         }
@@ -415,11 +427,13 @@ export function useAppState() {
             setAudioMasterSaturation: (v: number) => audioEngine?.setMasterSaturation?.(v),
             setAudioGlobalPan: (v: number) => audioEngine?.setGlobalPan?.(v),
             getCurrentStep: () => currentStepRef.current,
+            handleSessionControl: session.handleSessionMidi,
         }),
         [
             handleSynthChange, handleBass2Change, handleKickChange, handleSnareChange,
             handleClosedHatChange, handleOpenHatChange, handleSamplerChange,
             setMasterVolume, setMasterSaturation, setGlobalPan, audioEngine,
+            session.handleSessionMidi,
         ],
     );
 
@@ -495,6 +509,8 @@ export function useAppState() {
         patternRef, tempoRef,
         synthARef, synthBRef, bass2Ref, kickRef, snareRef, closedHatRef, openHatRef, samplerRef,
         trackStorageRef, activeTrackSlotsRef, songStructureRef,
+        sessionDocumentRef: session.sessionDocumentRef,
+        setSessionDocument: session.setSessionDocument,
         ambianceUrl, backgroundImage, sampleBuffers, ttsPhrases,
         songStorage, pattern, tempo, trackStorage,
         setPattern, setTempo, setAmbianceUrl, setBackgroundImage,
@@ -748,5 +764,23 @@ export function useAppState() {
         noteDragRef,
         tempoLocked,
         slavePlayLabel,
+        isSessionOpen: session.isSessionOpen,
+        setIsSessionOpen: session.setIsSessionOpen,
+        sessionDocument: session.sessionDocument,
+        setSessionDocument: session.setSessionDocument,
+        sessionPlayingSlots: session.playingSlots,
+        isSessionCapturing: session.isCapturing,
+        launchSessionClip: session.launchClip,
+        launchSessionScene: session.launchScene,
+        stopSessionTrack: session.stopTrack,
+        stopSessionAll: session.stopAll,
+        setSessionQuantization: session.setQuantization,
+        beginSessionCapture: session.beginCapture,
+        finishSessionCapture: session.finishCapture,
+        undoSession: session.undoSession,
+        redoSession: session.redoSession,
+        canUndoSession: session.canUndoSession,
+        canRedoSession: session.canRedoSession,
+        loadSessionPack: (id: string) => session.loadPack(id, setTrackStorage),
     }
 }

--- a/src/hooks/useMidi.ts
+++ b/src/hooks/useMidi.ts
@@ -1,8 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { midiPortManager } from '../midi/MidiPortManager';
 import { midiMapStore } from '../stores/midiMapStore';
-import type { AutomationTarget } from '../types';
-import type { MidiBinding } from '../types/midi';
+import type { MidiBinding, MidiControlTarget } from '../types/midi';
 import { formatMidiBindingLabel, makeMidiControlId, midiValueToNormalized } from '../types/midi';
 import { applyMidiControlValue, type MidiParamHandlers } from '../utils/midiParamDispatch';
 import { midiMessageToBinding, parseMidiMessage } from '../utils/midiMessageParse';
@@ -89,12 +88,12 @@ export function useMidi({ handlers, showToast }: UseMidiOptions): void {
 }
 
 /** Register a control touch for MIDI learn (knob drag, slider focus, long-press). */
-export function registerMidiControlTouch(target: AutomationTarget, param: string): void {
+export function registerMidiControlTouch(target: MidiControlTarget, param: string): void {
   midiMapStore.touchControl(makeMidiControlId(target, param));
 }
 
 /** Long-press on a control: arm learn mode for that parameter. */
-export function startMidiLearnForControl(target: AutomationTarget, param: string): void {
+export function startMidiLearnForControl(target: MidiControlTarget, param: string): void {
   midiMapStore.touchControl(makeMidiControlId(target, param));
   midiMapStore.setLearnMode(true);
 }

--- a/src/hooks/useSongStorage.ts
+++ b/src/hooks/useSongStorage.ts
@@ -18,6 +18,7 @@ import { automationStore, convertHyphonLanes } from '../stores/automationStore';
 import { midiMapStore } from '../stores/midiMapStore';
 import { e2eTransportSnapshot, isE2eMode, setE2eLaneCount } from '../e2e/probe';
 import { RbsExporter, hyphonSongFromSavedData } from '../importers/rbs';
+import { migrateSavedSongSession } from '../session/migrate';
 import { getWamHost } from '../audio/wam';
 
 // ---- Types for the hook parameters ----
@@ -39,6 +40,8 @@ export interface SongStorageDeps {
     trackStorageRef: MutableRefObject<Record<TrackKey, (PartSequence | PartSequence[] | null)[]>>;
     activeTrackSlotsRef: MutableRefObject<Record<TrackKey, number>>;
     songStructureRef: MutableRefObject<({ [key in TrackKey]: number | null })[]>;
+    sessionDocumentRef?: MutableRefObject<import('../session/types').SessionDocument>;
+    setSessionDocument?: (doc: import('../session/types').SessionDocument, recordUndo?: boolean) => void;
 
     // State values (needed as deps for serialization)
     ambianceUrl: string;
@@ -131,6 +134,7 @@ export function useSongStorage(deps: SongStorageDeps): SongStorageReturn {
         patternRef, tempoRef,
         synthARef, synthBRef, bass2Ref, kickRef, snareRef, closedHatRef, openHatRef, samplerRef,
         trackStorageRef, activeTrackSlotsRef, songStructureRef,
+        sessionDocumentRef, setSessionDocument,
         ambianceUrl, backgroundImage, sampleBuffers, ttsPhrases,
         songStorage, pattern, tempo, trackStorage,
         setPattern, setTempo, setAmbianceUrl, setBackgroundImage,
@@ -182,6 +186,7 @@ export function useSongStorage(deps: SongStorageDeps): SongStorageReturn {
             trackStorage: trackStorageRef.current,
             activeTrackSlots: activeTrackSlotsRef.current,
             songStructure: songStructureRef.current,
+            session: sessionDocumentRef?.current,
             embeddedSamples: encodedSamples,
             ttsPhrases,
             ...(exportedLanes.length > 0 ? { automationLanes: exportedLanes } : {}),
@@ -253,6 +258,13 @@ export function useSongStorage(deps: SongStorageDeps): SongStorageReturn {
             if (songData.songStructure) {
                 clearSongUndo?.();
                 setSongStructure(songData.songStructure as unknown as ({ [key in TrackKey]: number | null })[]);
+            }
+            if (setSessionDocument) {
+                const migrated = migrateTrackStorage(songData.trackStorage ?? {});
+                setSessionDocument(
+                    migrateSavedSongSession(songData.version, songData.session, migrated),
+                    false,
+                );
             }
             if (songData.ttsPhrases && Array.isArray(songData.ttsPhrases) && songData.ttsPhrases.length === 8) {
                 setTtsPhrases(songData.ttsPhrases);

--- a/src/hooks/useStepHandler.ts
+++ b/src/hooks/useStepHandler.ts
@@ -14,6 +14,7 @@ import type { TrackKey } from '../constants/appDefaults';
 import { noteToMidi, midiToNote, tunedNoteToFrequency } from '../utils/musicTheory';
 import type { ScaleDefinition } from '../utils/musicTheory';
 import { EMPTY_SEQ, EMPTY_SAMPLER_SEQUENCE } from '../constants/appDefaults';
+import { TRACK_KEYS } from '../constants';
 import type { SynthNoteParams } from './audioEngine/audioPlayback';
 import { automationStore } from '../stores/automationStore';
 import type { AutomationTarget, UnifiedAutomationLane } from '../types';
@@ -37,7 +38,7 @@ const getAutomationValue = (target: AutomationTarget, param: string, step: numbe
 
 
 
-import { isE2eMode, setE2eTransportStep } from '../e2e/probe';
+import { isE2eMode, setE2eTransportStep, setE2eSessionState } from '../e2e/probe';
 import { AutomationScheduler } from '../audio/automation/AutomationScheduler';
 import { TICKS_PER_BAR } from '../importers/rbs/types';
 import {
@@ -142,6 +143,10 @@ export interface UseStepHandlerOptions {
     automationSchedulerRef?: React.MutableRefObject<AutomationScheduler | null>;
     /** Resolved TRAK events from an imported RBS song for sub-step automation scheduling. */
     trakEventsRef?: React.MutableRefObject<ResolvedTrakEvent[] | null>;
+    sessionEngineRef?: React.MutableRefObject<import('../session/SessionLaunchEngine').SessionLaunchEngine | null>;
+    sessionClockRef?: React.MutableRefObject<{ step: number; audioTime: number; tempo: number }>;
+    setIsSongModeActive?: (active: boolean) => void;
+    onSessionTick?: (playing: Record<TrackKey, number | null>) => void;
 }
 
 export const useStepHandler = ({
@@ -174,6 +179,10 @@ export const useStepHandler = ({
     setCurrentSongMeasure,
     automationSchedulerRef,
     trakEventsRef,
+    sessionEngineRef,
+    sessionClockRef,
+    setIsSongModeActive,
+    onSessionTick,
 }: UseStepHandlerOptions) => {
     const lastHandledStepRef = useRef({ step: -1, audioTime: 0 });
     const lastTrakBarRef = useRef(-1);
@@ -202,8 +211,56 @@ export const useStepHandler = ({
 
         let activePattern = patternRef.current;
 
-        // Song Mode Measure Handling
-        if (isSongModeActiveRef.current) {
+        if (sessionClockRef) {
+            sessionClockRef.current = { step, audioTime: time, tempo };
+        }
+        const sessionEngine = sessionEngineRef?.current;
+        if (sessionEngine) {
+            const tick = sessionEngine.tick({
+                step,
+                audioTime: time,
+                tempo,
+                patternSteps: 32,
+                stepsPerBeat: 4,
+                stepsPerBar: 16,
+                isPlaying: true,
+                songModeActive: isSongModeActiveRef.current,
+            });
+            if (tick.preemptSongMode) setIsSongModeActive?.(false);
+            for (const track of tick.flushTracks) {
+                audioEngine.stopTrackNotes?.(track);
+                lastFreqRef.current[track] = 0;
+            }
+            onSessionTick?.(sessionEngine.playingSlots());
+            if (isE2eMode()) {
+                setE2eSessionState({
+                    playingCount: TRACK_KEYS.filter((t) => sessionEngine.playingSlot(t) != null).length,
+                    lastApplyStep: tick.applied[0]?.step ?? (typeof window !== 'undefined' ? window.__HYPHON_E2E_SESSION__?.lastApplyStep ?? -1 : -1),
+                    captureCount: sessionEngine.captureEvents.length,
+                });
+            }
+        }
+
+        // Session clip playback overlays the live pattern (stopped tracks are silent).
+        if (sessionEngine?.hasPlaying()) {
+            const slots = sessionEngine.playingSlots();
+            const getSessionSeq = (key: TrackKey) => {
+                const slot = slots[key];
+                if (slot === null) return key === 'sampler' ? EMPTY_SAMPLER_SEQUENCE : EMPTY_SEQ;
+                const stored = trackStorageRef.current[key][slot];
+                return stored ?? (key === 'sampler' ? EMPTY_SAMPLER_SEQUENCE : EMPTY_SEQ);
+            };
+            activePattern = {
+                partA: getSessionSeq('partA'),
+                partB: getSessionSeq('partB'),
+                bass2: getSessionSeq('bass2'),
+                kick: getSessionSeq('kick'),
+                snare: getSessionSeq('snare'),
+                closedHat: getSessionSeq('closedHat'),
+                openHat: getSessionSeq('openHat'),
+                sampler: getSessionSeq('sampler'),
+            } as Pattern;
+        } else if (isSongModeActiveRef.current) {
             if (step === 0) {
                 if (isFirstStepRef.current) {
                     isFirstStepRef.current = false;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -38,6 +38,8 @@ if (typeof location !== 'undefined' && new URLSearchParams(location.search).has(
     getRbsAutomationLaneCount: () =>
       automationStore.getState().lanes.filter((l) => l.source === 'rbs').length,
     getAutomationPlaybackStep: () => e2eTransportSnapshot().step,
+    getSessionPlayingCount: () => window.__HYPHON_E2E_SESSION__?.playingCount ?? 0,
+    getSessionLastApplyStep: () => window.__HYPHON_E2E_SESSION__?.lastApplyStep ?? -1,
     setLiveAutomatedValue: (target: string, param: string, value: number) => {
       automationStore.setLiveValues({ [`${target}:${param}`]: value });
     },

--- a/src/session/SessionLaunchEngine.ts
+++ b/src/session/SessionLaunchEngine.ts
@@ -1,0 +1,397 @@
+import { TRACK_KEYS } from '@/constants';
+import type { TrackKey } from '@/constants/appDefaults';
+import { NUM_STEPS } from '@/constants';
+import {
+  resolveTrackConflicts,
+  shouldPreemptSession,
+  shouldPreemptSongMode,
+} from './conflict';
+import { emptyPlayingMap } from './defaults';
+import { resolveFollowClip } from './followActions';
+import { nextFollowBoundary, quantizeLaunch } from './quantize';
+import type {
+  ClipId,
+  CompiledLaunchEvent,
+  LaunchIntent,
+  LaunchQuantization,
+  PlayingClipState,
+  SessionCaptureEvent,
+  SessionDocument,
+  SessionTickResult,
+  TransportClockSnapshot,
+} from './types';
+
+function playingRecord(): Record<TrackKey, PlayingClipState | null> {
+  const map = {} as Record<TrackKey, PlayingClipState | null>;
+  for (const t of TRACK_KEYS) map[t] = null;
+  return map;
+}
+
+export class SessionLaunchEngine {
+  document: SessionDocument;
+  quantization: LaunchQuantization;
+  playing: Record<TrackKey, PlayingClipState | null> = playingRecord();
+  queued: CompiledLaunchEvent[] = [];
+  timelineStep = 0;
+  private lastClockStep = -1;
+  private seq = 0;
+  capturing = false;
+  captureEvents: SessionCaptureEvent[] = [];
+  private rng: () => number;
+  private songModeLatched = false;
+
+  constructor(document: SessionDocument, rng: () => number = Math.random) {
+    this.document = document;
+    this.quantization = document.quantization;
+    this.rng = rng;
+  }
+
+  setDocument(document: SessionDocument): void {
+    this.document = document;
+    this.quantization = document.quantization;
+  }
+
+  setQuantization(q: LaunchQuantization): void {
+    this.quantization = q;
+    this.document = { ...this.document, quantization: q };
+  }
+
+  nextSeq(): number {
+    this.seq += 1;
+    return this.seq;
+  }
+
+  resetTransport(): void {
+    this.queued = [];
+    this.playing = playingRecord();
+    this.timelineStep = 0;
+    this.lastClockStep = -1;
+    this.songModeLatched = false;
+  }
+
+  armCapture(): void {
+    this.capturing = true;
+    this.captureEvents = [];
+  }
+
+  disarmCapture(): SessionCaptureEvent[] {
+    this.capturing = false;
+    return this.captureEvents.slice();
+  }
+
+  /**
+   * Compile a user/MIDI/scene intent into queued timeline events.
+   * Does not depend on React; call from click/MIDI handlers with the latest clock.
+   */
+  enqueue(intent: Omit<LaunchIntent, 'requestSeq'> & { requestSeq?: number }, clock: TransportClockSnapshot): CompiledLaunchEvent[] {
+    const requestSeq = intent.requestSeq ?? this.nextSeq();
+    const full: LaunchIntent = { ...intent, requestSeq };
+    const events = this.compileIntent(full, clock);
+    this.queued.push(...events);
+    this.queued.sort((a, b) => a.timelineStep - b.timelineStep || a.requestSeq - b.requestSeq);
+    return events;
+  }
+
+  compileIntent(intent: LaunchIntent, clock: TransportClockSnapshot): CompiledLaunchEvent[] {
+    const q = quantizeLaunch(
+      this.quantization,
+      clock,
+      intent.requestStep,
+      intent.requestAudioTime,
+      this.timelineStep,
+    );
+
+    if (intent.kind === 'stop-all') {
+      return TRACK_KEYS.map((track) => this.makeEvent(intent, clock, q, track, 'stop', null));
+    }
+
+    if (intent.kind === 'stop-track' && intent.track) {
+      return [this.makeEvent(intent, clock, q, intent.track, 'stop', null)];
+    }
+
+    if (intent.kind === 'scene' && intent.sceneId) {
+      const scene = this.document.scenes.find((s) => s.id === intent.sceneId);
+      if (!scene) return [];
+      const out: CompiledLaunchEvent[] = [];
+      for (const track of TRACK_KEYS) {
+        const clipId = scene.clipIds[track];
+        if (clipId === undefined) continue;
+        if (clipId === null) {
+          out.push(this.makeEvent(intent, clock, q, track, 'stop', null, scene.id));
+          continue;
+        }
+        const clip = this.document.columns[track]?.clips.find((c) => c.id === clipId);
+        if (!clip || clip.empty) continue;
+        const playing = this.playing[track];
+        const action = playing ? 'replace' : 'start';
+        out.push(this.makeEvent(intent, clock, q, track, action, clip.id, scene.id));
+      }
+      return out;
+    }
+
+    if (intent.kind === 'clip' && intent.track && intent.clipId) {
+      const track = intent.track;
+      const clip = this.document.columns[track]?.clips.find((c) => c.id === intent.clipId);
+      if (!clip || clip.empty) return [];
+
+      const playing = this.playing[track];
+
+      if (clip.launchMode === 'gate' && intent.gateDown === false) {
+        if (playing?.clipId === clip.id) {
+          return [this.makeEvent(intent, clock, q, track, 'stop', null)];
+        }
+        return [];
+      }
+
+      if (clip.launchMode === 'toggle' && playing?.clipId === clip.id) {
+        return [this.makeEvent(intent, clock, q, track, 'stop', null)];
+      }
+
+      const action = playing ? 'replace' : 'start';
+      return [this.makeEvent(intent, clock, q, track, action, clip.id)];
+    }
+
+    return [];
+  }
+
+  /**
+   * Consume the audio-clock step. Returns applied events for this exact boundary.
+   */
+  tick(clock: TransportClockSnapshot): SessionTickResult {
+    if (this.lastClockStep < 0) {
+      this.timelineStep = 0;
+    } else if (clock.step !== this.lastClockStep) {
+      const pattern = Math.max(1, clock.patternSteps);
+      const delta = (clock.step - this.lastClockStep + pattern) % pattern;
+      this.timelineStep += delta === 0 ? 1 : delta;
+    }
+    this.lastClockStep = clock.step;
+
+    if (clock.songModeActive && !this.songModeLatched && !this.hasLiveQueued()) {
+      this.songModeLatched = true;
+      const songModeStops = this.stopPlayingAsSongMode(clock);
+      if (songModeStops.length > 0) {
+        return this.applyEvents(songModeStops, clock, false, true);
+      }
+    }
+    if (!clock.songModeActive) this.songModeLatched = false;
+
+    const due = this.queued.filter((e) => e.timelineStep <= this.timelineStep);
+    this.queued = this.queued.filter((e) => e.timelineStep > this.timelineStep);
+
+    const follow = clock.songModeActive ? [] : this.collectFollowEvents(clock);
+    const merged = resolveTrackConflicts([...due, ...follow]);
+
+    const preemptSongMode = merged.some((e) => shouldPreemptSongMode(e.source, clock.songModeActive));
+    const preemptSession = merged.some((e) => shouldPreemptSession(e.source));
+
+    return this.applyEvents(merged, clock, preemptSongMode, preemptSession);
+  }
+
+  playingSlot(track: TrackKey): number | null {
+    return this.playing[track]?.slotIndex ?? null;
+  }
+
+  playingSlots(): Record<TrackKey, number | null> {
+    const out = emptyPlayingMap() as Record<TrackKey, number | null>;
+    for (const track of TRACK_KEYS) {
+      out[track] = this.playingSlot(track);
+    }
+    return out;
+  }
+
+  hasPlaying(): boolean {
+    return TRACK_KEYS.some((t) => this.playing[t] != null);
+  }
+
+  private hasLiveQueued(): boolean {
+    return this.queued.some(
+      (e) => e.source === 'manual' || e.source === 'midi' || e.source === 'gamepad' || e.source === 'scene',
+    );
+  }
+
+  private collectFollowEvents(clock: TransportClockSnapshot): CompiledLaunchEvent[] {
+    const out: CompiledLaunchEvent[] = [];
+    for (const track of TRACK_KEYS) {
+      const playing = this.playing[track];
+      if (!playing) continue;
+      const clip = this.document.columns[track]?.clips.find((c) => c.id === playing.clipId);
+      if (!clip) continue;
+      const length = clock.patternSteps || NUM_STEPS;
+      const boundary = nextFollowBoundary(clock, playing.startedTimelineStep, length, this.timelineStep);
+      if (!boundary) continue;
+
+      if (clip.launchMode === 'one-shot') {
+        out.push(this.followEvent(clock, boundary, track, 'stop', null));
+        continue;
+      }
+
+      if (clip.followAction === 'repeat') {
+        playing.loopsCompleted += 1;
+        if (playing.followRepeatRemaining > 1) {
+          playing.followRepeatRemaining -= 1;
+          continue;
+        }
+        out.push(this.followEvent(clock, boundary, track, 'stop', null));
+        continue;
+      }
+
+      const next = resolveFollowClip(this.document, track, clip, this.rng);
+      if (next === 'stop') {
+        out.push(this.followEvent(clock, boundary, track, 'stop', null));
+      } else if (next) {
+        out.push(this.followEvent(clock, boundary, track, 'replace', next.id));
+      }
+    }
+    return out;
+  }
+
+  private applyEvents(
+    events: CompiledLaunchEvent[],
+    clock: TransportClockSnapshot,
+    preemptSongMode: boolean,
+    preemptSession: boolean,
+  ): SessionTickResult {
+    const flushTracks: TrackKey[] = [];
+    const applied: CompiledLaunchEvent[] = [];
+
+    if (preemptSession) {
+      for (const track of TRACK_KEYS) {
+        if (this.playing[track]) {
+          flushTracks.push(track);
+          this.playing[track] = null;
+        }
+      }
+      this.queued = [];
+    }
+
+    for (const ev of events) {
+      const prev = this.playing[ev.track];
+      if (ev.action === 'stop') {
+        if (prev) flushTracks.push(ev.track);
+        this.playing[ev.track] = null;
+        applied.push(ev);
+        if (this.capturing) {
+          this.captureEvents.push({
+            audioTime: ev.audioTime,
+            step: ev.step,
+            timelineStep: ev.timelineStep,
+            track: ev.track,
+            action: ev.action,
+            clipId: ev.clipId,
+            slotIndex: ev.slotIndex,
+            sceneId: ev.sceneId,
+          });
+        }
+      } else if (ev.clipId) {
+        const clip = this.document.columns[ev.track]?.clips.find((c) => c.id === ev.clipId);
+        if (!clip || clip.empty) continue;
+        if (prev && prev.clipId !== clip.id) flushTracks.push(ev.track);
+        this.playing[ev.track] = {
+          clipId: clip.id,
+          slotIndex: clip.slotIndex,
+          launchMode: clip.launchMode,
+          loopsCompleted: 0,
+          followRepeatRemaining: clip.followRepeatN,
+          startedTimelineStep: this.timelineStep,
+        };
+        applied.push(ev);
+        if (this.capturing) {
+          this.captureEvents.push({
+            audioTime: ev.audioTime,
+            step: ev.step,
+            timelineStep: ev.timelineStep,
+            track: ev.track,
+            action: ev.action,
+            clipId: ev.clipId,
+            slotIndex: ev.slotIndex,
+            sceneId: ev.sceneId,
+          });
+        }
+      }
+    }
+
+    if (preemptSongMode) this.songModeLatched = false;
+
+    return {
+      applied,
+      flushTracks: [...new Set(flushTracks)],
+      playing: { ...this.playing },
+      queued: this.queued.slice(),
+      preemptSongMode,
+      preemptSession,
+    };
+  }
+
+  private stopPlayingAsSongMode(clock: TransportClockSnapshot): CompiledLaunchEvent[] {
+    if (!this.hasPlaying()) return [];
+    const q = quantizeLaunch('immediate', clock, clock.step, clock.audioTime, this.timelineStep);
+    return TRACK_KEYS.filter((t) => this.playing[t]).map((track) =>
+      this.makeEvent(
+        {
+          kind: 'stop-all',
+          source: 'song-mode',
+          requestSeq: this.nextSeq(),
+          requestAudioTime: clock.audioTime,
+          requestStep: clock.step,
+        },
+        clock,
+        q,
+        track,
+        'stop',
+        null,
+      ),
+    );
+  }
+
+  private makeEvent(
+    intent: LaunchIntent,
+    _clock: TransportClockSnapshot,
+    q: { step: number; audioTime: number; timelineStep: number },
+    track: TrackKey,
+    action: CompiledLaunchEvent['action'],
+    clipId: ClipId | null,
+    sceneId?: string,
+  ): CompiledLaunchEvent {
+    const clip = clipId
+      ? this.document.columns[track]?.clips.find((c) => c.id === clipId)
+      : undefined;
+    return {
+      audioTime: q.audioTime,
+      step: q.step,
+      timelineStep: q.timelineStep,
+      track,
+      action,
+      clipId,
+      slotIndex: clip?.slotIndex ?? null,
+      sceneId,
+      source: intent.source,
+      requestSeq: intent.requestSeq,
+    };
+  }
+
+  private followEvent(
+    clock: TransportClockSnapshot,
+    q: { step: number; audioTime: number; timelineStep: number },
+    track: TrackKey,
+    action: CompiledLaunchEvent['action'],
+    clipId: ClipId | null,
+  ): CompiledLaunchEvent {
+    return this.makeEvent(
+      {
+        kind: clipId ? 'clip' : 'stop-track',
+        source: 'follow',
+        requestSeq: this.nextSeq(),
+        requestAudioTime: clock.audioTime,
+        requestStep: clock.step,
+        track,
+        clipId: clipId ?? undefined,
+      },
+      clock,
+      q,
+      track,
+      action,
+      clipId,
+    );
+  }
+}

--- a/src/session/__tests__/sessionLauncher.test.ts
+++ b/src/session/__tests__/sessionLauncher.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from 'vitest';
+import fc from 'fast-check';
+import { TRACK_KEYS, NUM_STEPS } from '../../constants';
+import { createEmptyTrackStorage } from '../../utils/trackStorageUtils';
+import { SessionLaunchEngine } from '../SessionLaunchEngine';
+import { createDefaultSessionDocument } from '../defaults';
+import { migrateSavedSongSession, sessionFromTrackStorage } from '../migrate';
+import { quantizeLaunch, secondsPerStep } from '../quantize';
+import { resolveTrackConflicts } from '../conflict';
+import { captureEventsToSongStructure } from '../capture';
+import { resolveFollowClip } from '../followActions';
+import { moveSessionFocus } from '../gridKeyboard';
+import { parseSessionMidiParam, sessionClipControlId } from '../midiMap';
+import type { CompiledLaunchEvent, TransportClockSnapshot } from '../types';
+
+function clock(partial?: Partial<TransportClockSnapshot>): TransportClockSnapshot {
+  return {
+    step: 0,
+    audioTime: 1.0,
+    tempo: 120,
+    patternSteps: NUM_STEPS,
+    stepsPerBeat: 4,
+    stepsPerBar: 16,
+    isPlaying: true,
+    songModeActive: false,
+    ...partial,
+  };
+}
+
+function fillClip(engine: SessionLaunchEngine, track: 'kick' = 'kick', row = 0) {
+  engine.document.columns[track].clips[row].empty = false;
+}
+
+describe('quantizeLaunch', () => {
+  it('fires on the current bar when the request arrives on a bar boundary', () => {
+    const c = clock({ step: 0, audioTime: 2 });
+    const q = quantizeLaunch('bar', c, 0, 2, 0);
+    expect(q.deltaSteps).toBe(0);
+    expect(q.audioTime).toBe(2);
+  });
+
+  it('waits until the next bar when not on the grid', () => {
+    const c = clock({ step: 4, audioTime: 2 });
+    const q = quantizeLaunch('bar', c, 4, 2, 4);
+    expect(q.deltaSteps).toBe(12);
+    expect(q.step).toBe(16);
+    expect(q.audioTime).toBeCloseTo(2 + 12 * secondsPerStep(120));
+  });
+
+  it('is deterministic for the same clock even if requestAudioTime jitters within the step', () => {
+    const c = clock({ step: 8, audioTime: 5, tempo: 140 });
+    const a = quantizeLaunch('beat', c, 8, 5.001, 8);
+    const b = quantizeLaunch('beat', c, 8, 5.01, 8);
+    expect(a.step).toBe(b.step);
+    expect(a.timelineStep).toBe(b.timelineStep);
+  });
+});
+
+describe('SessionLaunchEngine', () => {
+  it('launches a clip at the quantized bar and leaves other tracks independent', () => {
+    const doc = createDefaultSessionDocument();
+    doc.columns.kick.clips[0].empty = false;
+    doc.columns.snare.clips[0].empty = false;
+    const engine = new SessionLaunchEngine(doc);
+    engine.enqueue(
+      { kind: 'clip', source: 'manual', requestAudioTime: 1, requestStep: 0, track: 'kick', clipId: doc.columns.kick.clips[0].id },
+      clock(),
+    );
+    const tick = engine.tick(clock());
+    expect(tick.applied).toHaveLength(1);
+    expect(tick.applied[0].track).toBe('kick');
+    expect(engine.playingSlot('kick')).toBe(0);
+    expect(engine.playingSlot('snare')).toBeNull();
+  });
+
+  it('applies a scene atomically on one boundary', () => {
+    const doc = createDefaultSessionDocument();
+    for (const t of TRACK_KEYS) {
+      doc.columns[t].clips[0].empty = false;
+      doc.scenes[0].clipIds[t] = doc.columns[t].clips[0].id;
+    }
+    const engine = new SessionLaunchEngine(doc);
+    engine.enqueue(
+      { kind: 'scene', source: 'scene', requestAudioTime: 1, requestStep: 0, sceneId: doc.scenes[0].id },
+      clock(),
+    );
+    const tick = engine.tick(clock());
+    expect(new Set(tick.applied.map((e) => e.step)).size).toBe(1);
+    expect(tick.applied).toHaveLength(TRACK_KEYS.length);
+    for (const t of TRACK_KEYS) {
+      expect(engine.playingSlot(t)).toBe(0);
+    }
+  });
+
+  it('lets a later manual clip override a scene on the same track', () => {
+    const doc = createDefaultSessionDocument();
+    doc.columns.kick.clips[0].empty = false;
+    doc.columns.kick.clips[1].empty = false;
+    doc.scenes[0].clipIds.kick = doc.columns.kick.clips[0].id;
+    const engine = new SessionLaunchEngine(doc);
+    const c = clock();
+    engine.enqueue(
+      { kind: 'scene', source: 'scene', requestSeq: 1, requestAudioTime: 1, requestStep: 0, sceneId: doc.scenes[0].id },
+      c,
+    );
+    engine.enqueue(
+      { kind: 'clip', source: 'manual', requestSeq: 2, requestAudioTime: 1, requestStep: 0, track: 'kick', clipId: doc.columns.kick.clips[1].id },
+      c,
+    );
+    engine.tick(c);
+    expect(engine.playingSlot('kick')).toBe(1);
+  });
+
+  it('toggles a playing clip off', () => {
+    const doc = createDefaultSessionDocument();
+    doc.columns.kick.clips[0].empty = false;
+    doc.columns.kick.clips[0].launchMode = 'toggle';
+    const engine = new SessionLaunchEngine(doc);
+    const id = doc.columns.kick.clips[0].id;
+    engine.enqueue({ kind: 'clip', source: 'manual', requestAudioTime: 1, requestStep: 0, track: 'kick', clipId: id }, clock());
+    engine.tick(clock());
+    expect(engine.playingSlot('kick')).toBe(0);
+    engine.enqueue({ kind: 'clip', source: 'manual', requestAudioTime: 1, requestStep: 0, track: 'kick', clipId: id }, clock());
+    engine.tick(clock({ step: 0, audioTime: 1 }));
+    expect(engine.playingSlot('kick')).toBeNull();
+  });
+
+  it('releases a gate clip on gateDown=false', () => {
+    const doc = createDefaultSessionDocument();
+    doc.columns.kick.clips[0].empty = false;
+    doc.columns.kick.clips[0].launchMode = 'gate';
+    const engine = new SessionLaunchEngine(doc);
+    const id = doc.columns.kick.clips[0].id;
+    engine.enqueue({ kind: 'clip', source: 'midi', requestAudioTime: 1, requestStep: 0, track: 'kick', clipId: id, gateDown: true }, clock());
+    engine.tick(clock());
+    expect(engine.playingSlot('kick')).toBe(0);
+    engine.enqueue({ kind: 'clip', source: 'midi', requestAudioTime: 1, requestStep: 0, track: 'kick', clipId: id, gateDown: false }, clock());
+    engine.tick(clock());
+    expect(engine.playingSlot('kick')).toBeNull();
+  });
+
+  it('one-shot stops after one loop', () => {
+    const doc = createDefaultSessionDocument();
+    doc.columns.kick.clips[0].empty = false;
+    doc.columns.kick.clips[0].launchMode = 'one-shot';
+    const engine = new SessionLaunchEngine(doc);
+    engine.enqueue(
+      { kind: 'clip', source: 'manual', requestAudioTime: 1, requestStep: 0, track: 'kick', clipId: doc.columns.kick.clips[0].id },
+      clock(),
+    );
+    engine.tick(clock({ step: 0, audioTime: 1 }));
+    expect(engine.playingSlot('kick')).toBe(0);
+    // Advance a full pattern (32 steps) so follow boundary fires.
+    let audio = 1;
+    let step = 0;
+    for (let i = 0; i < NUM_STEPS; i++) {
+      step = (step + 1) % NUM_STEPS;
+      audio += secondsPerStep(120);
+      engine.tick(clock({ step, audioTime: audio }));
+    }
+    expect(engine.playingSlot('kick')).toBeNull();
+  });
+
+  it('preempts song mode on a live scene launch', () => {
+    const doc = createDefaultSessionDocument();
+    fillClip(new SessionLaunchEngine(doc));
+    doc.columns.kick.clips[0].empty = false;
+    const engine = new SessionLaunchEngine(doc);
+    engine.enqueue(
+      { kind: 'clip', source: 'manual', requestAudioTime: 1, requestStep: 0, track: 'kick', clipId: doc.columns.kick.clips[0].id },
+      clock({ songModeActive: true }),
+    );
+    const tick = engine.tick(clock({ songModeActive: true }));
+    expect(tick.preemptSongMode).toBe(true);
+    expect(engine.playingSlot('kick')).toBe(0);
+  });
+
+  it('stops session clips when song mode latches', () => {
+    const doc = createDefaultSessionDocument();
+    doc.columns.kick.clips[0].empty = false;
+    const engine = new SessionLaunchEngine(doc);
+    engine.enqueue(
+      { kind: 'clip', source: 'manual', requestAudioTime: 1, requestStep: 0, track: 'kick', clipId: doc.columns.kick.clips[0].id },
+      clock(),
+    );
+    engine.tick(clock());
+    expect(engine.playingSlot('kick')).toBe(0);
+    const tick = engine.tick(clock({ step: 1, audioTime: 1.125, songModeActive: true }));
+    expect(tick.preemptSession).toBe(true);
+    expect(engine.playingSlot('kick')).toBeNull();
+  });
+
+  it('captures launches and compiles equivalent song-structure order', () => {
+    const doc = createDefaultSessionDocument();
+    doc.columns.kick.clips[0].empty = false;
+    doc.columns.snare.clips[1].empty = false;
+    const engine = new SessionLaunchEngine(doc);
+    engine.armCapture();
+    engine.enqueue(
+      { kind: 'clip', source: 'manual', requestAudioTime: 1, requestStep: 0, track: 'kick', clipId: doc.columns.kick.clips[0].id },
+      clock(),
+    );
+    engine.tick(clock());
+    engine.enqueue(
+      { kind: 'clip', source: 'manual', requestAudioTime: 1, requestStep: 0, track: 'snare', clipId: doc.columns.snare.clips[1].id },
+      clock({ step: 16, audioTime: 1 + 16 * secondsPerStep(120) }),
+    );
+    // Need timeline to advance to bar 2 — simulate 16 steps first
+    let audio = 1;
+    for (let s = 1; s <= 16; s++) {
+      audio += secondsPerStep(120);
+      engine.tick(clock({ step: s % NUM_STEPS, audioTime: audio }));
+    }
+    const captured = engine.disarmCapture();
+    expect(captured.length).toBeGreaterThanOrEqual(1);
+    const structure = captureEventsToSongStructure(captured);
+    expect(structure[0].kick).toBe(0);
+  });
+
+  it('stress: rapid scene changes never leave two clips playing on one track', () => {
+    const doc = createDefaultSessionDocument();
+    for (const t of TRACK_KEYS) {
+      doc.columns[t].clips[0].empty = false;
+      doc.columns[t].clips[1].empty = false;
+      doc.scenes[0].clipIds[t] = doc.columns[t].clips[0].id;
+      doc.scenes[1].clipIds[t] = doc.columns[t].clips[1].id;
+    }
+    const engine = new SessionLaunchEngine(doc);
+    const c = clock();
+    for (let i = 0; i < 64; i++) {
+      engine.enqueue(
+        { kind: 'scene', source: 'scene', requestAudioTime: 1, requestStep: 0, sceneId: doc.scenes[i % 2].id },
+        c,
+      );
+    }
+    engine.tick(c);
+    for (const t of TRACK_KEYS) {
+      const slot = engine.playingSlot(t);
+      expect(slot === 0 || slot === 1).toBe(true);
+    }
+  });
+});
+
+describe('migrateSavedSongSession', () => {
+  it('builds a default session from v2 songs without a session field', () => {
+    const storage = createEmptyTrackStorage();
+    storage.kick[0] = { steps: Array(NUM_STEPS).fill({ note: 'C2', velocity: 1 }) };
+    const doc = migrateSavedSongSession(2, undefined, storage);
+    expect(doc.schemaVersion).toBe(1);
+    expect(doc.columns.kick.clips[0].empty).toBe(false);
+    expect(doc.columns.snare.clips[0].empty).toBe(true);
+  });
+
+  it('preserves clip ids when round-tripping JSON', () => {
+    const original = sessionFromTrackStorage(createEmptyTrackStorage());
+    original.columns.partA.clips[0].name = 'Lead A';
+    original.columns.partA.clips[0].empty = false;
+    const parsed = migrateSavedSongSession(3, JSON.parse(JSON.stringify(original)));
+    expect(parsed.columns.partA.clips[0].id).toBe(original.columns.partA.clips[0].id);
+    expect(parsed.columns.partA.clips[0].name).toBe('Lead A');
+  });
+});
+
+describe('followActions', () => {
+  it('picks next non-empty clip', () => {
+    const doc = createDefaultSessionDocument();
+    doc.columns.kick.clips[0].empty = false;
+    doc.columns.kick.clips[2].empty = false;
+    const next = resolveFollowClip(doc, 'kick', { ...doc.columns.kick.clips[0], followAction: 'next' });
+    expect(next === 'stop' ? null : next?.id).toBe(doc.columns.kick.clips[2].id);
+  });
+});
+
+describe('gridKeyboard', () => {
+  it('moves from scene column into the first track', () => {
+    const next = moveSessionFocus({ kind: 'scene', row: 2 }, 'ArrowRight', 8);
+    expect(next).toEqual({ kind: 'clip', track: 'partA', row: 2 });
+  });
+});
+
+describe('session midi ids', () => {
+  it('parses clip / scene / stop controls', () => {
+    expect(parseSessionMidiParam('clip:kick:3', 1)).toEqual({ type: 'clip', track: 'kick', row: 3, down: true });
+    expect(parseSessionMidiParam('scene:1', 0)).toEqual({ type: 'scene', sceneIndex: 1, down: false });
+    expect(parseSessionMidiParam('stop:partA', 1)).toEqual({ type: 'stop-track', track: 'partA' });
+    expect(sessionClipControlId('kick', 0)).toBe('session:clip:kick:0');
+  });
+});
+
+describe('quantizeLaunch properties', () => {
+  it('never schedules in the past relative to the origin audioTime', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 31 }),
+        fc.integer({ min: 60, max: 180 }),
+        fc.constantFrom('step', 'beat', 'bar', '2bars', '4bars') as fc.Arbitrary<
+          'step' | 'beat' | 'bar' | '2bars' | '4bars'
+        >,
+        (step, tempo, quant) => {
+          const c = clock({ step, tempo, audioTime: 10 });
+          const q = quantizeLaunch(quant, c, step, 10, step);
+          expect(q.audioTime).toBeGreaterThanOrEqual(10 - 1e-9);
+          expect(q.deltaSteps).toBeGreaterThanOrEqual(0);
+        },
+      ),
+    );
+  });
+});
+
+describe('resolveTrackConflicts', () => {
+  it('keeps a single winner per track', () => {
+    const mk = (seq: number, source: CompiledLaunchEvent['source'], slot: number): CompiledLaunchEvent => ({
+      audioTime: 1,
+      step: 0,
+      timelineStep: 0,
+      track: 'kick',
+      action: 'start',
+      clipId: `c:kick:${slot}`,
+      slotIndex: slot,
+      source,
+      requestSeq: seq,
+    });
+    const winner = resolveTrackConflicts([mk(1, 'scene', 0), mk(2, 'manual', 1)]);
+    expect(winner).toHaveLength(1);
+    expect(winner[0].slotIndex).toBe(1);
+  });
+});

--- a/src/session/__tests__/sessionPacks.test.ts
+++ b/src/session/__tests__/sessionPacks.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { SESSION_PACKS, getSessionPack, mergePackStorage } from '../packs';
+import { createEmptyTrackStorage } from '../../utils/trackStorageUtils';
+import { TRACK_KEYS } from '../../constants';
+
+describe('session starter packs', () => {
+  it('ships the four curated live sets', () => {
+    expect(SESSION_PACKS.map((p) => p.id).sort()).toEqual([
+      'acid-live-set',
+      'dual-303-jam',
+      'minimal-drum-lab',
+      'vocal-chop-performance',
+    ].sort());
+  });
+
+  it('fills at least one clip per pack and merges without wiping empty slots', () => {
+    for (const pack of SESSION_PACKS) {
+      const filled = TRACK_KEYS.some((t) => pack.session.columns[t].clips.some((c) => !c.empty));
+      expect(filled).toBe(true);
+      const base = createEmptyTrackStorage();
+      const merged = mergePackStorage(base, pack.trackStorage);
+      expect(merged.kick.length).toBe(base.kick.length);
+    }
+    expect(getSessionPack('acid-live-set')?.name).toBe('Acid Live Set');
+  });
+});

--- a/src/session/capture.ts
+++ b/src/session/capture.ts
@@ -1,0 +1,63 @@
+import { TRACK_KEYS } from '@/constants';
+import { NUM_STEPS } from '@/constants';
+import type { TrackKey } from '@/constants/appDefaults';
+import type { SongMeasure, SongStructure } from '@/types/songMode';
+import { createEmptyMeasure } from '@/utils/songModeEditing';
+import type { SessionCaptureEvent } from './types';
+
+export const SESSION_STEPS_PER_MEASURE = 16;
+
+/**
+ * Compile a captured live-launch performance into Song Mode measures.
+ * Each measure holds the last launched slot per track (null = stopped / empty).
+ * Order and quantized step timing are preserved by expanding the timeline.
+ */
+export function captureEventsToSongStructure(
+  events: SessionCaptureEvent[],
+  options?: { stepsPerMeasure?: number; minMeasures?: number },
+): SongStructure {
+  const spm = options?.stepsPerMeasure ?? SESSION_STEPS_PER_MEASURE;
+  const minMeasures = options?.minMeasures ?? 1;
+  if (events.length === 0) {
+    return Array.from({ length: minMeasures }, () => createEmptyMeasure());
+  }
+
+  const lastTimeline = Math.max(...events.map((e) => e.timelineStep));
+  const measureCount = Math.max(minMeasures, Math.floor(lastTimeline / spm) + 1);
+
+  const slotAt = {} as Record<TrackKey, number | null>;
+  for (const t of TRACK_KEYS) slotAt[t] = null;
+
+  const byTime = [...events].sort((a, b) => a.timelineStep - b.timelineStep);
+  let ei = 0;
+  const measures: SongMeasure[] = [];
+
+  for (let m = 0; m < measureCount; m++) {
+    const start = m * spm;
+    const end = start + spm;
+    while (ei < byTime.length && byTime[ei].timelineStep < end) {
+      const ev = byTime[ei];
+      if (ev.action === 'stop') slotAt[ev.track] = null;
+      else slotAt[ev.track] = ev.slotIndex;
+      ei += 1;
+    }
+    const measure = createEmptyMeasure();
+    for (const t of TRACK_KEYS) {
+      measure[t] = slotAt[t];
+    }
+    measures.push(measure);
+  }
+
+  return measures;
+}
+
+/** Replay helper: restore capture events as launch intents at their timeline steps. */
+export function songStructureSlotAt(
+  structure: SongStructure,
+  measure: number,
+  track: TrackKey,
+): number | null {
+  return structure[measure]?.[track] ?? null;
+}
+
+export { NUM_STEPS };

--- a/src/session/conflict.ts
+++ b/src/session/conflict.ts
@@ -1,0 +1,68 @@
+import type { TrackKey } from '@/constants/appDefaults';
+import type { CompiledLaunchEvent, LaunchSource } from './types';
+
+/**
+ * Conflict rules (same quantized boundary):
+ *
+ * 1. Song Mode vs Session
+ *    - Starting Song Mode playback stops session clips (`song-mode` source).
+ *    - A live session launch (`manual` / `midi` / `gamepad` / `scene`) preempts
+ *      Song Mode: the arrangement yields at that boundary.
+ *
+ * 2. Scene vs per-track manual
+ *    - Later `requestSeq` wins.
+ *    - If seq is equal, manual/midi/gamepad clip launch beats scene.
+ *    - `stop-track` / `stop-all` beat start/replace from a scene at the same seq.
+ *
+ * 3. Per-track independence
+ *    - Events on different tracks never cancel each other (scene atomicity is
+ *      expressed by sharing audioTime/step, not by locking tracks).
+ */
+const SOURCE_RANK: Record<LaunchSource, number> = {
+  'song-mode': 0,
+  scene: 1,
+  follow: 2,
+  'capture-replay': 3,
+  manual: 4,
+  midi: 4,
+  gamepad: 4,
+};
+
+function actionRank(action: CompiledLaunchEvent['action']): number {
+  if (action === 'stop') return 2;
+  if (action === 'replace') return 1;
+  return 0;
+}
+
+export function compareLaunchPriority(a: CompiledLaunchEvent, b: CompiledLaunchEvent): number {
+  if (a.requestSeq !== b.requestSeq) return a.requestSeq - b.requestSeq;
+  const src = SOURCE_RANK[a.source] - SOURCE_RANK[b.source];
+  if (src !== 0) return src;
+  return actionRank(a.action) - actionRank(b.action);
+}
+
+/** Keep the winning event per track at a shared timelineStep. */
+export function resolveTrackConflicts(events: CompiledLaunchEvent[]): CompiledLaunchEvent[] {
+  const byTrack = new Map<TrackKey, CompiledLaunchEvent>();
+  const ordered = [...events].sort(compareLaunchPriority);
+  for (const ev of ordered) {
+    const prev = byTrack.get(ev.track);
+    if (!prev) {
+      byTrack.set(ev.track, ev);
+      continue;
+    }
+    if (compareLaunchPriority(prev, ev) <= 0) {
+      byTrack.set(ev.track, ev);
+    }
+  }
+  return [...byTrack.values()].sort((a, b) => a.track.localeCompare(b.track));
+}
+
+export function shouldPreemptSongMode(source: LaunchSource, songModeActive: boolean): boolean {
+  if (!songModeActive) return false;
+  return source === 'manual' || source === 'midi' || source === 'gamepad' || source === 'scene';
+}
+
+export function shouldPreemptSession(source: LaunchSource): boolean {
+  return source === 'song-mode';
+}

--- a/src/session/defaults.ts
+++ b/src/session/defaults.ts
@@ -1,0 +1,67 @@
+import { TRACK_KEYS } from '@/constants';
+import type { TrackKey } from '@/constants/appDefaults';
+import { clipIdForSlot, sceneIdForIndex } from './ids';
+import {
+  SESSION_DEFAULT_ROWS,
+  SESSION_DOCUMENT_VERSION,
+  type SessionClip,
+  type SessionDocument,
+  type SessionScene,
+  type SessionTrackColumn,
+} from './types';
+
+export function createEmptyClip(track: TrackKey, slotIndex: number, empty = true): SessionClip {
+  return {
+    id: clipIdForSlot(track, slotIndex),
+    name: `${slotIndex + 1}`,
+    slotIndex,
+    launchMode: 'trigger',
+    followAction: 'none',
+    followRepeatN: 1,
+    empty,
+  };
+}
+
+export function createDefaultColumn(track: TrackKey, rows = SESSION_DEFAULT_ROWS): SessionTrackColumn {
+  return {
+    track,
+    clips: Array.from({ length: rows }, (_, i) => createEmptyClip(track, i, true)),
+  };
+}
+
+export function createDefaultScenes(columns: Record<TrackKey, SessionTrackColumn>): SessionScene[] {
+  const rows = columns.partA?.clips.length ?? SESSION_DEFAULT_ROWS;
+  return Array.from({ length: rows }, (_, i) => {
+    const clipIds: SessionScene['clipIds'] = {};
+    for (const track of TRACK_KEYS) {
+      const clip = columns[track]?.clips[i];
+      clipIds[track] = clip && !clip.empty ? clip.id : clip?.id ?? null;
+    }
+    return {
+      id: sceneIdForIndex(i),
+      name: `Scene ${i + 1}`,
+      clipIds,
+    };
+  });
+}
+
+export function createDefaultSessionDocument(rows = SESSION_DEFAULT_ROWS): SessionDocument {
+  const columns = {} as Record<TrackKey, SessionTrackColumn>;
+  for (const track of TRACK_KEYS) {
+    columns[track] = createDefaultColumn(track, rows);
+  }
+  return {
+    schemaVersion: SESSION_DOCUMENT_VERSION,
+    quantization: 'bar',
+    columns,
+    scenes: createDefaultScenes(columns),
+  };
+}
+
+export function emptyPlayingMap(): Record<TrackKey, null> {
+  const map = {} as Record<TrackKey, null>;
+  for (const track of TRACK_KEYS) {
+    map[track] = null;
+  }
+  return map;
+}

--- a/src/session/followActions.ts
+++ b/src/session/followActions.ts
@@ -1,0 +1,52 @@
+import type { TrackKey } from '@/constants/appDefaults';
+import type { SessionClip, SessionDocument } from './types';
+
+export function clipById(doc: SessionDocument, track: TrackKey, clipId: string): SessionClip | null {
+  return doc.columns[track]?.clips.find((c) => c.id === clipId) ?? null;
+}
+
+export function columnClips(doc: SessionDocument, track: TrackKey): SessionClip[] {
+  return doc.columns[track]?.clips ?? [];
+}
+
+export function resolveFollowClip(
+  doc: SessionDocument,
+  track: TrackKey,
+  current: SessionClip,
+  rng: () => number = Math.random,
+): SessionClip | 'stop' | null {
+  const clips = columnClips(doc, track);
+  const idx = clips.findIndex((c) => c.id === current.id);
+  if (idx < 0) return null;
+
+  switch (current.followAction) {
+    case 'none':
+      return null;
+    case 'stop':
+      return 'stop';
+    case 'repeat':
+      return null;
+    case 'next': {
+      for (let i = 1; i <= clips.length; i++) {
+        const c = clips[(idx + i) % clips.length];
+        if (c && !c.empty && c.id !== current.id) return c;
+      }
+      return 'stop';
+    }
+    case 'previous': {
+      for (let i = 1; i <= clips.length; i++) {
+        const c = clips[(idx - i + clips.length) % clips.length];
+        if (c && !c.empty && c.id !== current.id) return c;
+      }
+      return 'stop';
+    }
+    case 'random': {
+      const candidates = clips.filter((c) => !c.empty && c.id !== current.id);
+      if (candidates.length === 0) return 'stop';
+      const pick = Math.floor(rng() * candidates.length);
+      return candidates[pick] ?? 'stop';
+    }
+    default:
+      return null;
+  }
+}

--- a/src/session/gridKeyboard.ts
+++ b/src/session/gridKeyboard.ts
@@ -1,0 +1,32 @@
+import type { TrackKey } from '@/constants/appDefaults';
+import { TRACK_KEYS } from '@/constants';
+
+export type SessionGridFocus = { kind: 'clip'; track: TrackKey; row: number } | { kind: 'scene'; row: number };
+
+export function moveSessionFocus(
+  focus: SessionGridFocus,
+  key: string,
+  rowCount: number,
+): SessionGridFocus {
+  const lastRow = Math.max(0, rowCount - 1);
+  const trackIndex = (t: TrackKey) => TRACK_KEYS.indexOf(t);
+
+  if (focus.kind === 'scene') {
+    if (key === 'ArrowDown') return { kind: 'scene', row: Math.min(lastRow, focus.row + 1) };
+    if (key === 'ArrowUp') return { kind: 'scene', row: Math.max(0, focus.row - 1) };
+    if (key === 'ArrowRight') return { kind: 'clip', track: TRACK_KEYS[0], row: focus.row };
+    return focus;
+  }
+
+  const ti = trackIndex(focus.track);
+  if (key === 'ArrowLeft') {
+    if (ti <= 0) return { kind: 'scene', row: focus.row };
+    return { kind: 'clip', track: TRACK_KEYS[ti - 1], row: focus.row };
+  }
+  if (key === 'ArrowRight' && ti < TRACK_KEYS.length - 1) {
+    return { kind: 'clip', track: TRACK_KEYS[ti + 1], row: focus.row };
+  }
+  if (key === 'ArrowDown') return { kind: 'clip', track: focus.track, row: Math.min(lastRow, focus.row + 1) };
+  if (key === 'ArrowUp') return { kind: 'clip', track: focus.track, row: Math.max(0, focus.row - 1) };
+  return focus;
+}

--- a/src/session/ids.ts
+++ b/src/session/ids.ts
@@ -1,0 +1,28 @@
+import type { TrackKey } from '@/constants/appDefaults';
+import type { ClipId, SceneId } from './types';
+
+/** Deterministic clip id used by migration / default adapters. */
+export function clipIdForSlot(track: TrackKey, slotIndex: number): ClipId {
+  return `c:${track}:${slotIndex}`;
+}
+
+export function sceneIdForIndex(index: number): SceneId {
+  return `s:${index}`;
+}
+
+let extraSeq = 0;
+
+/** Extra clips created after migration (still stable for the process + save). */
+export function allocateClipId(track: TrackKey, slotIndex: number): ClipId {
+  extraSeq += 1;
+  return `c:${track}:${slotIndex}:x${extraSeq.toString(36)}`;
+}
+
+export function parseClipId(id: ClipId): { track: TrackKey; slotIndex: number } | null {
+  const parts = id.split(':');
+  if (parts.length < 3 || parts[0] !== 'c') return null;
+  const track = parts[1] as TrackKey;
+  const slotIndex = Number(parts[2]);
+  if (!Number.isInteger(slotIndex) || slotIndex < 0) return null;
+  return { track, slotIndex };
+}

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -1,0 +1,15 @@
+export type { SessionDocument, SessionClip, SessionScene, LaunchQuantization } from './types';
+export {
+  SESSION_DOCUMENT_VERSION,
+  SAVED_SONG_DATA_VERSION_WITH_SESSION,
+  SESSION_DEFAULT_ROWS,
+  LAUNCH_QUANTIZATIONS,
+  SESSION_TRACK_LABELS,
+  SESSION_TRACKS,
+} from './types';
+export { SessionLaunchEngine } from './SessionLaunchEngine';
+export { createDefaultSessionDocument } from './defaults';
+export { migrateSavedSongSession, parseSessionDocument, sessionFromTrackStorage } from './migrate';
+export { captureEventsToSongStructure } from './capture';
+export { quantizeLaunch, secondsPerStep } from './quantize';
+export { resolveTrackConflicts } from './conflict';

--- a/src/session/midiMap.ts
+++ b/src/session/midiMap.ts
@@ -1,0 +1,50 @@
+import type { MidiControlId } from '@/types/midi';
+import type { TrackKey } from '@/constants/appDefaults';
+import { TRACK_KEYS } from '@/constants';
+
+export function sessionClipControlId(track: TrackKey, row: number): MidiControlId {
+  return `session:clip:${track}:${row}` as MidiControlId;
+}
+
+export function sessionSceneControlId(sceneIndex: number): MidiControlId {
+  return `session:scene:${sceneIndex}` as MidiControlId;
+}
+
+export function sessionStopTrackControlId(track: TrackKey): MidiControlId {
+  return `session:stop:${track}` as MidiControlId;
+}
+
+export function sessionStopAllControlId(): MidiControlId {
+  return 'session:stopAll' as MidiControlId;
+}
+
+export type SessionMidiAction =
+  | { type: 'clip'; track: TrackKey; row: number; down: boolean }
+  | { type: 'scene'; sceneIndex: number; down: boolean }
+  | { type: 'stop-track'; track: TrackKey }
+  | { type: 'stop-all' };
+
+export function parseSessionMidiParam(param: string, normalized: number): SessionMidiAction | null {
+  const down = normalized > 0;
+  if (param === 'stopAll') return { type: 'stop-all' };
+  if (param.startsWith('scene:')) {
+    const sceneIndex = Number(param.slice('scene:'.length));
+    if (!Number.isInteger(sceneIndex) || sceneIndex < 0) return null;
+    return { type: 'scene', sceneIndex, down };
+  }
+  if (param.startsWith('stop:')) {
+    const track = param.slice('stop:'.length) as TrackKey;
+    if (!TRACK_KEYS.includes(track)) return null;
+    return { type: 'stop-track', track };
+  }
+  if (param.startsWith('clip:')) {
+    const rest = param.slice('clip:'.length);
+    const colon = rest.lastIndexOf(':');
+    if (colon <= 0) return null;
+    const track = rest.slice(0, colon) as TrackKey;
+    const row = Number(rest.slice(colon + 1));
+    if (!TRACK_KEYS.includes(track) || !Number.isInteger(row) || row < 0) return null;
+    return { type: 'clip', track, row, down };
+  }
+  return null;
+}

--- a/src/session/migrate.ts
+++ b/src/session/migrate.ts
@@ -1,0 +1,170 @@
+import { TRACK_KEYS } from '@/constants';
+import type { TrackKey } from '@/constants/appDefaults';
+import type { PartSequence } from '@/types';
+import type { TrackStorageMap } from '@/utils/trackStorageUtils';
+import { createDefaultSessionDocument, createEmptyClip } from './defaults';
+import {
+  SESSION_DEFAULT_ROWS,
+  SESSION_DOCUMENT_VERSION,
+  type SessionClip,
+  type SessionDocument,
+  type SessionScene,
+  type SessionTrackColumn,
+} from './types';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function parseLaunchMode(value: unknown): SessionClip['launchMode'] {
+  if (value === 'trigger' || value === 'gate' || value === 'toggle' || value === 'one-shot') {
+    return value;
+  }
+  return 'trigger';
+}
+
+function parseFollow(value: unknown): SessionClip['followAction'] {
+  if (
+    value === 'none' ||
+    value === 'next' ||
+    value === 'previous' ||
+    value === 'random' ||
+    value === 'stop' ||
+    value === 'repeat'
+  ) {
+    return value;
+  }
+  return 'none';
+}
+
+function parseClip(raw: unknown, track: TrackKey, fallbackSlot: number): SessionClip {
+  const base = createEmptyClip(track, fallbackSlot, true);
+  if (!isRecord(raw)) return base;
+  const slotIndex = typeof raw.slotIndex === 'number' && Number.isInteger(raw.slotIndex)
+    ? Math.max(0, raw.slotIndex)
+    : fallbackSlot;
+  return {
+    id: typeof raw.id === 'string' && raw.id.length > 0 ? raw.id : base.id,
+    name: typeof raw.name === 'string' && raw.name.length > 0 ? raw.name : String(slotIndex + 1),
+    slotIndex,
+    launchMode: parseLaunchMode(raw.launchMode),
+    followAction: parseFollow(raw.followAction),
+    followRepeatN:
+      typeof raw.followRepeatN === 'number' && raw.followRepeatN >= 1
+        ? Math.floor(raw.followRepeatN)
+        : 1,
+    empty: raw.empty === false ? false : Boolean(raw.empty ?? true),
+  };
+}
+
+function parseColumn(raw: unknown, track: TrackKey): SessionTrackColumn {
+  const fallback = createDefaultSessionDocument().columns[track];
+  if (!isRecord(raw) || !Array.isArray(raw.clips)) return fallback;
+  const clips = raw.clips.map((c, i) => parseClip(c, track, i));
+  return { track, clips: clips.length > 0 ? clips : fallback.clips };
+}
+
+function parseScene(raw: unknown, index: number, fallback: SessionScene): SessionScene {
+  if (!isRecord(raw)) return fallback;
+  const clipIds: SessionScene['clipIds'] = { ...fallback.clipIds };
+  if (isRecord(raw.clipIds)) {
+    for (const track of TRACK_KEYS) {
+      const v = raw.clipIds[track];
+      if (v === null || typeof v === 'string') clipIds[track] = v;
+    }
+  }
+  return {
+    id: typeof raw.id === 'string' && raw.id.length > 0 ? raw.id : fallback.id,
+    name: typeof raw.name === 'string' && raw.name.length > 0 ? raw.name : fallback.name,
+    clipIds,
+  };
+}
+
+/**
+ * Build a session document from existing trackStorage: occupied slots become
+ * non-empty clips. Legacy 8-slot songs map to 8 rows / 8 scenes.
+ */
+export function sessionFromTrackStorage(
+  storage: TrackStorageMap | undefined,
+  rows = SESSION_DEFAULT_ROWS,
+): SessionDocument {
+  const doc = createDefaultSessionDocument(rows);
+  if (!storage) return doc;
+  for (const track of TRACK_KEYS) {
+    const slots = storage[track] ?? [];
+    const clips = doc.columns[track].clips.map((clip, i) => {
+      const stored = slots[clip.slotIndex] ?? slots[i] ?? null;
+      const occupied = stored != null && hasAnyNotes(stored);
+      return { ...clip, empty: !occupied };
+    });
+    doc.columns[track] = { track, clips };
+  }
+  doc.scenes = doc.scenes.map((scene, i) => {
+    const clipIds: SessionScene['clipIds'] = {};
+    for (const track of TRACK_KEYS) {
+      const clip = doc.columns[track].clips[i];
+      clipIds[track] = clip && !clip.empty ? clip.id : null;
+    }
+    return { ...scene, clipIds };
+  });
+  return doc;
+}
+
+function hasAnyNotes(seq: PartSequence | PartSequence[]): boolean {
+  if (Array.isArray(seq)) {
+    return seq.some((bank) => bank.steps.some((n) => n != null));
+  }
+  return seq.steps.some((n) => n != null);
+}
+
+/** Parse unknown JSON into a valid SessionDocument; never throws. */
+export function parseSessionDocument(
+  raw: unknown,
+  storage?: TrackStorageMap,
+): SessionDocument {
+  const fallback = sessionFromTrackStorage(storage);
+  if (!isRecord(raw)) return fallback;
+
+  const columns = {} as Record<TrackKey, SessionTrackColumn>;
+  const rawColumns = isRecord(raw.columns) ? raw.columns : {};
+  for (const track of TRACK_KEYS) {
+    columns[track] = parseColumn(rawColumns[track], track);
+  }
+
+  const defaultScenes = fallback.scenes;
+  const scenesRaw = Array.isArray(raw.scenes) ? raw.scenes : [];
+  const scenes = (scenesRaw.length > 0 ? scenesRaw : defaultScenes).map((s, i) =>
+    parseScene(s, i, defaultScenes[i] ?? defaultScenes[0]),
+  );
+
+  const quant = raw.quantization;
+  const quantization =
+    quant === 'immediate' ||
+    quant === 'step' ||
+    quant === 'beat' ||
+    quant === 'bar' ||
+    quant === '2bars' ||
+    quant === '4bars'
+      ? quant
+      : fallback.quantization;
+
+  return {
+    schemaVersion: SESSION_DOCUMENT_VERSION,
+    quantization,
+    columns,
+    scenes: scenes.length > 0 ? scenes : defaultScenes,
+  };
+}
+
+export function migrateSavedSongSession(
+  version: number | undefined,
+  sessionRaw: unknown,
+  storage?: TrackStorageMap,
+): SessionDocument {
+  if (sessionRaw != null) {
+    return parseSessionDocument(sessionRaw, storage);
+  }
+  // v1 (8 slots) and v2 (32 slots) songs without a session document.
+  const rows = version === 1 ? 8 : SESSION_DEFAULT_ROWS;
+  return sessionFromTrackStorage(storage, rows);
+}

--- a/src/session/packs/index.ts
+++ b/src/session/packs/index.ts
@@ -1,0 +1,200 @@
+import { TRACK_KEYS, NUM_STEPS } from '@/constants';
+import type { TrackKey } from '@/constants/appDefaults';
+import type { Note, PartSequence } from '@/types';
+import type { TrackStorageMap } from '@/utils/trackStorageUtils';
+import { createEmptyTrackStorage } from '@/utils/trackStorageUtils';
+import { randomizeDrumTrack, randomizeMelodicTrack, seededRng } from '@/utils/patternRandomizer';
+import { createDefaultSessionDocument } from '../defaults';
+import type { SessionDocument } from '../types';
+
+export interface SessionPack {
+  id: string;
+  name: string;
+  description: string;
+  session: SessionDocument;
+  trackStorage: TrackStorageMap;
+}
+
+function note(n: string, velocity = 0.9, extra?: Partial<Note>): Note {
+  return { note: n, velocity, ...extra };
+}
+
+function seqFromNotes(steps: (Note | null)[]): PartSequence {
+  const padded = [...steps];
+  while (padded.length < NUM_STEPS) padded.push(null);
+  return { steps: padded.slice(0, NUM_STEPS) };
+}
+
+function emptySampler(): PartSequence[] {
+  return Array.from({ length: 8 }, () => ({ steps: Array(NUM_STEPS).fill(null) as (Note | null)[] }));
+}
+
+function putSlot(storage: TrackStorageMap, track: TrackKey, slot: number, seq: PartSequence | PartSequence[]): void {
+  storage[track][slot] = seq;
+}
+
+function nameClips(session: SessionDocument, track: TrackKey, names: string[]): void {
+  names.forEach((name, i) => {
+    const clip = session.columns[track].clips[i];
+    if (!clip) return;
+    clip.name = name;
+    clip.empty = false;
+  });
+}
+
+function wireScenes(session: SessionDocument, filledRows: number): void {
+  session.scenes = session.scenes.map((scene, i) => {
+    const clipIds = { ...scene.clipIds };
+    for (const track of TRACK_KEYS) {
+      const clip = session.columns[track].clips[i];
+      clipIds[track] = i < filledRows && clip && !clip.empty ? clip.id : null;
+    }
+    return { ...scene, clipIds, name: scene.name };
+  });
+}
+
+/** Acid Live Set — 303 lines + 909-ish drums. */
+export function createAcidLiveSetPack(): SessionPack {
+  const rng = seededRng(303);
+  const storage = createEmptyTrackStorage();
+  const session = createDefaultSessionDocument();
+
+  putSlot(storage, 'partB', 0, randomizeMelodicTrack(NUM_STEPS, { root: 'A', scale: 'Minor', density: 0.45, rng }));
+  putSlot(storage, 'partB', 1, randomizeMelodicTrack(NUM_STEPS, { root: 'A', scale: 'Minor', density: 0.7, rng }));
+  putSlot(storage, 'bass2', 0, randomizeMelodicTrack(NUM_STEPS, { root: 'A', scale: 'Minor', density: 0.5, rng }));
+  putSlot(storage, 'bass2', 1, randomizeMelodicTrack(NUM_STEPS, { root: 'E', scale: 'Minor', density: 0.55, rng }));
+  putSlot(storage, 'kick', 0, randomizeDrumTrack(NUM_STEPS, { density: 0.25, euclidean: true, rng }));
+  putSlot(storage, 'kick', 1, seqFromNotes([note('C2'), null, null, null, note('C2'), null, null, null, note('C2'), null, null, null, note('C2'), null, null, null]));
+  putSlot(storage, 'snare', 0, seqFromNotes([null, null, null, null, note('D3'), null, null, null, null, null, null, null, note('D3'), null, null, null]));
+  putSlot(storage, 'closedHat', 0, randomizeDrumTrack(NUM_STEPS, { density: 0.5, euclidean: true, rng }));
+  putSlot(storage, 'openHat', 0, seqFromNotes([null, null, null, note('F#3'), null, null, null, note('F#3')]));
+
+  nameClips(session, 'partB', ['Acid A', 'Acid B']);
+  nameClips(session, 'bass2', ['303 A', '303 B']);
+  nameClips(session, 'kick', ['Four', 'Boom']);
+  nameClips(session, 'snare', ['Back']);
+  nameClips(session, 'closedHat', ['Hats']);
+  nameClips(session, 'openHat', ['Open']);
+  session.scenes[0].name = 'Intro';
+  session.scenes[1].name = 'Drop';
+  wireScenes(session, 2);
+  return {
+    id: 'acid-live-set',
+    name: 'Acid Live Set',
+    description: 'Dual 303 lines with four-on-the-floor drums for a live acid set.',
+    session,
+    trackStorage: storage,
+  };
+}
+
+/** Vocal Chop Performance — sampler-forward scenes. */
+export function createVocalChopPack(): SessionPack {
+  const rng = seededRng(808);
+  const storage = createEmptyTrackStorage();
+  const session = createDefaultSessionDocument();
+  const chopA: PartSequence[] = emptySampler();
+  chopA[0] = seqFromNotes([note('C4'), null, note('C4'), null, note('D4'), null, note('C4'), null]);
+  const chopB: PartSequence[] = emptySampler();
+  chopB[0] = seqFromNotes([note('E4', 1, { reverse: true }), null, null, note('G4'), null, note('E4')]);
+  putSlot(storage, 'sampler', 0, chopA);
+  putSlot(storage, 'sampler', 1, chopB);
+  putSlot(storage, 'kick', 0, randomizeDrumTrack(NUM_STEPS, { density: 0.2, euclidean: true, rng }));
+  putSlot(storage, 'snare', 0, randomizeDrumTrack(NUM_STEPS, { density: 0.12, rng }));
+  putSlot(storage, 'partA', 0, randomizeMelodicTrack(NUM_STEPS, { root: 'C', scale: 'Major', density: 0.2, rng }));
+
+  nameClips(session, 'sampler', ['Chop A', 'Chop B']);
+  nameClips(session, 'kick', ['Pulse']);
+  nameClips(session, 'snare', ['Snap']);
+  nameClips(session, 'partA', ['Pad']);
+  session.scenes[0].name = 'Vox In';
+  session.scenes[1].name = 'Chop Flip';
+  wireScenes(session, 2);
+  return {
+    id: 'vocal-chop-performance',
+    name: 'Vocal Chop Performance',
+    description: 'Sampler banks as launchable vocal chops over a light rhythm bed.',
+    session,
+    trackStorage: storage,
+  };
+}
+
+/** Dual-303 Jam — lead + bass 303 with complementary scenes. */
+export function createDual303JamPack(): SessionPack {
+  const rng = seededRng(303303);
+  const storage = createEmptyTrackStorage();
+  const session = createDefaultSessionDocument();
+  putSlot(storage, 'partA', 0, randomizeMelodicTrack(NUM_STEPS, { root: 'G', scale: 'Minor', density: 0.35, rng }));
+  putSlot(storage, 'partA', 1, randomizeMelodicTrack(NUM_STEPS, { root: 'G', scale: 'Minor', density: 0.6, rng }));
+  putSlot(storage, 'partB', 0, randomizeMelodicTrack(NUM_STEPS, { root: 'G', scale: 'Minor', density: 0.4, rng }));
+  putSlot(storage, 'bass2', 0, randomizeMelodicTrack(NUM_STEPS, { root: 'G', scale: 'Minor', density: 0.5, rng }));
+  putSlot(storage, 'kick', 0, randomizeDrumTrack(NUM_STEPS, { density: 0.25, euclidean: true, rng }));
+  putSlot(storage, 'closedHat', 0, randomizeDrumTrack(NUM_STEPS, { density: 0.45, rng }));
+
+  nameClips(session, 'partA', ['Lead A', 'Lead B']);
+  nameClips(session, 'partB', ['Bass 303']);
+  nameClips(session, 'bass2', ['Bass 2']);
+  nameClips(session, 'kick', ['Kick']);
+  nameClips(session, 'closedHat', ['Hats']);
+  session.scenes[0].name = 'Jam A';
+  session.scenes[1].name = 'Jam B';
+  wireScenes(session, 2);
+  return {
+    id: 'dual-303-jam',
+    name: 'Dual-303 Jam',
+    description: 'Lead and bass 303 clips for call-and-response scene launches.',
+    session,
+    trackStorage: storage,
+  };
+}
+
+/** Minimal Drum Lab — kick/snare/hat variations. */
+export function createMinimalDrumLabPack(): SessionPack {
+  const rng = seededRng(909);
+  const storage = createEmptyTrackStorage();
+  const session = createDefaultSessionDocument();
+  putSlot(storage, 'kick', 0, seqFromNotes([note('C2'), null, null, null, note('C2'), null, null, null]));
+  putSlot(storage, 'kick', 1, randomizeDrumTrack(NUM_STEPS, { density: 0.35, euclidean: true, rng }));
+  putSlot(storage, 'snare', 0, seqFromNotes([null, null, null, null, note('D3'), null, null, null]));
+  putSlot(storage, 'snare', 1, randomizeDrumTrack(NUM_STEPS, { density: 0.18, rng }));
+  putSlot(storage, 'closedHat', 0, randomizeDrumTrack(NUM_STEPS, { density: 0.5, euclidean: true, rng }));
+  putSlot(storage, 'closedHat', 1, randomizeDrumTrack(NUM_STEPS, { density: 0.75, rng }));
+  putSlot(storage, 'openHat', 0, seqFromNotes([null, null, null, null, null, null, note('F#3'), null]));
+
+  nameClips(session, 'kick', ['Four', 'Broken']);
+  nameClips(session, 'snare', ['2+4', 'Ghost']);
+  nameClips(session, 'closedHat', ['16ths', 'Busy']);
+  nameClips(session, 'openHat', ['Off']);
+  session.scenes[0].name = 'Lab A';
+  session.scenes[1].name = 'Lab B';
+  wireScenes(session, 2);
+  return {
+    id: 'minimal-drum-lab',
+    name: 'Minimal Drum Lab',
+    description: 'Kick, snare, and hat clip columns for drum-only scene practice.',
+    session,
+    trackStorage: storage,
+  };
+}
+
+export const SESSION_PACKS: SessionPack[] = [
+  createAcidLiveSetPack(),
+  createVocalChopPack(),
+  createDual303JamPack(),
+  createMinimalDrumLabPack(),
+];
+
+export function getSessionPack(id: string): SessionPack | undefined {
+  return SESSION_PACKS.find((p) => p.id === id);
+}
+
+/** Merge pack slots into existing storage without wiping empty user slots. */
+export function mergePackStorage(base: TrackStorageMap, pack: TrackStorageMap): TrackStorageMap {
+  const next = createEmptyTrackStorage();
+  for (const track of TRACK_KEYS) {
+    next[track] = base[track].slice();
+    for (let i = 0; i < pack[track].length; i++) {
+      if (pack[track][i] != null) next[track][i] = pack[track][i];
+    }
+  }
+  return next;
+}

--- a/src/session/quantize.ts
+++ b/src/session/quantize.ts
@@ -1,0 +1,120 @@
+import type { LaunchQuantization, TransportClockSnapshot } from './types';
+
+export interface QuantizeResult {
+  /** Pattern-local step (0 … patternSteps-1) where the launch applies. */
+  step: number;
+  /** AudioTime of that boundary. */
+  audioTime: number;
+  /** Steps from the origin step along the infinite timeline (>= 0). */
+  deltaSteps: number;
+  timelineStep: number;
+}
+
+function quantGrid(quant: LaunchQuantization, clock: TransportClockSnapshot): number {
+  switch (quant) {
+    case 'immediate':
+      return 1;
+    case 'step':
+      return 1;
+    case 'beat':
+      return clock.stepsPerBeat;
+    case 'bar':
+      return clock.stepsPerBar;
+    case '2bars':
+      return clock.stepsPerBar * 2;
+    case '4bars':
+      return clock.stepsPerBar * 4;
+    default:
+      return clock.stepsPerBar;
+  }
+}
+
+export function secondsPerStep(tempo: number): number {
+  return 60 / tempo / 4;
+}
+
+/**
+ * Map a launch request onto the next quantization boundary of the audio timeline.
+ *
+ * Uses only the last known worklet step timestamp — never `performance.now()` or
+ * React render time — so a stalled UI cannot shift the scheduled boundary.
+ *
+ * `immediate` applies at the current step's audioTime when the request arrived
+ * on that step; otherwise it still waits for the next step so we never schedule
+ * in the past relative to the last processed tick.
+ */
+export function quantizeLaunch(
+  quant: LaunchQuantization,
+  clock: TransportClockSnapshot,
+  requestStep: number,
+  requestAudioTime: number,
+  timelineOriginStep = 0,
+): QuantizeResult {
+  const stepDur = secondsPerStep(clock.tempo);
+  const pattern = Math.max(1, clock.patternSteps);
+  const originStep = ((clock.step % pattern) + pattern) % pattern;
+  const originTime = clock.audioTime;
+  const originTimeline = timelineOriginStep;
+
+  if (quant === 'immediate') {
+    const late = requestAudioTime > originTime + stepDur * 0.5;
+    if (!late) {
+      return {
+        step: originStep,
+        audioTime: originTime,
+        deltaSteps: 0,
+        timelineStep: originTimeline,
+      };
+    }
+    const deltaSteps = 1;
+    return {
+      step: (originStep + 1) % pattern,
+      audioTime: originTime + stepDur,
+      deltaSteps,
+      timelineStep: originTimeline + deltaSteps,
+    };
+  }
+
+  const grid = quantGrid(quant, clock);
+  const abs = originTimeline;
+  // If the request is processed on a boundary that already matches the grid
+  // and arrived no later than this step's audioTime, fire on this step.
+  const onGrid = abs % grid === 0;
+  const arrivedOnThisStep =
+    requestStep === originStep && requestAudioTime <= originTime + stepDur * 0.25;
+
+  let deltaSteps: number;
+  if (onGrid && arrivedOnThisStep) {
+    deltaSteps = 0;
+  } else {
+    const rem = abs % grid;
+    deltaSteps = rem === 0 ? grid : grid - rem;
+  }
+
+  return {
+    step: (originStep + deltaSteps) % pattern,
+    audioTime: originTime + deltaSteps * stepDur,
+    deltaSteps,
+    timelineStep: originTimeline + deltaSteps,
+  };
+}
+
+export function nextFollowBoundary(
+  clock: TransportClockSnapshot,
+  startedTimelineStep: number,
+  clipLengthSteps: number,
+  timelineOriginStep: number,
+): QuantizeResult | null {
+  if (clipLengthSteps <= 0) return null;
+  const elapsed = timelineOriginStep - startedTimelineStep;
+  if (elapsed < 0) return null;
+  if (elapsed > 0 && elapsed % clipLengthSteps === 0) {
+    return {
+      step: clock.step,
+      audioTime: clock.audioTime,
+      deltaSteps: 0,
+      timelineStep: timelineOriginStep,
+    };
+  }
+  return null;
+}

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -1,0 +1,179 @@
+import type { TrackKey } from '@/constants/appDefaults';
+import { TRACK_KEYS } from '@/constants';
+
+/** Nested session document version (independent of SavedSongData.version). */
+export const SESSION_DOCUMENT_VERSION = 1;
+
+/** SavedSongData version that first includes a session document. */
+export const SAVED_SONG_DATA_VERSION_WITH_SESSION = 3;
+
+export const SESSION_TRACKS: readonly TrackKey[] = TRACK_KEYS;
+
+/** Default live-set rows (legacy 8-slot songs map 1:1). */
+export const SESSION_DEFAULT_ROWS = 8;
+
+/** 16th-note step clock: 4 steps/beat, 16 steps/bar, 32-step pattern = 2 bars. */
+export const SESSION_STEPS_PER_BEAT = 4;
+export const SESSION_STEPS_PER_BAR = 16;
+
+export type ClipId = string;
+export type SceneId = string;
+
+export type ClipLaunchMode = 'trigger' | 'gate' | 'toggle' | 'one-shot';
+
+export type FollowActionKind = 'none' | 'next' | 'previous' | 'random' | 'stop' | 'repeat';
+
+export type LaunchQuantization = 'immediate' | 'step' | 'beat' | 'bar' | '2bars' | '4bars';
+
+export const LAUNCH_QUANTIZATIONS: readonly LaunchQuantization[] = [
+  'immediate',
+  'step',
+  'beat',
+  'bar',
+  '2bars',
+  '4bars',
+] as const;
+
+export type LaunchSource =
+  | 'manual'
+  | 'scene'
+  | 'follow'
+  | 'song-mode'
+  | 'midi'
+  | 'gamepad'
+  | 'capture-replay';
+
+export type LaunchKind = 'clip' | 'scene' | 'stop-track' | 'stop-all';
+
+export interface SessionClip {
+  id: ClipId;
+  name: string;
+  /** Pattern slot in trackStorage this clip references (content lives there). */
+  slotIndex: number;
+  launchMode: ClipLaunchMode;
+  followAction: FollowActionKind;
+  /** Loops before follow-action `repeat` stops (ignored for other follow kinds). */
+  followRepeatN: number;
+  empty: boolean;
+}
+
+export interface SessionTrackColumn {
+  track: TrackKey;
+  clips: SessionClip[];
+}
+
+export interface SessionScene {
+  id: SceneId;
+  name: string;
+  /** Clip id per track; omitted/null = leave that track unchanged on scene launch. */
+  clipIds: Partial<Record<TrackKey, ClipId | null>>;
+}
+
+export interface SessionDocument {
+  schemaVersion: typeof SESSION_DOCUMENT_VERSION;
+  quantization: LaunchQuantization;
+  columns: Record<TrackKey, SessionTrackColumn>;
+  scenes: SessionScene[];
+}
+
+export interface TransportClockSnapshot {
+  /** Last (or current) fired sequencer step, 0 … patternSteps-1. */
+  step: number;
+  /** AudioTime of that step (sample-accurate worklet timestamp). */
+  audioTime: number;
+  tempo: number;
+  patternSteps: number;
+  stepsPerBeat: number;
+  stepsPerBar: number;
+  isPlaying: boolean;
+  songModeActive: boolean;
+}
+
+export interface LaunchIntent {
+  kind: LaunchKind;
+  source: LaunchSource;
+  /** Monotonic id — later intents win on the same quantized boundary. */
+  requestSeq: number;
+  requestAudioTime: number;
+  requestStep: number;
+  track?: TrackKey;
+  clipId?: ClipId;
+  sceneId?: SceneId;
+  /** Gate mode: false on note/button release. */
+  gateDown?: boolean;
+}
+
+export type CompiledLaunchAction = 'start' | 'stop' | 'replace';
+
+export interface CompiledLaunchEvent {
+  audioTime: number;
+  step: number;
+  /** Absolute step index from an origin (for capture / property tests). */
+  timelineStep: number;
+  track: TrackKey;
+  action: CompiledLaunchAction;
+  clipId: ClipId | null;
+  slotIndex: number | null;
+  sceneId?: SceneId;
+  source: LaunchSource;
+  requestSeq: number;
+}
+
+export interface PlayingClipState {
+  clipId: ClipId;
+  slotIndex: number;
+  launchMode: ClipLaunchMode;
+  loopsCompleted: number;
+  followRepeatRemaining: number;
+  startedTimelineStep: number;
+}
+
+export interface QueuedLaunch {
+  event: CompiledLaunchEvent;
+}
+
+export interface SessionRuntimeSnapshot {
+  playing: Record<TrackKey, PlayingClipState | null>;
+  queued: CompiledLaunchEvent[];
+  capturing: boolean;
+  captureEvents: SessionCaptureEvent[];
+}
+
+export interface SessionCaptureEvent {
+  audioTime: number;
+  step: number;
+  timelineStep: number;
+  track: TrackKey;
+  action: CompiledLaunchAction;
+  clipId: ClipId | null;
+  slotIndex: number | null;
+  sceneId?: SceneId;
+}
+
+export interface SessionTickResult {
+  applied: CompiledLaunchEvent[];
+  flushTracks: TrackKey[];
+  playing: Record<TrackKey, PlayingClipState | null>;
+  queued: CompiledLaunchEvent[];
+  /** Live session launch should deactivate Song Mode at this boundary. */
+  preemptSongMode: boolean;
+  /** Song Mode start should stop session clips. */
+  preemptSession: boolean;
+}
+
+export interface SessionFocus {
+  track: TrackKey;
+  row: number;
+  sceneIndex: number;
+}
+
+export const SESSION_TRACK_LABELS: Record<TrackKey, string> = {
+  partA: 'SYNTH A',
+  partB: 'SYNTH B',
+  bass2: 'BASS 2',
+  kick: 'KICK',
+  snare: 'SNARE',
+  closedHat: 'CH',
+  openHat: 'OH',
+  sampler: 'SMP',
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -604,6 +604,8 @@ export interface AudioEngine {
   noteOffSynth?: (id: number) => void;
 
   stopAllNotes?: () => void;
+  /** Flush hanging voices on one track at a clip transition. */
+  stopTrackNotes?: (track: 'partA' | 'partB' | 'bass2' | 'kick' | 'snare' | 'closedHat' | 'openHat' | 'sampler') => void;
 
   // Other existing methods
   loadSampleToEngine: (name: string, buffer: AudioBuffer, onProgress?: (progress: number) => void) => Promise<void> | void;
@@ -803,7 +805,7 @@ export interface SongStructure {
 }
 
 export interface SavedSongData {
-  /** Schema version: 1 = 8 pattern slots per track, 2 = 32 slots (ReBirth-compatible). */
+  /** Schema version: 1 = 8 pattern slots, 2 = 32 slots, 3 = 32 slots + session. */
   version?: number;
   pattern: Pattern;
   params: {
@@ -830,6 +832,8 @@ export interface SavedSongData {
   midiMappings?: import('./types/midi').MidiBinding[];
   /** WAM2 plugin slots (identity, version, param/plugin state). */
   wam2?: import('./audio/wam').Wam2SongPayload;
+  /** Session / clip launcher document (v3+). Absent on v1/v2 songs — migrated on load. */
+  session?: import('./session/types').SessionDocument;
 }
 export interface AmbianceTrack {
   id: string;

--- a/src/types/midi.ts
+++ b/src/types/midi.ts
@@ -1,7 +1,7 @@
 import type { AutomationTarget } from '../types';
 
 /** Identifies a mappable on-screen control (automation target + parameter id). */
-export type MidiControlTarget = AutomationTarget;
+export type MidiControlTarget = AutomationTarget | 'session';
 export type MidiControlId = `${MidiControlTarget}:${string}`;
 
 export function makeMidiControlId(target: MidiControlTarget, param: string): MidiControlId {

--- a/src/utils/__tests__/midiParamDispatch.test.ts
+++ b/src/utils/__tests__/midiParamDispatch.test.ts
@@ -62,4 +62,22 @@ describe('midiParamDispatch', () => {
     expect(buf?.points.length).toBeGreaterThan(0);
     automationStore.reset();
   });
+
+  it('routes session clip launches', () => {
+    const handleSessionControl = vi.fn();
+    applyMidiControlValue(makeMidiControlId('session', 'clip:kick:0'), 1, {
+      handleSynthChange: vi.fn(),
+      handleBass2Change: vi.fn(),
+      handleKickChange: vi.fn(),
+      handleSnareChange: vi.fn(),
+      handleClosedHatChange: vi.fn(),
+      handleOpenHatChange: vi.fn(),
+      handleSamplerChange: vi.fn(),
+      setMasterVolume: vi.fn(),
+      setMasterSaturation: vi.fn(),
+      setGlobalPan: vi.fn(),
+      handleSessionControl,
+    });
+    expect(handleSessionControl).toHaveBeenCalledWith('clip:kick:0', 1);
+  });
 });

--- a/src/utils/midiParamDispatch.ts
+++ b/src/utils/midiParamDispatch.ts
@@ -18,6 +18,7 @@ export interface MidiParamHandlers {
   setAudioMasterSaturation?: (v: number) => void;
   setAudioGlobalPan?: (v: number) => void;
   getCurrentStep?: () => number;
+  handleSessionControl?: (param: string, normalized: number) => void;
 }
 
 /** Map normalized 0–1 MIDI value to control-specific range, then dispatch. */
@@ -28,6 +29,11 @@ export function applyMidiControlValue(
 ): void {
   const { target, param } = parseMidiControlId(controlId);
   const n = Math.max(0, Math.min(1, normalized));
+
+  if (target === 'session') {
+    handlers.handleSessionControl?.(param, n);
+    return;
+  }
 
   if (target === 'master') {
     applyMasterParam(param, n, handlers);

--- a/tests/session-launcher.spec.ts
+++ b/tests/session-launcher.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import { initializeHyphonAudio } from './helpers/boot';
+import { startPlaybackAndAwaitClock } from './helpers/rbs-e2e';
+
+test.describe('Session clip launcher', () => {
+  test('boot → load pack → launch scene → quantized play → capture → song mode', async ({ page }) => {
+    await initializeHyphonAudio(page);
+
+    await page.getByRole('button', { name: 'Toggle Session Launcher' }).click();
+    await expect(page.getByRole('dialog', { name: 'SESSION' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Load starter pack Acid Live Set' }).click();
+    await expect(page.getByTestId('session-clip-kick-0')).toBeEnabled();
+
+    await startPlaybackAndAwaitClock(page);
+
+    await page.getByTestId('session-scene-0').click();
+
+    await expect
+      .poll(async () => {
+        return page.evaluate(() => {
+          const w = window as Window & {
+            __HYPHON_E2E__?: { getSessionPlayingCount?: () => number; getSessionLastApplyStep?: () => number };
+          };
+          return w.__HYPHON_E2E__?.getSessionPlayingCount?.() ?? 0;
+        });
+      }, { timeout: 15_000, intervals: [100, 250, 500] })
+      .toBeGreaterThan(0);
+
+    await page.getByRole('button', { name: 'Capture launches into Song Mode' }).click();
+    await page.getByRole('button', { name: 'Stop capturing launches into Song Mode' }).click();
+
+    await expect(page.getByText('SONG ARRANGER')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('cell-kick-0')).toBeVisible();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a non-linear **Session / Clip Launcher** that compiles clip and scene launches into timestamped events on the existing AudioWorklet transport (no second clock).

- Versioned `SavedSongData` **v3** with nested `session` document; v1/v2 songs load unchanged and gain a default adapter from occupied pattern slots.
- Per-track clips (8 rows by default) referencing `trackStorage`; scenes launch atomically at one quantization boundary (`immediate` / `step` / `beat` / `bar` / `2bars` / `4bars`).
- Launch modes: trigger, toggle, gate, one-shot. Follow actions: next, previous, random, stop, repeat N.
- Conflict rules: live session preempts Song Mode; Song Mode latch stops session clips; later manual/MIDI/gamepad beats scene on the same track.
- Clip transitions flush hanging voices via `stopTrackNotes`.
- **CAPTURE** writes launches into the Song Mode arrangement (song-structure undo).
- MIDI Learn on clip/scene cells (`session:clip:…`, `session:scene:…`); gamepad D-pad + Attack/Jump when Session is focused.
- Starter packs: Acid Live Set, Vocal Chop Performance, Dual-303 Jam, Minimal Drum Lab.

Docs: `docs/session-launcher.md`.

## Testing

- Unit/property: `src/session/__tests__/sessionLauncher.test.ts` (20), packs (2), Session a11y (2), MIDI dispatch, trackStorage v3, scheduler, useMidi — 55 tests green.
- `tsc -b` clean.
- Playwright spec added: `tests/session-launcher.spec.ts` (boot → pack → scene launch → capture → Song Mode). Not run in this environment (needs full WASM/dev server boot).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-719316f4-d26b-4a6a-8d37-54499b05200a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-719316f4-d26b-4a6a-8d37-54499b05200a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

