### PR TITLE
Fix JC-303 native check when Emscripten 6 inlines pthread workers

### DIFF
--- a/.jules/setup.sh
+++ b/.jules/setup.sh
@@ -1,3 +1,3 @@
 git clone https://github.com/emscripten-core/emsdk.git
-cd emsdk && ./emsdk install latest && ./emsdk activate latest && source ./emsdk_env.sh
+cd emsdk && ./emsdk install 3.1.51 && ./emsdk activate 3.1.51 && source ./emsdk_env.sh
 npm install

--- a/docs/wasm/BUILD_NOTES.md
+++ b/docs/wasm/BUILD_NOTES.md
@@ -66,6 +66,14 @@ with `-s USE_PTHREADS=1`. No host `libomp` is involved. Rubber Band is compiled
 pthread pool exists for Emscripten's own runtime work. Comments elsewhere that
 describe Rubber Band as OpenMP-parallel are stale — this section is authoritative.
 
+CI and `AGENTS.md` pin **Emscripten 3.1.51**, which still emits a separate
+`*.worker.js` for pthreads. Emscripten 3.1.58+ inlines that worker into the
+main JS, and 6.x no longer writes the file at all. `check:native` still
+requires `public/jc303-threaded.worker.js` and `public/hyphon_native.worker.js`.
+`scripts/ensure-pthread-worker-stamp.mjs` copies a real worker when present
+and otherwise writes a stamp stub so Colab/`emsdk install latest` builds do
+not fail after a successful compile.
+
 ---
 
 ## Four Worlds memory budget

--- a/emscripten/build.sh
+++ b/emscripten/build.sh
@@ -277,6 +277,11 @@ if [ $? -eq 0 ]; then
         "$REPO_ROOT/public/hyphon_wasm_export_map.json"
     echo "Validating export map against emscripten/wasm_export_manifest.json..."
     node "$REPO_ROOT/tools/check_wasm_export_map.mjs" --glue "$OUTPUT_JS"
+    # Emscripten 3.1.51 emits hyphon_native.worker.js; 6.x inlines pthread workers.
+    node "$REPO_ROOT/scripts/ensure-pthread-worker-stamp.mjs" \
+        --src-dir "$REPO_ROOT/public" \
+        --stem hyphon_native \
+        --dest "$REPO_ROOT/public/hyphon_native.worker.js"
     echo "Build successful! (profile=$BUILD_PROFILE, legacy_jc303=$HYPHON_LEGACY_JC303)"
     echo "Generated: public/hyphon_native.js (and .wasm/.worker.js)"
     rm -rf "$TEMP_DIR"

--- a/scripts/ensure-pthread-worker-stamp.mjs
+++ b/scripts/ensure-pthread-worker-stamp.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Copy an Emscripten pthread worker if the toolchain still emits one.
+ * Otherwise write a small stamp file so native-world output checks stay green.
+ *
+ * Emscripten 3.1.51 (CI) writes `NAME.worker.js`. From 3.1.58 workers are
+ * inlined into the main JS; 6.x no longer emits a separate worker at all
+ * (emscripten#21701, #22598). `check:native` still lists the historical path.
+ *
+ * Usage:
+ *   node scripts/ensure-pthread-worker-stamp.mjs --src-dir <dir> --stem jc303 --dest <path>
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const PTHREAD_WORKER_STAMP_BANNER =
+  '// Hyphon native-world stamp: Emscripten >= 3.1.58 inlines pthread workers into the main JS.\n' +
+  '// Emscripten 6.x does not emit a separate .worker.js (PR 21701 / 22598).\n' +
+  '// Do not load this file at runtime — the glue in the companion .js module boots workers itself.\n';
+
+export function parseEnsureWorkerArgs(argv) {
+  const args = { srcDir: null, stem: null, dest: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    const next = argv[i + 1];
+    if (a === '--src-dir' && next) {
+      args.srcDir = next;
+      i += 1;
+    } else if (a === '--stem' && next) {
+      args.stem = next;
+      i += 1;
+    } else if (a === '--dest' && next) {
+      args.dest = next;
+      i += 1;
+    } else if (a === '--help' || a === '-h') {
+      args.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+  return args;
+}
+
+/**
+ * @returns {{ action: 'copied' | 'stubbed', dest: string, source: string | null }}
+ */
+export function ensurePthreadWorkerStamp({ srcDir, stem, dest }) {
+  if (!srcDir || !stem || !dest) {
+    throw new Error('ensurePthreadWorkerStamp requires srcDir, stem, and dest');
+  }
+  const candidates = [`${stem}.worker.js`, `${stem}.worker.mjs`];
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  for (const name of candidates) {
+    const source = path.join(srcDir, name);
+    if (fs.existsSync(source) && fs.statSync(source).isFile()) {
+      fs.copyFileSync(source, dest);
+      return { action: 'copied', dest, source };
+    }
+  }
+  fs.writeFileSync(dest, PTHREAD_WORKER_STAMP_BANNER);
+  return { action: 'stubbed', dest, source: null };
+}
+
+export function runEnsurePthreadWorkerCli(argv) {
+  const args = parseEnsureWorkerArgs(argv);
+  if (args.help) {
+    process.stdout.write(
+      'Usage: node scripts/ensure-pthread-worker-stamp.mjs --src-dir DIR --stem NAME --dest PATH\n',
+    );
+    return 0;
+  }
+  const result = ensurePthreadWorkerStamp(args);
+  if (result.action === 'copied') {
+    process.stdout.write(`[pthread-worker] copied ${result.source} -> ${result.dest}\n`);
+  } else {
+    process.stdout.write(
+      `[pthread-worker] no ${args.stem}.worker.js from this Emscripten; wrote stamp stub ${result.dest}\n`,
+    );
+  }
+  return 0;
+}
+
+const invokedAsScript =
+  Boolean(process.argv[1]) &&
+  path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+
+if (invokedAsScript) {
+  try {
+    process.exit(runEnsurePthreadWorkerCli(process.argv.slice(2)));
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : err}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/native-worlds.mjs
+++ b/scripts/native-worlds.mjs
@@ -178,6 +178,7 @@ export function defineWorlds(repoRoot, scripts = loadPackageScripts(repoRoot)) {
         ...jc303WasmFiles.map(fileInput),
         ...jc303SrcFiles.map(fileInput),
         fileInput('tools/build_jc303_omp.sh'),
+        fileInput('scripts/ensure-pthread-worker-stamp.mjs'),
         fileInput('tools/jc303_cmake/CMakeLists.txt'),
         fileInput(budgetRel),
         textInput('jc303_wasm.submodule', readSubmoduleCommit(repoRoot)),
@@ -202,6 +203,7 @@ export function defineWorlds(repoRoot, scripts = loadPackageScripts(repoRoot)) {
         ...rubberbandSrc.map(fileInput),
         ...open303Dsp.map(fileInput),
         fileInput('emscripten/wasm_export_manifest.json'),
+        fileInput('scripts/ensure-pthread-worker-stamp.mjs'),
         fileInput(budgetRel),
       ],
       outputs: [

--- a/src/__tests__/ensurePthreadWorkerStamp.test.ts
+++ b/src/__tests__/ensurePthreadWorkerStamp.test.ts
@@ -1,0 +1,67 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error -- scripts/*.mjs has no project-referenced types
+import {
+  PTHREAD_WORKER_STAMP_BANNER,
+  ensurePthreadWorkerStamp,
+} from '../../scripts/ensure-pthread-worker-stamp.mjs';
+
+function tempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'hyphon-pthread-worker-'));
+}
+
+describe('ensurePthreadWorkerStamp', () => {
+  it('copies a real Emscripten 3.1-style worker.js when present', () => {
+    const root = tempDir();
+    const srcDir = join(root, 'build');
+    mkdirSync(srcDir);
+    writeFileSync(join(srcDir, 'jc303.worker.js'), '/* real pthread worker */\n');
+    const dest = join(root, 'public', 'jc303-threaded.worker.js');
+    const result = ensurePthreadWorkerStamp({ srcDir, stem: 'jc303', dest });
+    expect(result.action).toBe('copied');
+    expect(readFileSync(dest, 'utf8')).toBe('/* real pthread worker */\n');
+  });
+
+  it('copies .worker.mjs when that is what the toolchain emitted', () => {
+    const root = tempDir();
+    const srcDir = join(root, 'build');
+    mkdirSync(srcDir);
+    writeFileSync(join(srcDir, 'hyphon_native.worker.mjs'), 'export {}\n');
+    const dest = join(root, 'public', 'hyphon_native.worker.js');
+    const result = ensurePthreadWorkerStamp({ srcDir, stem: 'hyphon_native', dest });
+    expect(result.action).toBe('copied');
+    expect(readFileSync(dest, 'utf8')).toBe('export {}\n');
+  });
+
+  it('writes a stamp stub when Emscripten 6 inlines the worker (no file)', () => {
+    const root = tempDir();
+    const srcDir = join(root, 'build');
+    mkdirSync(srcDir);
+    const dest = join(root, 'public', 'jc303-threaded.worker.js');
+    const result = ensurePthreadWorkerStamp({ srcDir, stem: 'jc303', dest });
+    expect(result.action).toBe('stubbed');
+    expect(result.source).toBeNull();
+    const body = readFileSync(dest, 'utf8');
+    expect(body).toBe(PTHREAD_WORKER_STAMP_BANNER);
+    expect(body).toContain('inlines pthread workers');
+  });
+});
+
+describe('jc303 / emcc build scripts wire the stamp helper', () => {
+  const repoRoot = join(__dirname, '../..');
+
+  it('build_jc303_omp.sh invokes the helper for the threaded variant', () => {
+    const sh = readFileSync(join(repoRoot, 'tools/build_jc303_omp.sh'), 'utf8');
+    expect(sh).toContain('scripts/ensure-pthread-worker-stamp.mjs');
+    expect(sh).toContain('--stem jc303');
+    expect(sh).not.toMatch(/cp -f jc303\.worker\.js .*2>\/dev\/null \|\| true/);
+  });
+
+  it('emscripten/build.sh invokes the helper after a successful link', () => {
+    const sh = readFileSync(join(repoRoot, 'emscripten/build.sh'), 'utf8');
+    expect(sh).toContain('scripts/ensure-pthread-worker-stamp.mjs');
+    expect(sh).toContain('--stem hyphon_native');
+  });
+});

--- a/src/__tests__/nativeBuildPreflight.test.ts
+++ b/src/__tests__/nativeBuildPreflight.test.ts
@@ -86,4 +86,14 @@ describe('native preflight', () => {
     expect(byId.jc303).toBe('pnpm run build:wasm:jc303');
     expect(byId['as-oscillators']).toBe('pnpm run build:wasm:oscillators');
   });
+
+  it('jc303 world still stamps the historical pthread worker path', () => {
+    const worlds = defineWorlds(defaultRepoRoot());
+    const jc303 = worlds.find((w: { id: string }) => w.id === 'jc303');
+    expect(jc303).toBeDefined();
+    expect(jc303!.outputs).toContain('public/jc303-threaded.worker.js');
+    expect(jc303!.inputs.some((i: { name: string }) => i.name === 'scripts/ensure-pthread-worker-stamp.mjs')).toBe(
+      true,
+    );
+  });
 });

--- a/tools/build_jc303_omp.sh
+++ b/tools/build_jc303_omp.sh
@@ -173,15 +173,22 @@ build_variant() {
     echo -e "${YELLOW}Building...${NC}"
     emmake make -j8
     
-    # Copy built files with variant suffix
+    # Copy built files with variant suffix. Fail closed on glue/wasm/worklet —
+    # a missing file used to be swallowed by `|| true` and only failed later in
+    # check:native after the script printed "Build Complete!".
     echo -e "${YELLOW}Copying ${VARIANT_NAME} variant to distribution...${NC}"
-    cp -f jc303.js "${DIST_DIR}/jc303-${VARIANT_NAME}.js" 2>/dev/null || true
-    cp -f jc303.wasm "${DIST_DIR}/jc303-${VARIANT_NAME}.wasm" 2>/dev/null || true
-    cp -f jc303_worklet.js "${DIST_DIR}/jc303-${VARIANT_NAME}-worklet.js" 2>/dev/null || true
-    
-    # Threaded variant also produces worker files
+    cp -f jc303.js "${DIST_DIR}/jc303-${VARIANT_NAME}.js"
+    cp -f jc303.wasm "${DIST_DIR}/jc303-${VARIANT_NAME}.wasm"
+    cp -f jc303_worklet.js "${DIST_DIR}/jc303-${VARIANT_NAME}-worklet.js"
+
+    # Threaded variant: Emscripten 3.1.51 emits jc303.worker.js; 6.x inlines it.
+    # ensure-pthread-worker-stamp.mjs copies the real worker or writes a stamp stub
+    # so public/jc303-threaded.worker.js exists for check:native.
     if [ "$ENABLE_THREADING" = "true" ]; then
-        cp -f jc303.worker.js "${DIST_DIR}/jc303-${VARIANT_NAME}.worker.js" 2>/dev/null || true
+        node "$REPO_ROOT/scripts/ensure-pthread-worker-stamp.mjs" \
+            --src-dir "$(pwd)" \
+            --stem jc303 \
+            --dest "${DIST_DIR}/jc303-${VARIANT_NAME}.worker.js"
     fi
     
     echo -e "${GREEN}${VARIANT_NAME} variant build complete!${NC}"
@@ -207,20 +214,27 @@ fi
 # Copy to main public directory for use in web_sequencer
 if [ -d "$PUBLIC_DIR" ]; then
     echo -e "${YELLOW}Copying to web_sequencer public directory...${NC}"
-    cp -f "${DIST_DIR}"/jc303-*.js "$PUBLIC_DIR/" 2>/dev/null || true
-    cp -f "${DIST_DIR}"/jc303-*.wasm "$PUBLIC_DIR/" 2>/dev/null || true
-    cp -f "${DIST_DIR}"/jc303-*.worker.js "$PUBLIC_DIR/" 2>/dev/null || true
+    shopt -s nullglob
+    jc303_js=( "${DIST_DIR}"/jc303-*.js )
+    jc303_wasm=( "${DIST_DIR}"/jc303-*.wasm )
+    shopt -u nullglob
+    if [ ${#jc303_js[@]} -eq 0 ] || [ ${#jc303_wasm[@]} -eq 0 ]; then
+        echo -e "${RED}Error: expected jc303-* artifacts in ${DIST_DIR}${NC}"
+        exit 1
+    fi
+    cp -f "${jc303_js[@]}" "$PUBLIC_DIR/"
+    cp -f "${jc303_wasm[@]}" "$PUBLIC_DIR/"
 
     # Also copy without suffix for backward compatibility (prefer single-threaded if both exist)
     if [ -f "${DIST_DIR}/jc303-single.js" ]; then
-        cp -f "${DIST_DIR}/jc303-single.js" "$PUBLIC_DIR/jc303.js" 2>/dev/null || true
-        cp -f "${DIST_DIR}/jc303-single.wasm" "$PUBLIC_DIR/jc303.wasm" 2>/dev/null || true
-        cp -f "${DIST_DIR}/jc303-single-worklet.js" "$PUBLIC_DIR/jc303_worklet.js" 2>/dev/null || true
+        cp -f "${DIST_DIR}/jc303-single.js" "$PUBLIC_DIR/jc303.js"
+        cp -f "${DIST_DIR}/jc303-single.wasm" "$PUBLIC_DIR/jc303.wasm"
+        cp -f "${DIST_DIR}/jc303-single-worklet.js" "$PUBLIC_DIR/jc303_worklet.js"
     elif [ -f "${DIST_DIR}/jc303-threaded.js" ]; then
-        cp -f "${DIST_DIR}/jc303-threaded.js" "$PUBLIC_DIR/jc303.js" 2>/dev/null || true
-        cp -f "${DIST_DIR}/jc303-threaded.wasm" "$PUBLIC_DIR/jc303.wasm" 2>/dev/null || true
-        cp -f "${DIST_DIR}/jc303-threaded-worklet.js" "$PUBLIC_DIR/jc303_worklet.js" 2>/dev/null || true
-        cp -f "${DIST_DIR}/jc303-threaded.worker.js" "$PUBLIC_DIR/jc303.worker.js" 2>/dev/null || true
+        cp -f "${DIST_DIR}/jc303-threaded.js" "$PUBLIC_DIR/jc303.js"
+        cp -f "${DIST_DIR}/jc303-threaded.wasm" "$PUBLIC_DIR/jc303.wasm"
+        cp -f "${DIST_DIR}/jc303-threaded-worklet.js" "$PUBLIC_DIR/jc303_worklet.js"
+        cp -f "${DIST_DIR}/jc303-threaded.worker.js" "$PUBLIC_DIR/jc303.worker.js"
     fi
 fi
 
@@ -237,6 +251,7 @@ echo ""
 if [ "$BUILD_VARIANT" = "both" ] || [ "$BUILD_VARIANT" = "threaded" ]; then
     echo "Threaded variant files: jc303-threaded.{js,wasm,worker.js}"
     echo "  Note: Requires COOP/COEP headers on web server"
+    echo "  Note: On Emscripten 6.x the .worker.js path is a stamp stub (workers are inlined)"
 fi
 if [ "$BUILD_VARIANT" = "both" ] || [ "$BUILD_VARIANT" = "single" ]; then
     echo "Single-threaded variant files: jc303-single.{js,wasm}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Colab / `emsdk install latest` (currently Emscripten **6.0.7**) builds JC-303 successfully, then `pnpm run build:release` fails:

```
[check:native] FAILED — 1 world(s) need a rebuild
[check:native] missing: jc303
  reason: missing outputs: public/jc303-threaded.worker.js
```

CI still pins Emscripten **3.1.51**, which emits a separate `jc303.worker.js`. From 3.1.58 pthread workers are inlined into the main JS; 6.x no longer writes the file at all ([emscripten#21701](https://github.com/emscripten-core/emscripten/pull/21701), [#22598](https://github.com/emscripten-core/emscripten/pull/22598)). `tools/build_jc303_omp.sh` copied the worker with `|| true`, so the script printed “Build Complete!” while `check:native` later failed closed.

## Fix

- Add `scripts/ensure-pthread-worker-stamp.mjs`: copy `NAME.worker.js` / `.mjs` when present, otherwise write a documented stamp stub at the historical path.
- Call it from `tools/build_jc303_omp.sh` (threaded variant) and `emscripten/build.sh` (hyphon_native).
- Fail closed on missing `jc303.js` / `.wasm` / worklet instead of swallowing copy errors.
- Pin `.jules/setup.sh` to Emscripten 3.1.51 to match CI.

`check:native` still requires `public/jc303-threaded.worker.js`. On 3.1.51 that file remains the real worker; on 6.x it is a stub the runtime does not load.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d5c99d5-ee78-4903-a9b5-517de6ef0ac5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d5c99d5-ee78-4903-a9b5-517de6ef0ac5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WASM builds across supported Emscripten versions by handling both generated and inlined pthread workers.
  * Build artifact copying now reports missing JavaScript, WebAssembly, or worklet files instead of silently continuing.
  * Preserved compatibility worker files for threaded builds.

* **Documentation**
  * Added guidance on Emscripten pthread worker-generation differences and build behavior.

* **Tests**
  * Added coverage for worker copying, fallback stubs, build integration, and missing artifact detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->