### PR TITLE
Fix TypeScript build failure in ensurePthreadWorkerStamp.test.ts

### DIFF
--- a/src/__tests__/ensurePthreadWorkerStamp.test.ts
+++ b/src/__tests__/ensurePthreadWorkerStamp.test.ts
@@ -3,10 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 // @ts-expect-error -- scripts/*.mjs has no project-referenced types
-import {
-  PTHREAD_WORKER_STAMP_BANNER,
-  ensurePthreadWorkerStamp,
-} from '../../scripts/ensure-pthread-worker-stamp.mjs';
+import { PTHREAD_WORKER_STAMP_BANNER, ensurePthreadWorkerStamp } from '../../scripts/ensure-pthread-worker-stamp.mjs';
 
 function tempDir(): string {
   return mkdtempSync(join(tmpdir(), 'hyphon-pthread-worker-'));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`pnpm run build` fails at `tsc -b` with:

- `TS2578`: Unused `@ts-expect-error` directive
- `TS7016`: Could not find a declaration file for `../../scripts/ensure-pthread-worker-stamp.mjs`

This was introduced in #1122 when `ensurePthreadWorkerStamp.test.ts` was added.

## Root cause

`@ts-expect-error` only suppresses diagnostics on the **immediately following line**. The new test used a multi-line import, so the directive sat on the `import {` line while `TS7016` was reported on the `from '...'` line — matching the pattern used by other `scripts/*.mjs` test imports, but broken because they are single-line.

## Fix

Collapse the import to a single line, consistent with `nativeBuildPreflight.test.ts` and `jc303LinkFlags.test.ts`.

## Verification

- `npx tsc -b` — passes
- `CI=true pnpm run test:unit -- src/__tests__/ensurePthreadWorkerStamp.test.ts` — passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc77c658-215b-4133-ba39-e1a366b5796a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc77c658-215b-4133-ba39-e1a366b5796a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test imports and TypeScript suppression handling without changing public functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->