### PR TITLE
Fix WebGPU knob click targets offset from the drawn face

### DIFF
--- a/src/__tests__/HardwareModule.test.tsx
+++ b/src/__tests__/HardwareModule.test.tsx
@@ -201,4 +201,22 @@ describe('HardwareModule - 3D Holographic Mode', () => {
         const sweepSpan = valueArc.args[4] - valueArc.args[3];
         expect(sweepSpan).toBeCloseTo(0.8 * KNOB_MATERIAL.geometry.sweepTotal, 5);
     });
+
+    it('keeps GPU canvases untransformed inside a centered slot', () => {
+        const onParamChange = vi.fn();
+        const { getByTestId } = render(
+            <HardwareModule
+                title="Test Module"
+                colorHex={mockColorHex}
+                controls={mockControls}
+                onParamChange={onParamChange}
+            />
+        );
+        const canvas = getByTestId('hardware-knob-canvas-test1') as HTMLCanvasElement;
+        expect(canvas.style.transform === '' || canvas.style.transform === 'none').toBe(true);
+        const slot = canvas.parentElement as HTMLElement;
+        expect(slot.style.transform).toContain('translate(-50%, -50%)');
+        expect(slot.style.left).toBe('30%');
+        expect(slot.style.top).toBe('50%');
+    });
 });

--- a/src/components/HardwareKnob.tsx
+++ b/src/components/HardwareKnob.tsx
@@ -428,8 +428,6 @@ export const HardwareKnob: React.FC<HardwareKnobProps> = memo(({
                     <canvas
                         ref={canvasRef}
                         data-testid={testId}
-                        width={size * 2}
-                        height={size * 2}
                         style={{
                             width: '100%',
                             height: '100%',
@@ -439,6 +437,7 @@ export const HardwareKnob: React.FC<HardwareKnobProps> = memo(({
                             left: 0,
                             zIndex: 10,
                             pointerEvents: 'none',
+                            transform: 'none',
                         }}
                     />
                 </div>

--- a/src/components/HardwareModule.tsx
+++ b/src/components/HardwareModule.tsx
@@ -6,7 +6,7 @@ export type { Knob2DDimensions, Knob2DDrawCommand } from './knobRender';
 export { buildKnob2DDrawCalls } from './knobRender';
 import { isPointerNearArcRing, valueFromArcPointer, createKnobDragAnchor, computeKnobDragValue, getKnobCanvasValue, getKnobDragCursor, type KnobDragAnchor, type KnobDragModifier } from './knobInteraction';
 import { notifyDetentCross, snappedDetentIndex } from './knobDetentFeedback';
-import { findHitKnobIndex } from '../utils/touchHitTesting';
+import { findHitKnobIndexFromCanvases } from '../utils/touchHitTesting';
 import { useCompactLayoutOptional } from '../contexts/CompactLayoutContext';
 import { MidiBadge } from './MidiBadge';
 import type { AutomationTarget } from '../types';
@@ -474,8 +474,7 @@ export const HardwareModule = memo(
             observer.observe(container);
 
             const findHitKnob = (clientX: number, clientY: number): number => {
-                const rect = cachedRectRef.current || container.getBoundingClientRect();
-                return findHitKnobIndex(controlsRef.current, clientX, clientY, rect, {
+                return findHitKnobIndexFromCanvases(knobCanvasRefs.current, clientX, clientY, {
                     hitRadiusMultiplier: isCompact ? 1.35 : 1.15,
                 });
             };
@@ -534,12 +533,16 @@ export const HardwareModule = memo(
 
             const tryArcClickToSet = (hitIndex: number, clientX: number, clientY: number): boolean => {
                 const k = controlsRef.current[hitIndex];
+                const canvas = knobCanvasRefs.current[hitIndex];
+                const kRect = canvas?.getBoundingClientRect();
                 const rect = cachedRectRef.current || container.getBoundingClientRect();
-                const kCenterX = rect.left + k.x * rect.width;
-                const kCenterY = rect.top + k.y * rect.height;
+                const kCenterX = kRect ? kRect.left + kRect.width / 2 : rect.left + k.x * rect.width;
+                const kCenterY = kRect ? kRect.top + kRect.height / 2 : rect.top + k.y * rect.height;
                 const dx = clientX - kCenterX;
                 const dy = clientY - kCenterY;
-                const bodyRadius = k.size * Math.min(rect.width, rect.height);
+                const bodyRadius = kRect
+                    ? Math.min(kRect.width, kRect.height) / 2
+                    : k.size * Math.min(rect.width, rect.height);
 
                 if (!isPointerNearArcRing(dx, dy, bodyRadius, KNOB_MATERIAL)) {
                     return false;
@@ -698,35 +701,37 @@ export const HardwareModule = memo(
         useEffect(() => {
             const container = containerRef.current;
             if (!container) return;
-            const ro = new ResizeObserver((entries) => {
-                const rect = entries[0].contentRect;
-                const minDim = Math.min(rect.width, rect.height);
+            const layoutKnobSlot = (index: number) => {
+                const ctrl = controlsRef.current[index];
+                const canvas = knobCanvasRefs.current[index];
+                const moduleEl = containerRef.current;
+                if (!ctrl || !canvas || !moduleEl) return;
+                const minDim = Math.min(moduleEl.clientWidth, moduleEl.clientHeight);
+                const wrap = canvas.parentElement;
+                const sizePx = ctrl.size * minDim * 2;
+                if (wrap) {
+                    wrap.style.width = `${sizePx}px`;
+                    wrap.style.height = `${sizePx}px`;
+                }
+                canvas.style.width = '100%';
+                canvas.style.height = '100%';
+                canvas.style.transform = 'none';
+                const handle = knobHandlesRef.current[index];
+                if (handle && KnobGPUContext.isSlotActive(handle)) {
+                    KnobGPUContext.markDirty(handle);
+                } else {
+                    renderKnob2D(canvas, getCanvasValueAt(index), KNOB_MATERIAL, getAutomationOverlayAt(index));
+                }
+            };
+
+            const ro = new ResizeObserver(() => {
                 for (let i = 0; i < controlsRef.current.length; i++) {
-                    const ctrl = controlsRef.current[i];
-                    const canvas = knobCanvasRefs.current[i];
-                    if (!canvas) continue;
-                    const sizePx = ctrl.size * minDim * 2;
-                    canvas.style.width = `${sizePx}px`;
-                    canvas.style.height = `${sizePx}px`;
-                    canvas.style.left = `${ctrl.x * rect.width}px`;
-                    canvas.style.top = `${ctrl.y * rect.height}px`;
-                    canvas.style.position = 'absolute';
-                    canvas.style.transform = 'translate(-50%, -50%)';
-                    const dpr = window.devicePixelRatio || 1;
-                    const targetW = Math.max(1, Math.floor(sizePx * dpr));
-                    const targetH = Math.max(1, Math.floor(sizePx * dpr));
-                    if (canvas.width !== targetW || canvas.height !== targetH) {
-                        canvas.width = targetW;
-                        canvas.height = targetH;
-                    }
-                    if (knobHandlesRef.current[i] === null) {
-                        renderKnob2D(canvas, getCanvasValueAt(i), KNOB_MATERIAL, getAutomationOverlayAt(i));
-                    }
+                    layoutKnobSlot(i);
                 }
             });
             ro.observe(container);
             return () => ro.disconnect();
-        }, []);
+        }, [getCanvasValueAt, getAutomationOverlayAt]);
 
         const setKnobCanvasRef = useCallback((index: number) => (el: HTMLCanvasElement | null) => {
             const oldCanvas = knobCanvasRefs.current[index];
@@ -739,22 +744,18 @@ export const HardwareModule = memo(
             knobCanvasRefs.current[index] = el;
             if (!el) return;
 
-            const container = el.parentElement as HTMLDivElement | null;
-            if (container) {
-                const rect = container.getBoundingClientRect();
-                const minDim = Math.min(rect.width, rect.height);
+            const wrap = el.parentElement;
+            const moduleEl = containerRef.current;
+            if (wrap && moduleEl) {
+                const minDim = Math.min(moduleEl.clientWidth, moduleEl.clientHeight);
                 const ctrl = controlsRef.current[index];
                 if (ctrl) {
                     const sizePx = ctrl.size * minDim * 2;
-                    el.style.width = `${sizePx}px`;
-                    el.style.height = `${sizePx}px`;
-                    el.style.left = `${ctrl.x * rect.width}px`;
-                    el.style.top = `${ctrl.y * rect.height}px`;
-                    el.style.position = 'absolute';
-                    el.style.transform = 'translate(-50%, -50%)';
-                    const dpr = window.devicePixelRatio || 1;
-                    el.width = Math.max(1, Math.floor(sizePx * dpr));
-                    el.height = Math.max(1, Math.floor(sizePx * dpr));
+                    wrap.style.width = `${sizePx}px`;
+                    wrap.style.height = `${sizePx}px`;
+                    el.style.width = '100%';
+                    el.style.height = '100%';
+                    el.style.transform = 'none';
                 }
             }
 
@@ -839,13 +840,22 @@ export const HardwareModule = memo(
                     aria-hidden="true"
                 />
                 {controls.map((c, i) => (
-                    <canvas
+                    <div
                         key={c.id}
-                        ref={setKnobCanvasRef(i)}
-                        data-testid={`hardware-knob-canvas-${String(c.id).replace(KNOB_TEST_ID_SANITIZE_PATTERN, '_')}`}
-                        className="block"
-                        style={{ position: 'absolute', pointerEvents: 'none' }}
-                    />
+                        className="absolute pointer-events-none"
+                        style={{
+                            left: `${c.x * 100}%`,
+                            top: `${c.y * 100}%`,
+                            transform: 'translate(-50%, -50%)',
+                        }}
+                    >
+                        <canvas
+                            ref={setKnobCanvasRef(i)}
+                            data-testid={`hardware-knob-canvas-${String(c.id).replace(KNOB_TEST_ID_SANITIZE_PATTERN, '_')}`}
+                            className="block w-full h-full"
+                            style={{ pointerEvents: 'none' }}
+                        />
+                    </div>
                 ))}
                 <div className="absolute inset-0 pointer-events-none">
                     <PanelTitleBar

--- a/src/components/KnobGPUContext.ts
+++ b/src/components/KnobGPUContext.ts
@@ -531,17 +531,56 @@ class KnobGPUContextClass {
         slot.inViewport = true;
     }
 
+    /**
+     * Keep the WebGPU swapchain size in lockstep with the canvas CSS box.
+     * Changing `canvas.width` after the first configure() without reconfigure
+     * leaves the presented texture at the old size, which Chromium composites
+     * 1:1 from the bottom-left — the knob image sits up/right of the hit box.
+     */
+    private canvasBufferSize(canvas: HTMLCanvasElement): { w: number; h: number } {
+        const dpr = typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1;
+        const cssW = canvas.clientWidth > 0 ? canvas.clientWidth : canvas.width;
+        const cssH = canvas.clientHeight > 0 ? canvas.clientHeight : canvas.height;
+        return {
+            w: Math.max(1, Math.floor(cssW * dpr)),
+            h: Math.max(1, Math.floor(cssH * dpr)),
+        };
+    }
+
+    private configureCanvasContext(context: GPUCanvasContext, canvas: HTMLCanvasElement): void {
+        const { w, h } = this.canvasBufferSize(canvas);
+        if (canvas.width !== w) canvas.width = w;
+        if (canvas.height !== h) canvas.height = h;
+        context.configure({
+            device: this.device!,
+            format: this.format!,
+            alphaMode: 'premultiplied',
+        });
+    }
+
+    private syncSlotBuffer(slot: Slot): void {
+        if (!this.device || !this.format) return;
+        const { w, h } = this.canvasBufferSize(slot.canvas);
+        if (slot.canvas.width !== w || slot.canvas.height !== h || slot.width !== w || slot.height !== h) {
+            if (slot.canvas.width !== w) slot.canvas.width = w;
+            if (slot.canvas.height !== h) slot.canvas.height = h;
+            slot.width = w;
+            slot.height = h;
+            slot.context.configure({
+                device: this.device,
+                format: this.format,
+                alphaMode: 'premultiplied',
+            });
+        }
+    }
+
     private attachSlot(id: number, canvas: HTMLCanvasElement, getValue: () => number): boolean {
         if (!this.device || !this.pipeline || !this.format) return false;
         try {
             const context = canvas.getContext('webgpu') as GPUCanvasContext | null;
             if (!context) return false;
 
-            context.configure({
-                device: this.device,
-                format: this.format,
-                alphaMode: 'premultiplied',
-            });
+            this.configureCanvasContext(context, canvas);
 
             const uniformBuffer = this.device.createBuffer({
                 size: 32,
@@ -896,11 +935,7 @@ class KnobGPUContextClass {
             const slot = this.slots.get(id);
             if (!slot || !slot.inViewport) continue;
             try {
-                // Sync canvas buffer size if DPR/layout changed.
-                if (slot.canvas.width !== slot.width || slot.canvas.height !== slot.height) {
-                    slot.width = slot.canvas.width;
-                    slot.height = slot.canvas.height;
-                }
+                this.syncSlotBuffer(slot);
 
                 const value = slot.getValue();
                 const time = resolveKnobTimeUniform(nowSeconds, slot.animated, reduced);

--- a/src/utils/__tests__/touchHitTesting.test.ts
+++ b/src/utils/__tests__/touchHitTesting.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { findHitKnobIndex, MIN_TOUCH_TARGET_PX } from '../touchHitTesting';
+import { findHitKnobIndex, findHitKnobIndexFromCanvases, MIN_TOUCH_TARGET_PX } from '../touchHitTesting';
 
 describe('touchHitTesting', () => {
     const rect = new DOMRect(0, 0, 400, 400);
@@ -33,5 +33,28 @@ describe('touchHitTesting', () => {
     it('includes label zone below knob in hit test', () => {
         const index = findHitKnobIndex(controls, 100, 150, rect, { hitRadiusMultiplier: 1.5 });
         expect(index).toBe(0);
+    });
+});
+
+describe('findHitKnobIndexFromCanvases', () => {
+    function fakeCanvas(left: number, top: number, width: number, height: number): HTMLCanvasElement {
+        return {
+            getBoundingClientRect: () => new DOMRect(left, top, width, height),
+        } as HTMLCanvasElement;
+    }
+
+    it('hits the canvas whose layout box contains the pointer', () => {
+        const canvases = [
+            fakeCanvas(80, 80, 40, 40),
+            fakeCanvas(280, 80, 40, 40),
+        ];
+        expect(findHitKnobIndexFromCanvases(canvases, 100, 100)).toBe(0);
+        expect(findHitKnobIndexFromCanvases(canvases, 300, 100)).toBe(1);
+    });
+
+    it('uses the canvas box even when it is offset from a parent origin', () => {
+        const canvases = [fakeCanvas(160, 40, 80, 80)];
+        expect(findHitKnobIndexFromCanvases(canvases, 200, 80)).toBe(0);
+        expect(findHitKnobIndexFromCanvases(canvases, 10, 10)).toBe(-1);
     });
 });

--- a/src/utils/touchHitTesting.ts
+++ b/src/utils/touchHitTesting.ts
@@ -59,3 +59,46 @@ export function findHitKnobIndex(
 
     return bestIndex;
 }
+
+/**
+ * Hit-test against each knob canvas's layout box. WebGPU presents into the
+ * canvas bitmap; CSS transforms on that canvas can desync the visible image
+ * from reconstructed x/y math, so prefer the element's own rect.
+ */
+export function findHitKnobIndexFromCanvases(
+    canvases: Array<HTMLCanvasElement | null | undefined>,
+    clientX: number,
+    clientY: number,
+    options: FindHitKnobOptions = {}
+): number {
+    const minHitRadiusPx = options.minHitRadiusPx ?? MIN_TOUCH_TARGET_PX / 2;
+    const hitRadiusMultiplier = options.hitRadiusMultiplier ?? 1.15;
+
+    let bestIndex = -1;
+    let bestDist = Infinity;
+
+    for (let i = 0; i < canvases.length; i++) {
+        const canvas = canvases[i];
+        if (!canvas) continue;
+        const rect = canvas.getBoundingClientRect();
+        if (rect.width <= 0 || rect.height <= 0) continue;
+
+        const cx = rect.left + rect.width / 2;
+        const cy = rect.top + rect.height / 2;
+        const visualR = Math.min(rect.width, rect.height) / 2;
+        const hitRadius = Math.max(visualR * hitRadiusMultiplier, minHitRadiusPx);
+
+        const dx = clientX - cx;
+        const dy = clientY - cy;
+        const distCenter = Math.hypot(dx, dy);
+        const distLabel = Math.hypot(dx, clientY - (cy + visualR * 0.8));
+        const dist = Math.min(distCenter, distLabel);
+
+        if (dist < hitRadius && dist < bestDist) {
+            bestDist = dist;
+            bestIndex = i;
+        }
+    }
+
+    return bestIndex;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
WebGPU knobs were receiving pointer hits down/left of the visible face.

**Cause:** the GPU canvas used `transform: translate(-50%, -50%)` (Chromium often composites the swapchain without that transform) and the swapchain was not reconfigured after `canvas.width`/`height` changes, so a larger buffer was presented 1:1 from a corner.

**Fix:**
- Center knobs with a layout wrapper; keep the WebGPU canvas untransformed
- Hit-test and arc-click against each canvas `getBoundingClientRect()`
- Reconfigure the GPU canvas context when the CSS box / DPR changes
- Stop using a hardcoded 2× backing store on holographic `HardwareKnob` canvases

Unit tests cover canvas-rect hit testing and wrapper vs canvas transform.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eabed27f-7510-423d-92e6-cafebb57f479?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eabed27f-7510-423d-92e6-cafebb57f479&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hardware knob hit detection for more accurate mouse and touch interactions.
  * Corrected knob positioning and sizing across different layouts and screen resolutions.
  * Prevented visual distortion when hardware controls are centered or repositioned.
  * Improved rendering consistency on high-DPI displays and during layout changes.

* **Tests**
  * Added coverage for canvas-based hit detection, offset controls, and pointer interactions outside knob areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->